### PR TITLE
feat: add ReelSetBuilder.gsap(instance) for explicit DI

### DIFF
--- a/.changeset/feat-builder-gsap-injection.md
+++ b/.changeset/feat-builder-gsap-injection.md
@@ -1,0 +1,24 @@
+---
+'pixi-reels': minor
+---
+
+Add `ReelSetBuilder.gsap(instance)` for explicit GSAP dependency injection.
+
+The engine internally drives every tween, timeline, and `delayedCall` through a single bound `gsap` instance. By default that is the `gsap` resolved at the engine's own module path — fine for the common case where bundler `dedupe` collapses both the engine's and the consumer's `'gsap'` to one module instance.
+
+In setups where two `gsap` instances exist at runtime (symlinked workspaces, npm-link, misconfigured `dedupe`), tweens started by the engine live on a different root timeline than the one the consumer drives — animations stall, double-fire, or freeze on hidden tabs. Calling `.gsap(myGsap)` in the builder rebinds the engine to the consumer's instance:
+
+```ts
+import { gsap } from 'gsap';
+
+const reelSet = new ReelSetBuilder()
+  .reels(5).visibleRows(3).symbolSize(200, 200)
+  .symbols(...)
+  .ticker(app.ticker)
+  .gsap(gsap)         // ensure engine and app share one instance
+  .build();
+```
+
+Internally this is implemented via a tiny `getGsap()`/`setGsap()` shim in `utils/gsapRef.ts`. Every internal animation site now reads through `getGsap()` instead of importing `'gsap'` directly. A regression-guard test asserts no runtime `gsap.timeline(`/`gsap.to(`/`gsap.delayedCall(` calls outside the shim itself.
+
+No behavioural change for consumers who don't call `.gsap()`.

--- a/packages/pixi-reels/src/cascade/CascadeAnticipationPhase.ts
+++ b/packages/pixi-reels/src/cascade/CascadeAnticipationPhase.ts
@@ -1,4 +1,5 @@
-import { gsap } from 'gsap';
+import type { gsap } from 'gsap';
+import { getGsap } from '../utils/gsapRef.js';
 import { ReelPhase } from '../spin/phases/ReelPhase.js';
 
 /**
@@ -34,7 +35,7 @@ export class CascadeAnticipationPhase extends ReelPhase<void> {
     const halfPeriod = 0.04;
     const repeats = Math.round(duration / halfPeriod) - 1;
 
-    this._tween = gsap.to(this._reel.container, {
+    this._tween = getGsap().to(this._reel.container, {
       x: this._baseX + 4,
       duration: halfPeriod,
       ease: 'power1.inOut',

--- a/packages/pixi-reels/src/core/ReelSet.ts
+++ b/packages/pixi-reels/src/core/ReelSet.ts
@@ -15,7 +15,7 @@ import type { PhaseFactory } from '../spin/phases/PhaseFactory.js';
 import type { SpinningMode } from '../spin/modes/SpinningMode.js';
 import type { CellPin, CellPinOptions, PinExpireReason, MovePinOptions, CellCoord } from '../pins/CellPin.js';
 import { pinKey } from '../pins/CellPin.js';
-import { gsap } from 'gsap';
+import { getGsap } from '../utils/gsapRef.js';
 import type { FrameMiddleware } from '../frame/FrameBuilder.js';
 
 export interface ReelSetParams {
@@ -807,7 +807,7 @@ export class ReelSet extends Container implements Disposable {
     const duration = (opts?.duration ?? 400) / 1000;
     const easing = opts?.easing ?? 'power2.inOut';
     await new Promise<void>((resolve) => {
-      gsap.to(flight.view, {
+      getGsap().to(flight.view, {
         x: toX,
         y: toCellY,
         duration,

--- a/packages/pixi-reels/src/core/ReelSetBuilder.ts
+++ b/packages/pixi-reels/src/core/ReelSetBuilder.ts
@@ -1,4 +1,6 @@
 import type { Ticker } from 'pixi.js';
+import type { gsap } from 'gsap';
+import { setGsap } from '../utils/gsapRef.js';
 import type {
   SpeedProfile,
   SymbolData,
@@ -306,6 +308,44 @@ export class ReelSetBuilder {
   /** Set the PixiJS ticker for frame updates. */
   ticker(ticker: Ticker): this {
     this._ticker = ticker;
+    return this;
+  }
+
+  /**
+   * Inject the GSAP instance the engine should use for tweens.
+   *
+   * **When you need this:** if your app already imports `gsap` and your
+   * bundler resolves `gsap` to a different module instance than the one
+   * `pixi-reels` resolved (common with symlinked workspaces, npm-link, or
+   * misconfigured `dedupe`), every tween you start on a target the engine
+   * also tweens will fight a separate timeline. Symptoms: spotlights that
+   * render but never finish, animations that double-fire, tweens that
+   * silently drop on hidden tabs in only one of the two instances.
+   *
+   * Calling `.gsap(myGsap)` rebinds every internal phase, motion tween,
+   * pin-flight tween, and SpriteSymbol win pulse to the GSAP you pass —
+   * guaranteed to be the same instance that drives your own animations.
+   *
+   * Default: the `gsap` import resolved at the engine's own
+   * `node_modules/gsap` path. If your app and the engine resolve to the
+   * same instance (the common case in production bundles with proper
+   * `dedupe`), you do NOT need to call this.
+   *
+   * Idempotent — calling again with the same instance is a no-op. Calling
+   * with a different instance after `.build()` only affects tweens
+   * started after the swap.
+   *
+   * @example
+   * import { gsap } from 'gsap';
+   * const reelSet = new ReelSetBuilder()
+   *   .reels(5).visibleRows(3).symbolSize(200, 200)
+   *   .symbols(...)
+   *   .ticker(app.ticker)
+   *   .gsap(gsap)              // ensure engine and app share one instance
+   *   .build();
+   */
+  gsap(instance: typeof gsap): this {
+    setGsap(instance);
     return this;
   }
 

--- a/packages/pixi-reels/src/spin/phases/AdjustPhase.ts
+++ b/packages/pixi-reels/src/spin/phases/AdjustPhase.ts
@@ -1,4 +1,5 @@
-import { gsap } from 'gsap';
+import type { gsap } from 'gsap';
+import { getGsap } from '../../utils/gsapRef.js';
 import { ReelPhase } from './ReelPhase.js';
 import type { Reel } from '../../core/Reel.js';
 import type { SpeedProfile } from '../../config/types.js';
@@ -117,7 +118,7 @@ export class AdjustPhase extends ReelPhase<AdjustPhaseConfig> {
 
     const dur = this._durationMs / 1000;
     const ease = this._ease;
-    this._tween = gsap.timeline({
+    this._tween = getGsap().timeline({
       onComplete: () => {
         this._settle?.();
         this._settle = null;

--- a/packages/pixi-reels/src/spin/phases/AnticipationPhase.ts
+++ b/packages/pixi-reels/src/spin/phases/AnticipationPhase.ts
@@ -1,4 +1,5 @@
-import { gsap } from 'gsap';
+import type { gsap } from 'gsap';
+import { getGsap } from '../../utils/gsapRef.js';
 import { ReelPhase } from './ReelPhase.js';
 
 export interface AnticipationPhaseConfig {
@@ -32,7 +33,7 @@ export class AnticipationPhase extends ReelPhase<AnticipationPhaseConfig> {
       return;
     }
 
-    this._tween = gsap.timeline();
+    this._tween = getGsap().timeline();
 
     this._tween.to(reel, {
       speed: targetSpeed,

--- a/packages/pixi-reels/src/spin/phases/DropStopPhase.ts
+++ b/packages/pixi-reels/src/spin/phases/DropStopPhase.ts
@@ -1,5 +1,6 @@
-import { gsap } from 'gsap';
+import type { gsap } from 'gsap';
 import type { Container } from 'pixi.js';
+import { getGsap } from '../../utils/gsapRef.js';
 import type { Reel } from '../../core/Reel.js';
 import type { SpeedProfile } from '../../config/types.js';
 import { ReelPhase } from './ReelPhase.js';
@@ -72,7 +73,7 @@ export class DropStopPhase extends ReelPhase<DropStopPhaseConfig> {
       return;
     }
 
-    this._fallTween = gsap.timeline({
+    this._fallTween = getGsap().timeline({
       onComplete: () => {
         this._fallTween = null;
         views.forEach((v) => { v.alpha = 0; });
@@ -80,7 +81,7 @@ export class DropStopPhase extends ReelPhase<DropStopPhaseConfig> {
         const dropInDelay = (this._runConfig?.delay ?? 0) / 1000;
         if (dropInDelay > 0) {
           this._stage = 'waiting';
-          this._delayTween = gsap.delayedCall(dropInDelay, () => this._beginDropIn(dropFromY));
+          this._delayTween = getGsap().delayedCall(dropInDelay, () => this._beginDropIn(dropFromY));
         } else {
           this._beginDropIn(dropFromY);
         }
@@ -121,7 +122,7 @@ export class DropStopPhase extends ReelPhase<DropStopPhaseConfig> {
       return;
     }
 
-    this._dropTween = gsap.timeline({
+    this._dropTween = getGsap().timeline({
       onComplete: () => {
         this._stage = 'done';
         reel.notifyLanded();

--- a/packages/pixi-reels/src/spin/phases/StartPhase.ts
+++ b/packages/pixi-reels/src/spin/phases/StartPhase.ts
@@ -1,4 +1,5 @@
-import { gsap } from 'gsap';
+import type { gsap } from 'gsap';
+import { getGsap } from '../../utils/gsapRef.js';
 import { ReelPhase } from './ReelPhase.js';
 import type { SpinningMode } from '../modes/SpinningMode.js';
 
@@ -31,7 +32,7 @@ export class StartPhase extends ReelPhase<StartPhaseConfig> {
     reel.speed = 0;
 
     if (delay > 0) {
-      this._delayedCall = gsap.delayedCall(delay / 1000, () => this._launch());
+      this._delayedCall = getGsap().delayedCall(delay / 1000, () => this._launch());
     } else {
       this._launch();
     }
@@ -44,7 +45,7 @@ export class StartPhase extends ReelPhase<StartPhaseConfig> {
     const accelDuration = (speed.accelerationDuration ?? 300) / 1000;
     const accelEase = speed.accelerationEase ?? 'power2.in';
 
-    this._tween = gsap.timeline();
+    this._tween = getGsap().timeline();
 
     // Step-back: brief reverse to give a "pull" before launch.
     if (speed.bounceDistance > 0) {

--- a/packages/pixi-reels/src/spin/phases/StopPhase.ts
+++ b/packages/pixi-reels/src/spin/phases/StopPhase.ts
@@ -1,4 +1,5 @@
-import { gsap } from 'gsap';
+import type { gsap } from 'gsap';
+import { getGsap } from '../../utils/gsapRef.js';
 import { ReelPhase } from './ReelPhase.js';
 
 export interface StopPhaseConfig {
@@ -39,7 +40,7 @@ export class StopPhase extends ReelPhase<StopPhaseConfig> {
 
     const delay = (config.delay ?? 0) / 1000;
     if (delay > 0) {
-      this._delayTween = gsap.delayedCall(delay, () => this._beginSpinOut());
+      this._delayTween = getGsap().delayedCall(delay, () => this._beginSpinOut());
     } else {
       this._beginSpinOut();
     }
@@ -87,7 +88,7 @@ export class StopPhase extends ReelPhase<StopPhaseConfig> {
 
     const legDuration = (speed.bounceDuration ?? 600) / 2000; // half of total, in seconds
     this._stage = 'bouncing';
-    this._bounceTween = gsap.timeline();
+    this._bounceTween = getGsap().timeline();
     this._bounceTween.to(reel.container, {
       y: this._baseY + bounceDistance,
       duration: legDuration,

--- a/packages/pixi-reels/src/symbols/SpriteSymbol.ts
+++ b/packages/pixi-reels/src/symbols/SpriteSymbol.ts
@@ -1,5 +1,6 @@
 import { Sprite, type Texture } from 'pixi.js';
-import { gsap } from 'gsap';
+import type { gsap } from 'gsap';
+import { getGsap } from '../utils/gsapRef.js';
 import { ReelSymbol } from './ReelSymbol.js';
 
 export interface SpriteSymbolOptions {
@@ -42,7 +43,7 @@ export class SpriteSymbol extends ReelSymbol {
   async playWin(): Promise<void> {
     this._killWinTween();
     return new Promise<void>((resolve) => {
-      this._winTween = gsap.to(this._sprite.scale, {
+      this._winTween = getGsap().to(this._sprite.scale, {
         x: 1.15,
         y: 1.15,
         duration: 0.15,

--- a/packages/pixi-reels/src/utils/gsapRef.ts
+++ b/packages/pixi-reels/src/utils/gsapRef.ts
@@ -1,0 +1,41 @@
+import { gsap as defaultGsap } from 'gsap';
+
+/**
+ * The gsap instance every phase, motion tween, and cascade animation in
+ * the engine reads from.
+ *
+ * **Why this indirection exists:** under tools that resolve modules through
+ * symlinked workspaces (vite + a locally-linked pixi-reels, pnpm dev
+ * setups, esbuild plugin chains), the gsap import inside the lib's
+ * compiled `dist/index.js` and the gsap import in the consumer's source
+ * can resolve to *different module instances* — each with its own root
+ * timeline. The consumer drives one, the lib's tweens live on the other,
+ * and reels stall at progress 0.
+ *
+ * The fix: every internal animation site reads gsap through `getGsap()`
+ * instead of importing the `'gsap'` module directly. The builder method
+ * `ReelSetBuilder.gsap(myGsap)` rebinds the singleton so the consumer's
+ * gsap is the one the engine uses.
+ *
+ * Defaults to the gsap import resolved at lib-load time, so consumers
+ * who don't hit the dual-instance trap don't have to do anything.
+ */
+let currentGsap: typeof defaultGsap = defaultGsap;
+
+/**
+ * Replace the gsap instance the engine drives. Call this BEFORE
+ * `ReelSetBuilder.build()` (the builder does this for you when you call
+ * `.gsap(instance)`).
+ *
+ * Process-global: there's only one bound instance at a time. If you
+ * build several ReelSets with different gsap instances, the last
+ * `setGsap` call wins.
+ */
+export function setGsap(g: typeof defaultGsap): void {
+  currentGsap = g;
+}
+
+/** The currently-bound gsap instance. */
+export function getGsap(): typeof defaultGsap {
+  return currentGsap;
+}

--- a/packages/pixi-reels/tests/unit/gsapRef.test.ts
+++ b/packages/pixi-reels/tests/unit/gsapRef.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { gsap as defaultGsap } from 'gsap';
+import { getGsap, setGsap } from '../../src/utils/gsapRef.js';
+
+describe('gsapRef', () => {
+  afterEach(() => {
+    // Restore the default binding so other tests are not affected.
+    setGsap(defaultGsap);
+  });
+
+  it('returns the imported gsap by default', () => {
+    expect(getGsap()).toBe(defaultGsap);
+  });
+
+  it('setGsap rebinds the instance returned by getGsap', () => {
+    const fake = { timeline: vi.fn(), to: vi.fn(), delayedCall: vi.fn() } as unknown as typeof defaultGsap;
+    setGsap(fake);
+    expect(getGsap()).toBe(fake);
+    expect(getGsap()).not.toBe(defaultGsap);
+  });
+
+  it('builder.gsap(instance) wires through to getGsap()', async () => {
+    const { ReelSetBuilder } = await import('../../src/core/ReelSetBuilder.js');
+    const fake = { timeline: vi.fn(), to: vi.fn(), delayedCall: vi.fn() } as unknown as typeof defaultGsap;
+
+    new ReelSetBuilder().gsap(fake);
+
+    expect(getGsap()).toBe(fake);
+  });
+
+  it('builder.gsap() returns the builder for chaining', async () => {
+    const { ReelSetBuilder } = await import('../../src/core/ReelSetBuilder.js');
+    const builder = new ReelSetBuilder();
+    const fake = { timeline: vi.fn(), to: vi.fn(), delayedCall: vi.fn() } as unknown as typeof defaultGsap;
+
+    expect(builder.gsap(fake)).toBe(builder);
+  });
+
+  it('every internal animation file reads gsap through getGsap (regression guard)', async () => {
+    // If a future change re-introduces a bare `import { gsap } from 'gsap'`
+    // and uses it for a runtime tween call, this test will catch it: any
+    // `gsap.timeline(`, `gsap.to(`, or `gsap.delayedCall(` outside the
+    // gsapRef shim itself is a regression.
+    //
+    // Type-only imports (`import type { gsap } from 'gsap'`) are fine —
+    // they erase at compile time and never execute. Comments mentioning
+    // `gsap.com` (the docs URL) are also fine.
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const srcDir = path.resolve(__dirname, '../../src');
+
+    async function walk(dir: string): Promise<string[]> {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      const files: string[] = [];
+      for (const e of entries) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) files.push(...(await walk(full)));
+        else if (e.isFile() && full.endsWith('.ts')) files.push(full);
+      }
+      return files;
+    }
+
+    const files = await walk(srcDir);
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      if (file.endsWith('utils/gsapRef.ts')) continue;
+      const content = await fs.readFile(file, 'utf8');
+
+      // Strip line comments so docs URLs (`// gsap.com`) don't false-positive.
+      const stripped = content
+        .split('\n')
+        .map((line) => line.replace(/\/\/.*$/, ''))
+        .join('\n')
+        .replace(/\/\*[\s\S]*?\*\//g, '');
+
+      // Look for runtime calls: gsap.timeline(, gsap.to(, gsap.delayedCall(.
+      const runtimeCallRe = /\bgsap\.(timeline|to|delayedCall|fromTo|set|killTweensOf)\s*\(/;
+      if (runtimeCallRe.test(stripped)) {
+        offenders.push(path.relative(srcDir, file));
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces a tiny `getGsap()`/`setGsap()` shim in `utils/gsapRef.ts` and routes every internal tween, timeline, and `delayedCall` site through it (every animation file now reads gsap through `getGsap()` instead of importing `'gsap'` directly).
- Adds `ReelSetBuilder.gsap(myGsap)` so consumers can rebind the engine's gsap to their own instance — fixes the dual-instance trap (symlinked workspaces, npm-link, misconfigured `dedupe`) where the engine's tweens live on a different root timeline than the one the consumer drives, causing reels to stall at progress 0 or animations to double-fire.
- No behavioural change for consumers who don't call `.gsap()` — the default binding is the engine's own resolved `gsap` import.

## API

```ts
import { gsap } from 'gsap';

const reelSet = new ReelSetBuilder()
  .reels(5).visibleRows(3).symbolSize(200, 200)
  .symbols(...)
  .ticker(app.ticker)
  .gsap(gsap)         // ensure engine and app share one instance
  .build();
```

## Files touched
- New `src/utils/gsapRef.ts` — single-bound singleton with `getGsap()`/`setGsap()`.
- `src/core/ReelSetBuilder.ts` — new `.gsap(instance)` method with full TSDoc explaining when to use it.
- All animation sites converted to `getGsap()`:
  - `src/spin/phases/StartPhase.ts`
  - `src/spin/phases/StopPhase.ts`
  - `src/spin/phases/AnticipationPhase.ts`
  - `src/spin/phases/DropStopPhase.ts`
  - `src/spin/phases/AdjustPhase.ts`
  - `src/cascade/CascadeAnticipationPhase.ts`
  - `src/symbols/SpriteSymbol.ts`
  - `src/core/ReelSet.ts` (pin-flight tween)
- New `tests/unit/gsapRef.test.ts` — verifies binding swap + a regression-guard scan that asserts no runtime `gsap.timeline(`/`gsap.to(`/`gsap.delayedCall(` calls remain outside the shim.
- `.changeset/feat-builder-gsap-injection.md` — minor bump.

## Test plan
- [x] `pnpm --filter pixi-reels typecheck`
- [x] `pnpm --filter pixi-reels test` — 219 tests pass (5 new in `gsapRef.test.ts`)
- [x] `pnpm check:lint`
- [ ] Verify in a downstream symlinked-workspace consumer that `.gsap(myGsap)` resolves the dual-instance stall (manual; env-specific)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)