### PR TITLE
Add: `reelSet.spin({ holdReels: [...] })` for subset spinning

### DIFF
--- a/.changeset/feat-subset-spin-hold-reels.md
+++ b/.changeset/feat-subset-spin-hold-reels.md
@@ -1,0 +1,24 @@
+---
+"pixi-reels": minor
+---
+
+Add: `reelSet.spin({ holdReels: [...] })` for subset spinning.
+
+Held reels skip START / SPIN / STOP entirely and stay on whatever symbols they're currently showing — no more "fragment the board into one ReelSet per column" workaround for Hold & Win, sticky / expanding wilds, or trigger-column bonus respins. Held reels count as already-landed for the `spin:allLanded` resolver, so only the non-held reels actually animate.
+
+```ts
+// Hold reels 0 and 4; only reels 1, 2, 3 reroll.
+const spin = reelSet.spin({ holdReels: [0, 4] });
+reelSet.setResult(serverGrid); // entries at 0/4 are ignored
+await spin;
+```
+
+Behaviour:
+- `setResult(grid)` still expects a full `reelCount`-length grid; held entries are ignored.
+- `setAnticipation([...])` silently filters held indices.
+- `setStopDelays([...])` entries at held indices are ignored.
+- No `spin:reelLanded` / `spin:stopping` event fires for held reels; `spin:allLanded` fires once every non-held reel lands.
+- Out-of-range / duplicate / non-integer entries in `holdReels` are silently filtered.
+- Big-symbol blocks crossing the held / non-held boundary are not supported — author results so big symbols stay inside a contiguous run of non-held reels.
+
+Exports `SpinOptions` from the package root.

--- a/packages/pixi-reels/src/config/types.ts
+++ b/packages/pixi-reels/src/config/types.ts
@@ -227,3 +227,40 @@ export interface ReelSetInternalConfig {
   offset: OffsetConfig;
   ticker: Ticker;
 }
+
+/**
+ * Options accepted by `reelSet.spin(options?)`. All fields are optional —
+ * passing nothing reproduces the legacy "every reel spins" behaviour.
+ */
+export interface SpinOptions {
+  /**
+   * Reel indices to HOLD this spin. Held reels skip START / SPIN / STOP
+   * entirely and stay on whatever symbols they're currently showing.
+   * They count as already-landed for the `spin:allLanded` resolver — only
+   * non-held reels actually animate.
+   *
+   * Use cases:
+   *   - Hold & Win respins (most reels held, one or two reroll)
+   *   - Sticky / expanding wilds during a feature spin
+   *   - Bonus respin where the trigger column stays in place
+   *
+   * Notes:
+   *   - `setResult(grid)` still expects a full `reelCount`-length grid;
+   *     entries at held indices are ignored. Pass anything (including
+   *     the held reels' current visible rows) — the engine doesn't read
+   *     held columns.
+   *   - `setAnticipation([...])` silently filters held indices.
+   *   - `setStopDelays([...])` entries at held indices are ignored.
+   *   - The resolved `SpinResult.symbols` is the full visible grid AFTER
+   *     the spin lands — held reels contribute their unchanged rows,
+   *     non-held reels contribute their landed rows.
+   *   - No `spin:reelLanded` / `spin:stopping` event fires for held reels.
+   *   - Big-symbol blocks crossing held into non-held reels are not
+   *     supported — the engine doesn't reposition or reshape held reels
+   *     to accommodate them. Author results that keep big symbols inside
+   *     a contiguous run of non-held reels.
+   *   - Indices outside `[0, reelCount)` and duplicate entries are silently
+   *     filtered.
+   */
+  holdReels?: number[];
+}

--- a/packages/pixi-reels/src/core/ReelSet.ts
+++ b/packages/pixi-reels/src/core/ReelSet.ts
@@ -1,6 +1,6 @@
 import { Container } from 'pixi.js';
 import type { Disposable } from '../utils/Disposable.js';
-import type { ReelSetInternalConfig, CellBounds, SymbolData } from '../config/types.js';
+import type { ReelSetInternalConfig, CellBounds, SpinOptions, SymbolData } from '../config/types.js';
 import { EventEmitter } from '../events/EventEmitter.js';
 import type { ReelSetEvents, SpinResult, } from '../events/ReelEvents.js';
 import { Reel, } from './Reel.js';
@@ -241,9 +241,31 @@ export class ReelSet extends Container implements Disposable {
 
   // ─── Spin API ─────────────────────────────────────────────
 
-  /** Start spinning all reels. Returns a promise that resolves when all reels land. */
-  async spin(): Promise<SpinResult> {
-    return this._spinController.spin();
+  /**
+   * Start spinning. Returns a promise that resolves when all (non-held)
+   * reels land.
+   *
+   * Pass `{ holdReels: [i, ...] }` to keep specific columns frozen for
+   * this spin — they skip START / SPIN / STOP entirely and stay on
+   * whatever symbols they're currently showing. The use cases are
+   * Hold & Win respins, sticky / expanding wilds, and "the trigger
+   * column stays in place" bonus rounds.
+   *
+   * @example
+   * // Plain spin — every reel animates.
+   * await reelSet.spin();
+   *
+   * @example
+   * // Hold reels 0 and 4; only the middle three reroll.
+   * const spin = reelSet.spin({ holdReels: [0, 4] });
+   * reelSet.setResult(serverGrid); // entries at 0/4 are ignored
+   * await spin;
+   *
+   * See {@link SpinOptions} for the full contract (event behaviour,
+   * setResult interaction, setAnticipation filtering).
+   */
+  async spin(options?: SpinOptions): Promise<SpinResult> {
+    return this._spinController.spin(options);
   }
 
   /**

--- a/packages/pixi-reels/src/index.ts
+++ b/packages/pixi-reels/src/index.ts
@@ -12,6 +12,7 @@ export { SpeedPresets } from './config/SpeedPresets.js';
 export { DEFAULTS } from './config/defaults.js';
 export type {
   SpeedProfile,
+  SpinOptions,
   SymbolData,
   ReelGridConfig,
   ReelExtraSymbols,

--- a/packages/pixi-reels/src/spin/SpinController.ts
+++ b/packages/pixi-reels/src/spin/SpinController.ts
@@ -1,6 +1,6 @@
 import type { Ticker } from 'pixi.js';
 import type { Reel } from '../core/Reel.js';
-import type { SpeedProfile, SymbolData } from '../config/types.js';
+import type { SpeedProfile, SpinOptions, SymbolData } from '../config/types.js';
 import type { SpeedManager } from '../speed/SpeedManager.js';
 import type { FrameBuilder } from '../frame/FrameBuilder.js';
 import type { SpinResult } from '../events/ReelEvents.js';
@@ -101,6 +101,12 @@ export class SpinController implements Disposable {
   private _stopDelayOverride: number[] | null = null;
   private _activePhases: Map<number, ReelPhase<any>> = new Map();
   private _landedReels = new Set<number>();
+  /**
+   * Reels held for the current spin (per `SpinOptions.holdReels`). Held
+   * reels skip START / SPIN / STOP and stay on their current symbols.
+   * Cleared at the start of every spin.
+   */
+  private _heldReels = new Set<number>();
   private _wasSkipped = false;
   private _isDestroyed = false;
   private _currentSpinResolve: ((result: SpinResult) => void) | null = null;
@@ -148,7 +154,7 @@ export class SpinController implements Disposable {
     return this._isDestroyed;
   }
 
-  async spin(): Promise<SpinResult> {
+  async spin(options?: SpinOptions): Promise<SpinResult> {
     if (this._isSpinning) {
       throw new Error('Cannot start a new spin while one is in progress.');
     }
@@ -161,6 +167,7 @@ export class SpinController implements Disposable {
     this._stopDelayOverride = null;
     this._landedReels.clear();
     this._activePhases.clear();
+    this._heldReels = this._normalizeHoldReels(options?.holdReels);
     this._spinGeneration++;
 
     const generation = this._spinGeneration;
@@ -172,11 +179,38 @@ export class SpinController implements Disposable {
       this._currentSpinResolve = resolve;
     });
 
+    // Degenerate case: every reel held → resolve next microtask with the
+    // current visible grid. Spin emitted, but no animation runs.
+    if (this._heldReels.size === this._reels.length) {
+      Promise.resolve().then(() => {
+        if (generation !== this._spinGeneration) return;
+        this._finishSpin();
+      });
+      return resultPromise;
+    }
+
     for (let i = 0; i < this._reels.length; i++) {
+      if (this._heldReels.has(i)) continue;
       this._startReel(i, speed, generation);
     }
 
     return resultPromise;
+  }
+
+  /**
+   * Filter `holdReels` down to a clean Set: drop out-of-range, drop
+   * duplicates, drop non-integer entries. Returning a normalized set
+   * makes every internal call site safe to read without re-validating.
+   */
+  private _normalizeHoldReels(input: number[] | undefined): Set<number> {
+    const out = new Set<number>();
+    if (!input) return out;
+    for (const i of input) {
+      if (Number.isInteger(i) && i >= 0 && i < this._reels.length) {
+        out.add(i);
+      }
+    }
+    return out;
   }
 
   setResult(symbols: string[][]): void {
@@ -193,7 +227,10 @@ export class SpinController implements Disposable {
   }
 
   setAnticipation(reelIndices: number[]): void {
-    this._anticipationReels = reelIndices;
+    // Held reels never reach AnticipationPhase, but filter here too so the
+    // public API is forgiving — callers can pass a flat list without
+    // tracking which indices are held this spin.
+    this._anticipationReels = reelIndices.filter((i) => !this._heldReels.has(i));
   }
 
   /**
@@ -228,6 +265,7 @@ export class SpinController implements Disposable {
 
       for (let i = 0; i < this._reels.length; i++) {
         if (this._landedReels.has(i)) continue;
+        if (this._heldReels.has(i)) continue;
         const reel = this._reels[i];
         reel.speed = 0;
         reel.isStopping = false;
@@ -252,6 +290,7 @@ export class SpinController implements Disposable {
     } else {
       for (let i = 0; i < this._reels.length; i++) {
         if (this._landedReels.has(i)) continue;
+        if (this._heldReels.has(i)) continue;
         const reel = this._reels[i];
         reel.speed = 0;
         reel.isStopping = false;
@@ -333,6 +372,9 @@ export class SpinController implements Disposable {
 
     let allSpinning = true;
     for (let i = 0; i < this._reels.length; i++) {
+      // Held reels never enter the phase chain; they don't gate
+      // `spin:allStarted` or the stop-sequence start.
+      if (this._heldReels.has(i)) continue;
       const phase = this._activePhases.get(i);
       if (!phase || phase.name !== 'spin') { allSpinning = false; break; }
     }
@@ -438,6 +480,9 @@ export class SpinController implements Disposable {
     if (!this._resultSymbols) return;
 
     for (let i = 0; i < this._reels.length; i++) {
+      // Held reels never enter a phase chain — don't gate the stop
+      // sequence on them.
+      if (this._heldReels.has(i)) continue;
       const phase = this._activePhases.get(i);
       if (!phase || phase.name !== 'spin') return;
     }
@@ -457,9 +502,15 @@ export class SpinController implements Disposable {
     const decorated = this._coordinateBigSymbols(this._resultSymbols, visibleRowsForReel);
 
     // Build and cache frames using each reel's actual buffer/visible config.
-    // Reels may differ in buffer size; build each independently.
+    // Reels may differ in buffer size; build each independently. Held reels
+    // get an empty placeholder — their entry is never read because no
+    // StopPhase ever fires for them.
     const frames: string[][] = [];
     for (let i = 0; i < this._reels.length; i++) {
+      if (this._heldReels.has(i)) {
+        frames.push([]);
+        continue;
+      }
       const reel = this._reels[i];
       const rows = visibleRowsForReel(i);
       frames.push(
@@ -474,9 +525,11 @@ export class SpinController implements Disposable {
     }
     this._cachedFrames = frames;
 
-    // Resolve all SpinPhases; each reel's _startReel awaits its own spinDone,
-    // then independently runs ANTICIPATION/STOP.
+    // Resolve all non-held SpinPhases; each reel's _startReel awaits its own
+    // spinDone, then independently runs ANTICIPATION/STOP. Held reels have
+    // no SpinPhase to resolve.
     for (let i = 0; i < this._reels.length; i++) {
+      if (this._heldReels.has(i)) continue;
       const spinPhase = this._activePhases.get(i) as SpinPhase;
       if (spinPhase?.resolve) spinPhase.resolve();
     }
@@ -553,7 +606,10 @@ export class SpinController implements Disposable {
     reel.events.emit('landed', symbols);
     this._events.emit('spin:reelLanded', reelIndex, symbols);
 
-    if (this._landedReels.size === this._reels.length) {
+    // All NON-HELD reels accounted for → finish. Held reels never
+    // _markLanded, but their slots count toward `reels.length`, so we
+    // compare against the count that was supposed to actually animate.
+    if (this._landedReels.size === this._reels.length - this._heldReels.size) {
       this._finishSpin();
     }
   }

--- a/packages/pixi-reels/tests/integration/holdReels.test.ts
+++ b/packages/pixi-reels/tests/integration/holdReels.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Subset-spin via `SpinOptions.holdReels`. Held reels skip START/SPIN/STOP
+ * and stay on whatever symbols they're currently showing. Covers the
+ * core invariants exposed in the public API contract:
+ *
+ *   - non-held reels animate to their result rows
+ *   - held reels keep their pre-spin visible rows
+ *   - setAnticipation silently filters held indices
+ *   - skip() honours holdReels
+ *   - degenerate "all held" still resolves
+ *   - bad indices (out of range, duplicates) are silently filtered
+ *   - no `spin:reelLanded` / `spin:stopping` event fires for held reels
+ */
+import { describe, it, expect } from 'vitest';
+import { captureEvents, createTestReelSet } from '../../src/testing/index.js';
+
+const SYMBOLS = ['a', 'b', 'c', 'd', 'e', 'wild'];
+
+function makeHarness() {
+  return createTestReelSet({
+    reels: 5,
+    visibleRows: 3,
+    symbolIds: SYMBOLS,
+  });
+}
+
+async function spinAndLandWithHold(
+  h: ReturnType<typeof makeHarness>,
+  grid: string[][],
+  holdReels: number[],
+) {
+  const promise = h.reelSet.spin({ holdReels });
+  h.reelSet.setResult(grid);
+  h.reelSet.skip();
+  return promise;
+}
+
+describe('SpinOptions.holdReels — basic behaviour', () => {
+  it('spins only non-held reels; held reels keep their visible rows', async () => {
+    const h = makeHarness();
+    try {
+      // First spin: lands the whole board so we have a known starting grid.
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['d', 'd', 'd'],
+        ['e', 'e', 'e'],
+      ]);
+
+      const before = h.reelSet.reels.map((r) => r.getVisibleSymbols());
+
+      // Second spin: hold reels 0 and 4. Server tries to write 'wild'
+      // everywhere — held entries must be ignored.
+      const wildAll: string[][] = Array.from({ length: 5 }, () => ['wild', 'wild', 'wild']);
+      await spinAndLandWithHold(h, wildAll, [0, 4]);
+
+      const after = h.reelSet.reels.map((r) => r.getVisibleSymbols());
+
+      // Held reels unchanged.
+      expect(after[0]).toEqual(before[0]);
+      expect(after[4]).toEqual(before[4]);
+      // Non-held reels landed on the wilds.
+      expect(after[1]).toEqual(['wild', 'wild', 'wild']);
+      expect(after[2]).toEqual(['wild', 'wild', 'wild']);
+      expect(after[3]).toEqual(['wild', 'wild', 'wild']);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('SpinResult.symbols reports the full visible grid (held rows included)', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['d', 'd', 'd'],
+        ['e', 'e', 'e'],
+      ]);
+
+      const result = await spinAndLandWithHold(
+        h,
+        [
+          ['wild', 'wild', 'wild'],
+          ['wild', 'wild', 'wild'],
+          ['wild', 'wild', 'wild'],
+          ['wild', 'wild', 'wild'],
+          ['wild', 'wild', 'wild'],
+        ],
+        [2],
+      );
+
+      expect(result.symbols[2]).toEqual(['c', 'c', 'c']);
+      expect(result.symbols[0]).toEqual(['wild', 'wild', 'wild']);
+    } finally {
+      h.destroy();
+    }
+  });
+});
+
+describe('SpinOptions.holdReels — events', () => {
+  it('does not emit spin:reelLanded for held reels', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['d', 'd', 'd'],
+        ['e', 'e', 'e'],
+      ]);
+
+      // Note: we drive the spin via `skip()` so no `spin:stopping` fires
+      // for any reel (existing slam-stop semantics). The point of this
+      // test is `spin:reelLanded` — which DOES fire from the skip path
+      // via _markLanded — must NOT include held indices.
+      const log = captureEvents(h.reelSet, ['spin:reelLanded']);
+      const target: string[][] = [
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['d', 'd', 'd'],
+        ['e', 'e', 'e'],
+      ];
+      await spinAndLandWithHold(h, target, [1, 3]);
+
+      const reelLanded = log.map((e) => e.args[0]);
+      expect(reelLanded.sort()).toEqual([0, 2, 4]);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('still emits spin:allLanded when only non-held reels land', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['d', 'd', 'd'],
+        ['e', 'e', 'e'],
+      ]);
+
+      const log = captureEvents(h.reelSet, ['spin:allLanded', 'spin:complete']);
+      await spinAndLandWithHold(
+        h,
+        [
+          ['a', 'a', 'a'],
+          ['b', 'b', 'b'],
+          ['c', 'c', 'c'],
+          ['d', 'd', 'd'],
+          ['e', 'e', 'e'],
+        ],
+        [0, 1, 4],
+      );
+
+      expect(log.map((e) => e.event)).toEqual(['spin:allLanded', 'spin:complete']);
+    } finally {
+      h.destroy();
+    }
+  });
+});
+
+describe('SpinOptions.holdReels — degenerate cases', () => {
+  it('all reels held: resolves with the current visible grid, no events for reels', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['d', 'd', 'd'],
+        ['e', 'e', 'e'],
+      ]);
+      const before = h.reelSet.reels.map((r) => r.getVisibleSymbols());
+
+      const log = captureEvents(h.reelSet, [
+        'spin:start',
+        'spin:reelLanded',
+        'spin:allLanded',
+      ]);
+      const result = await h.reelSet.spin({ holdReels: [0, 1, 2, 3, 4] });
+
+      expect(result.symbols).toEqual(before);
+      expect(log.map((e) => e.event)).toEqual(['spin:start', 'spin:allLanded']);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('out-of-range and duplicate hold indices are filtered', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['d', 'd', 'd'],
+        ['e', 'e', 'e'],
+      ]);
+
+      const target: string[][] = [
+        ['wild', 'wild', 'wild'],
+        ['wild', 'wild', 'wild'],
+        ['wild', 'wild', 'wild'],
+        ['wild', 'wild', 'wild'],
+        ['wild', 'wild', 'wild'],
+      ];
+      await spinAndLandWithHold(h, target, [-1, 99, 2, 2, 7]);
+
+      const after = h.reelSet.reels.map((r) => r.getVisibleSymbols());
+      // Only reel 2 actually held; the rest are valid garbage indices that
+      // should not block spinning.
+      expect(after[2]).toEqual(['c', 'c', 'c']);
+      expect(after[0]).toEqual(['wild', 'wild', 'wild']);
+      expect(after[1]).toEqual(['wild', 'wild', 'wild']);
+      expect(after[3]).toEqual(['wild', 'wild', 'wild']);
+      expect(after[4]).toEqual(['wild', 'wild', 'wild']);
+    } finally {
+      h.destroy();
+    }
+  });
+});
+
+describe('SpinOptions.holdReels — interaction with setAnticipation', () => {
+  it('filters held indices out of the anticipation list silently', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['d', 'd', 'd'],
+        ['e', 'e', 'e'],
+      ]);
+
+      const promise = h.reelSet.spin({ holdReels: [3] });
+      // Set anticipation including the held reel — implementation must drop it.
+      h.reelSet.setAnticipation([2, 3, 4]);
+      h.reelSet.setResult([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['d', 'd', 'd'],
+        ['e', 'e', 'e'],
+      ]);
+      h.reelSet.skip();
+      await promise;
+
+      // No assertion failure thrown means the filter held — anticipation
+      // never tried to enter a phase chain on the held reel.
+      expect(h.reelSet.reels[3].getVisibleSymbols()).toEqual(['d', 'd', 'd']);
+    } finally {
+      h.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a first-class subset-spin API. Held reels skip START / SPIN / STOP entirely and stay on whatever symbols they're currently showing — replacing the workaround where consumers fragmented the board into one ReelSet per column to get hold-and-win, sticky/expanding wilds, or trigger-column bonus respins.

```ts
// Hold reels 0 and 4; only reels 1, 2, 3 reroll.
const spin = reelSet.spin({ holdReels: [0, 4] });
reelSet.setResult(serverGrid); // entries at held indices are ignored
await spin;
```

Held reels count as already-landed for the `spin:allLanded` resolver, so only the non-held reels actually animate. Spotlight, anticipation, win presenter, per-reel stagger — all keep working because everything stays inside one `ReelSet`.

## Public API

- `reelSet.spin(options?: SpinOptions): Promise<SpinResult>`
- `type SpinOptions = { holdReels?: number[] }` exported from the package root.

## Behaviour contract (also in `SpinOptions` TSDoc)

- `setResult(grid)` still expects a full `reelCount`-length grid; entries at held indices are ignored.
- `setAnticipation([...])` silently filters held indices.
- `setStopDelays([...])` entries at held indices are ignored.
- `skip()` honours `holdReels` — held reels are never placed.
- No `spin:reelLanded` / `spin:stopping` fires for held reels.
- `spin:allLanded` fires once every NON-held reel lands. The result's `symbols` is the full visible grid (held rows unchanged, non-held rows landed).
- Out-of-range / duplicate / non-integer entries in `holdReels` are silently filtered — callers can pass a flat list without pre-validating.
- Big-symbol blocks crossing the held / non-held boundary are not supported. Author results so big symbols stay inside a contiguous run of non-held reels.

## Test plan

- [x] New `tests/integration/holdReels.test.ts` covers:
  - non-held reels animate to the result, held reels keep their pre-spin rows
  - `SpinResult.symbols` reports the full visible grid (held rows included)
  - no `spin:reelLanded` fires for held indices
  - `spin:allLanded` still fires when only non-held reels land
  - all-held degenerate case resolves with the current grid
  - out-of-range / duplicate hold indices silently filtered
  - `setAnticipation` filters held indices
- [x] Full suite passes: 221 / 221 (`pnpm --filter pixi-reels test`).
- [x] Typecheck clean (`pnpm --filter pixi-reels typecheck`).
- [x] Lint clean (`pnpm check:lint`).

## Changeset

`.changeset/feat-subset-spin-hold-reels.md` — `minor` bump (additive, non-breaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #80