### PR TITLE
Fix: stop reparenting recycled symbols + always anchor _replaceSymbol to own container

### DIFF
--- a/.changeset/fix-symbol-parent-recycle.md
+++ b/.changeset/fix-symbol-parent-recycle.md
@@ -1,0 +1,12 @@
+---
+"pixi-reels": patch
+---
+
+Fix: stop reparenting recycled symbols on spotlight hide and always anchor `Reel._replaceSymbol` to its own container.
+
+Two related bugs caused symbols to render in the wrong reel after rapid spin/skip cycles, particularly when the win spotlight runs alongside an expanding-wild mechanic that triggers many `placeSymbols` calls in quick succession:
+
+- `SymbolSpotlight.hide()` reparented every symbol it had ever tracked back to its `originalParent`, even when `promoteAboveMask: false` (no reparenting on `show()`) or after the shared symbol pool had recycled the instance into a different reel. The recycled symbol got yanked from its new owner, leaving a hole there and a stranger in the original reel.
+- `Reel._replaceSymbol` used the captured `oldSymbol.view.parent` as the destination for the replacement view. If the old symbol had been moved (by the spotlight or by pool recycling), the new symbol landed in a foreign container — symbols accumulated in the wrong reel across spins.
+
+Both paths now anchor to the reel's own container; the spotlight only reparents symbols whose view is still in `spotlightContainer` (i.e., never recycled away).

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -552,6 +552,12 @@ export class Reel implements Disposable {
   private _replaceSymbol(index: number, newSymbolId: string): void {
     const oldSymbol = this.symbols[index];
     const isOldStub = oldSymbol instanceof OccupiedStub;
+    // Always parent into THIS reel's own container — the old symbol's
+    // `view.parent` is unsafe as a destination because the shared symbol
+    // pool can recycle a view across reels (or the spotlight may have
+    // promoted it above the mask), leaving `oldSymbol.view.parent`
+    // pointing at a foreign container.
+    const parent = this.container;
 
     // OCCUPIED: install a stub. Stubs are not pooled through SymbolFactory.
     if (newSymbolId === OCCUPIED_SENTINEL) {
@@ -559,7 +565,6 @@ export class Reel implements Disposable {
         oldSymbol.view.alpha = 0;
         return;
       }
-      const parent = oldSymbol.view.parent;
       const y = oldSymbol.view.y;
       this._symbolFactory.release(oldSymbol);
       const stub = this._acquireOccupiedStub();
@@ -568,14 +573,13 @@ export class Reel implements Disposable {
       stub.view.alpha = 0;
       stub.view.visible = true;
       stub.view.scale.set(1, 1);
-      if (parent && stub.view.parent !== parent) parent.addChild(stub.view);
+      if (stub.view.parent !== parent) parent.addChild(stub.view);
       this.symbols[index] = stub;
       return;
     }
 
     // Replacing a stub with a real symbol: release stub back to internal cache.
     if (isOldStub) {
-      const parent = oldSymbol.view.parent;
       const y = oldSymbol.view.y;
       this._releaseOccupiedStub(oldSymbol);
       const newSymbol = this._symbolFactory.acquire(newSymbolId);
@@ -585,21 +589,23 @@ export class Reel implements Disposable {
       newSymbol.view.alpha = 1;
       newSymbol.view.scale.set(1, 1);
       newSymbol.view.zIndex = 0;
-      if (parent) parent.addChild(newSymbol.view);
+      parent.addChild(newSymbol.view);
       this.symbols[index] = newSymbol;
       this.events.emit('symbol:created', newSymbolId, index);
       return;
     }
 
-    // Even if same symbolId, always reset visual state (alpha, scale, zIndex)
+    // Same id fast-path. Reset visual state and re-anchor the view to this
+    // reel's container in case the pool had moved it elsewhere since the
+    // last activation.
     if (oldSymbol.symbolId === newSymbolId) {
       oldSymbol.view.alpha = 1;
       oldSymbol.view.scale.set(1, 1);
       oldSymbol.view.zIndex = 0;
+      if (oldSymbol.view.parent !== parent) parent.addChild(oldSymbol.view);
       return;
     }
 
-    const parent = oldSymbol.view.parent;
     const y = oldSymbol.view.y;
 
     this._symbolFactory.release(oldSymbol);
@@ -611,9 +617,7 @@ export class Reel implements Disposable {
     newSymbol.view.scale.set(1, 1);
     newSymbol.view.zIndex = 0;
 
-    if (parent) {
-      parent.addChild(newSymbol.view);
-    }
+    parent.addChild(newSymbol.view);
 
     this.symbols[index] = newSymbol;
     this.events.emit('symbol:created', newSymbolId, index);

--- a/packages/pixi-reels/src/spotlight/SymbolSpotlight.ts
+++ b/packages/pixi-reels/src/spotlight/SymbolSpotlight.ts
@@ -109,11 +109,14 @@ export class SymbolSpotlight implements Disposable {
       if (seen.has(key)) continue;
       seen.add(key);
 
-      const originalParent = symbol.view.parent;
-      this._promoted.push({ symbol, originalParent, position: pos });
-
+      // Track for hide() only when we're actually moving the view —
+      // otherwise the entry's `originalParent` would become stale if the
+      // shared symbol pool recycles this instance into a different reel
+      // before the next hide(), and `hide()` would reparent it back to a
+      // reel that no longer owns it (leaving a hole on the new owner).
       if (promoteAboveMask) {
-        // Re-parent to spotlight container (above mask)
+        const originalParent = symbol.view.parent;
+        this._promoted.push({ symbol, originalParent, position: pos });
         const globalPos = symbol.view.getGlobalPosition();
         this._viewport.spotlightContainer.addChild(symbol.view);
         const localPos = this._viewport.spotlightContainer.toLocal(globalPos);
@@ -139,9 +142,13 @@ export class SymbolSpotlight implements Disposable {
       this._cycleAbort = null;
     }
 
-    // Return promoted symbols
+    // Return promoted symbols. Skip any whose view has been moved out of
+    // the spotlight container — that means the shared symbol pool has
+    // recycled them into another reel since show(), and reparenting back
+    // to `originalParent` would steal them from their new owner.
     for (const { symbol, originalParent } of this._promoted) {
-      if (originalParent && symbol.view.parent !== originalParent) {
+      if (symbol.view.parent !== this._viewport.spotlightContainer) continue;
+      if (originalParent) {
         const globalPos = symbol.view.getGlobalPosition();
         originalParent.addChild(symbol.view);
         const localPos = originalParent.toLocal(globalPos);

--- a/packages/pixi-reels/tests/integration/spotlight.test.ts
+++ b/packages/pixi-reels/tests/integration/spotlight.test.ts
@@ -1,0 +1,150 @@
+/**
+ * SymbolSpotlight integration tests — focused on the parent-restoration
+ * invariant that broke when symbols were pool-recycled across reels mid-
+ * spotlight.
+ */
+import { describe, it, expect } from 'vitest';
+import { createTestReelSet } from '../../src/testing/index.js';
+
+const SYMBOLS = ['a', 'b', 'c', 'wild'];
+
+function makeHarness() {
+  return createTestReelSet({
+    reels: 5,
+    visibleRows: 3,
+    symbolIds: SYMBOLS,
+  });
+}
+
+describe('SymbolSpotlight — symbol parent invariant after recycling', () => {
+  it('does not yank recycled symbols back to a stale parent (promoteAboveMask: false)', async () => {
+    const h = makeHarness();
+    try {
+      // Land a grid where reel 0 has a winner.
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['wild', 'wild', 'wild'],
+        ['a', 'b', 'c'],
+      ]);
+
+      // Fire a spotlight on reel 0 row 1. The ReelSet uses a shared symbol
+      // pool — the 'a' instance at reel 0 may end up reused on a different
+      // reel after the next placeSymbols call.
+      await h.reelSet.spotlight.show(
+        [{ reelIndex: 0, rowIndex: 1 }],
+        { promoteAboveMask: false },
+      );
+
+      // Land a different grid. Each reel's placeSymbols releases its old
+      // symbols to the pool and acquires fresh ones — guaranteeing the 'a'
+      // instance from reel 0 row 1 gets reassigned somewhere else.
+      await h.spinAndLand([
+        ['c', 'c', 'c'],
+        ['c', 'c', 'c'],
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['wild', 'wild', 'wild'],
+      ]);
+
+      // Calling show() (or hide() directly) re-runs spotlight cleanup.
+      // Before the fix, this reparented the recycled 'a' instance back to
+      // reel 0's container, leaving a hole on whichever reel now owns it
+      // and a stranger inside reel 0's container.
+      await h.reelSet.spotlight.show(
+        [{ reelIndex: 4, rowIndex: 0 }],
+        { promoteAboveMask: false },
+      );
+      h.reelSet.spotlight.hide();
+
+      // Invariant: every symbol's view.parent matches the container of the
+      // reel that owns it in `reels[i].symbols`.
+      for (let r = 0; r < 5; r++) {
+        const reel = h.reelSet.reels[r];
+        for (let i = 0; i < reel.symbols.length; i++) {
+          const sym = reel.symbols[i];
+          expect(sym.view.parent, `reel ${r} symbol[${i}] (${sym.symbolId}) parent`)
+            .toBe(reel.container);
+        }
+      }
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('does not yank recycled symbols back to a stale parent (promoteAboveMask: true)', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['wild', 'wild', 'wild'],
+        ['a', 'b', 'c'],
+      ]);
+
+      // Synchronously call show + immediately recycle by landing a new grid
+      // — the show's promoteAboveMask: true path stashes the promoted view
+      // in spotlightContainer, but if a follow-up placeSymbols (or the
+      // pool) yanks it back into a reel before hide() runs, hide() must
+      // not steal it from the new owner.
+      h.reelSet.spotlight.show(
+        [{ reelIndex: 0, rowIndex: 1 }],
+        { promoteAboveMask: true, playWinAnimation: false },
+      );
+      // Land a different grid that will exercise placeSymbols on every reel.
+      await h.spinAndLand([
+        ['c', 'c', 'c'],
+        ['c', 'c', 'c'],
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['wild', 'wild', 'wild'],
+      ]);
+      h.reelSet.spotlight.hide();
+
+      for (let r = 0; r < 5; r++) {
+        const reel = h.reelSet.reels[r];
+        for (let i = 0; i < reel.symbols.length; i++) {
+          const sym = reel.symbols[i];
+          expect(sym.view.parent, `reel ${r} symbol[${i}] (${sym.symbolId}) parent`)
+            .toBe(reel.container);
+        }
+      }
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('still restores promoted symbols when promoteAboveMask: true (regression)', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['wild', 'wild', 'wild'],
+        ['a', 'b', 'c'],
+      ]);
+
+      const reel0 = h.reelSet.reels[0];
+      const beforeSym = reel0.getSymbolAt(1);
+      const beforeParent = beforeSym.view.parent;
+
+      await h.reelSet.spotlight.show(
+        [{ reelIndex: 0, rowIndex: 1 }],
+        { promoteAboveMask: true },
+      );
+
+      // While promoted, the symbol is in the spotlight container.
+      expect(beforeSym.view.parent).not.toBe(beforeParent);
+
+      h.reelSet.spotlight.hide();
+
+      // Hide restores it to the original reel container.
+      expect(beforeSym.view.parent).toBe(beforeParent);
+    } finally {
+      h.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two related bugs caused symbols to render in the wrong reel after rapid spin/skip cycles — especially when the win spotlight runs alongside any mechanic that triggers many `placeSymbols` calls in quick succession (expanding wilds, sticky wilds, hold-and-win flows).

### 1. `SymbolSpotlight.hide()` reparenting recycled symbols

`hide()` reparented every symbol it had ever tracked back to its `originalParent`, regardless of whether the symbol was actually promoted on `show()` or whether it was still under the spotlight's care.

Failure mode:
- `show()` was called with `promoteAboveMask: false` (no reparenting), but `_promoted` got pushed to anyway.
- Or `show()` ran with `promoteAboveMask: true`, then the shared symbol pool recycled the instance into a different reel before `hide()` fired.
- Either way, `hide()` then yanked the view back to the stale `originalParent`, leaving a hole on whichever reel now owned that instance.

Fix: `hide()` only restores entries whose view is still in `spotlightContainer`. Symbols that have been pool-recycled away are left where their new owner placed them. `show()` only pushes to `_promoted` when it actually moves the view.

### 2. `Reel._replaceSymbol` using a stale `oldSymbol.view.parent`

`_replaceSymbol` captured `oldSymbol.view.parent` and used it as the destination for the new view. If the old symbol had previously been moved (by spotlight reparenting or pool recycling), the new view landed in a foreign container — symbols accumulated in the wrong reel across spins.

Fix: always anchor to `this.container`. Also re-anchor on the same-id fast path in case the view drifted while idle.

## Test plan

- [x] New `tests/integration/spotlight.test.ts` covers the recycle scenarios for both `promoteAboveMask: true` and `promoteAboveMask: false`.
- [x] All 217 existing tests still pass (`pnpm --filter pixi-reels test`).
- [x] Typecheck clean (`pnpm --filter pixi-reels typecheck`).
- [x] Lint clean (`pnpm check:lint`).
- [x] Verified end-to-end against a 5-column slot demo with rapid slam-stop + expanding-wild flow — no parent-violation, no holes, no symbols rendering in wrong reels across many cycles.

## Changeset

`.changeset/fix-symbol-parent-recycle.md` — `patch` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #79