### PR TITLE
feat: honor SymbolData.unmask by reparenting symbol view

### DIFF
--- a/.changeset/feat-auto-zindex-on-replace.md
+++ b/.changeset/feat-auto-zindex-on-replace.md
@@ -1,0 +1,11 @@
+---
+'pixi-reels': patch
+---
+
+Fix: `Reel._replaceSymbol` now sets the canonical zIndex inline on every symbol activation.
+
+Previously the activate path set `view.zIndex = 0` and relied on a follow-up `refreshZIndex()` call to apply the real formula `(symbolData.zIndex ?? 0) * 100 + arrayIndex`. All current callers happen to call `refreshZIndex` after, but the contract was fragile: any future caller that swapped a single symbol via the activate path would see the wrong layering until the next motion-wrap.
+
+A new private helper `_computeSymbolZIndex(symbolId, index)` centralizes the formula and is used by both `refreshZIndex` (full rescan) and `_replaceSymbol` (single-symbol activate). OCCUPIED stubs receive `arrayIndex` directly, matching what `refreshZIndex` would assign.
+
+No public API change. The fix unblocks future single-symbol swap APIs (e.g. a public `setSymbolAt`) without forcing every caller to remember to `refreshZIndex` afterwards.

--- a/.changeset/feat-unmask-reparent.md
+++ b/.changeset/feat-unmask-reparent.md
@@ -1,0 +1,11 @@
+---
+'pixi-reels': minor
+---
+
+Make `SymbolData.unmask: true` actually re-parent the symbol view to `viewport.unmaskedContainer`.
+
+Until now the `unmask` flag on `SymbolData` was accepted by the builder but never read by the engine — symbols always landed inside the reel's masked container regardless of the flag. With this change, every code path that places a symbol into the reel — `_setupSymbolPositions`, `_replaceSymbol` (both stub-install and stub-replace branches and the regular swap), and `reshape` — consults `_symbolsData[id].unmask` and parents the view to `viewport.unmaskedContainer` when set.
+
+When unmasked, the engine sets the view's X to `reel.container.x` and adds `reel.container.y` to the view's Y so the at-rest cell position aligns with the reel column (since `unmaskedContainer` sits at viewport-local 0,0).
+
+Documented limitation in `SymbolData.unmask` JSDoc: `ReelMotion` writes `view.y` in reel-local coords every frame, so an unmasked symbol on the strip will appear shifted vertically by `reel.container.y` while the reel is spinning. Treat `unmask: true` as a *landed-state* flag — it is correct at rest and during static frames, but not designed to stay visually accurate while the reel is spinning. For mid-spin "stays visible above mask" overlays, use a cell pin instead.

--- a/.changeset/fix-symbol-parent-recycle.md
+++ b/.changeset/fix-symbol-parent-recycle.md
@@ -1,0 +1,12 @@
+---
+"pixi-reels": patch
+---
+
+Fix: stop reparenting recycled symbols on spotlight hide and always anchor `Reel._replaceSymbol` to its own container.
+
+Two related bugs caused symbols to render in the wrong reel after rapid spin/skip cycles, particularly when the win spotlight runs alongside an expanding-wild mechanic that triggers many `placeSymbols` calls in quick succession:
+
+- `SymbolSpotlight.hide()` reparented every symbol it had ever tracked back to its `originalParent`, even when `promoteAboveMask: false` (no reparenting on `show()`) or after the shared symbol pool had recycled the instance into a different reel. The recycled symbol got yanked from its new owner, leaving a hole there and a stranger in the original reel.
+- `Reel._replaceSymbol` used the captured `oldSymbol.view.parent` as the destination for the replacement view. If the old symbol had been moved (by the spotlight or by pool recycling), the new symbol landed in a foreign container — symbols accumulated in the wrong reel across spins.
+
+Both paths now anchor to the reel's own container; the spotlight only reparents symbols whose view is still in `spotlightContainer` (i.e., never recycled away).

--- a/packages/pixi-reels/src/config/types.ts
+++ b/packages/pixi-reels/src/config/types.ts
@@ -31,7 +31,31 @@ export interface SymbolData {
   weight: number;
   /** Display layering order. Higher = in front. */
   zIndex?: number;
-  /** If true, this symbol renders above the reel mask (for oversized animations). */
+  /**
+   * If true, the engine parents this symbol's view to
+   * `viewport.unmaskedContainer` instead of the reel's masked container —
+   * the symbol renders above the reel mask, useful for oversized win
+   * animations (expanding wilds, splash frames) that should not be
+   * clipped at the cell boundary.
+   *
+   * **Coordinate space:** when unmasked, the engine sets the view's X to
+   * `reel.container.x` and adds `reel.container.y` to the view's Y so
+   * the at-rest position matches the reel's grid cell.
+   *
+   * **Motion limitation:** `ReelMotion` writes `view.y` in reel-local
+   * coordinates. While the reel is spinning, an unmasked symbol on the
+   * strip will appear shifted vertically by the reel's offset (the
+   * `reel.container.y` translation is only applied on activate, not on
+   * every motion frame). Treat `unmask: true` as a *landed-state* flag —
+   * it is correct at rest and during static frames, but not designed to
+   * stay visually accurate while the reel is spinning. If you need a
+   * mid-spin "stays visible above mask" overlay, use a cell pin instead.
+   *
+   * **Mask strategy:** the per-reel `RectMaskStrategy` (default) clips
+   * any horizontal gaps between reels. For symbols that need to overlap
+   * across reel boundaries while unmasked, prefer
+   * `SharedRectMaskStrategy`.
+   */
   unmask?: boolean;
   /**
    * Footprint in cells. Default `{ w: 1, h: 1 }`. When `w * h > 1` this

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -433,13 +433,14 @@ export class Reel implements Disposable {
   ): void {
     const newTotal = bufferAbove + newVisibleRows + bufferBelow;
 
-    // Grow: append additional symbols at the bottom buffer.
+    // Grow: append additional symbols at the bottom buffer. New symbols are
+    // parented based on `unmask` flag — same rule as `_replaceSymbol`.
     while (this.symbols.length < newTotal) {
       const id = this._randomProvider.next(true);
       const sym = this._symbolFactory.acquire(id);
       sym.resize(this._symbolWidth, newSymbolHeight);
-      sym.view.x = 0;
-      this.container.addChild(sym.view);
+      this._placeSymbolView(sym.view, sym.view.y, this._isUnmasked(id));
+      this._parentForSymbolId(id).addChild(sym.view);
       this.symbols.push(sym);
     }
 
@@ -520,19 +521,72 @@ export class Reel implements Disposable {
     this.events.emit('destroyed');
   }
 
+  /**
+   * Whether the symbol with this id has `unmask: true` in its data — i.e.
+   * its view should be parented to `viewport.unmaskedContainer` to render
+   * above the reel mask.
+   */
+  private _isUnmasked(symbolId: string): boolean {
+    return !!this._symbolsData[symbolId]?.unmask;
+  }
+
+  /**
+   * Pick the right parent container for a symbol view based on its
+   * `unmask` flag. Unmasked symbols sit in `viewport.unmaskedContainer`
+   * (above the reel mask); everything else lives in this reel's own
+   * container (which is itself inside `viewport.maskedContainer`).
+   */
+  private _parentForSymbolId(symbolId: string): Container {
+    return this._isUnmasked(symbolId)
+      ? this._viewport.unmaskedContainer
+      : this.container;
+  }
+
+  /**
+   * Position a symbol view at a given reel-local Y, choosing X and any
+   * parent-translation offset based on whether the symbol is unmasked.
+   *
+   * Unmasked views live in `viewport.unmaskedContainer` (at viewport
+   * (0,0)), so we add `reel.container.x` and `reel.container.y` to keep
+   * the at-rest cell position aligned with the reel column. Masked views
+   * live in `this.container`, so reel-local coords map directly.
+   */
+  private _placeSymbolView(view: Container, reelLocalY: number, isUnmasked: boolean): void {
+    if (isUnmasked) {
+      view.x = this.container.x;
+      view.y = this.container.y + reelLocalY;
+    } else {
+      view.x = 0;
+      view.y = reelLocalY;
+    }
+  }
+
+  /**
+   * Convert a view's current y back to reel-local coords. The view may
+   * be parented to either `this.container` (already reel-local) or
+   * `viewport.unmaskedContainer` (viewport-local — needs the reel offset
+   * subtracted).
+   */
+  private _toReelLocalY(view: Container): number {
+    return view.parent === this._viewport.unmaskedContainer
+      ? view.y - this.container.y
+      : view.y;
+  }
+
   private _setupSymbolPositions(config: ReelConfig): void {
     const slotH = this._spinSymbolHeight + config.symbolGapY;
+    // Add the reel container to the viewport's masked area first so
+    // `this.container.x/y` are in viewport coords if any initial symbol
+    // has `unmask: true` and needs parent-translation.
+    this._viewport.maskedContainer.addChild(this.container);
+
     for (let i = 0; i < this.symbols.length; i++) {
       const symbol = this.symbols[i];
       const y = (i - config.bufferAbove) * slotH;
-      symbol.view.y = y;
-      symbol.view.x = 0;
-
-      // All symbols go into the reel's own container
-      this.container.addChild(symbol.view);
+      const unmasked = this._isUnmasked(symbol.symbolId);
+      this._placeSymbolView(symbol.view, y, unmasked);
+      this._parentForSymbolId(symbol.symbolId).addChild(symbol.view);
     }
-    // Add the reel container to the viewport's masked area
-    this._viewport.maskedContainer.addChild(this.container);
   }
 
   private _onSymbolWrapped(symbol: ReelSymbol, row: number, direction: 'up' | 'down'): void {
@@ -553,39 +607,44 @@ export class Reel implements Disposable {
     const oldSymbol = this.symbols[index];
     const isOldStub = oldSymbol instanceof OccupiedStub;
 
-    // OCCUPIED: install a stub. Stubs are not pooled through SymbolFactory.
+    // Capture old Y in reel-local coords before releasing — old view may
+    // have been parented to viewport.unmaskedContainer and need an offset
+    // subtraction to be reused as the new symbol's reel-local Y.
+    const reelLocalY = isOldStub
+      ? oldSymbol.view.y
+      : this._toReelLocalY(oldSymbol.view);
+
+    // OCCUPIED: install a stub. Stubs are not pooled through SymbolFactory
+    // and never carry an `unmask` flag — they always live in `this.container`.
     if (newSymbolId === OCCUPIED_SENTINEL) {
       if (isOldStub) {
         oldSymbol.view.alpha = 0;
         return;
       }
-      const parent = oldSymbol.view.parent;
-      const y = oldSymbol.view.y;
       this._symbolFactory.release(oldSymbol);
       const stub = this._acquireOccupiedStub();
-      stub.view.y = y;
+      stub.view.y = reelLocalY;
       stub.view.x = 0;
       stub.view.alpha = 0;
       stub.view.visible = true;
       stub.view.scale.set(1, 1);
-      if (parent && stub.view.parent !== parent) parent.addChild(stub.view);
+      if (stub.view.parent !== this.container) this.container.addChild(stub.view);
       this.symbols[index] = stub;
       return;
     }
 
-    // Replacing a stub with a real symbol: release stub back to internal cache.
+    // Replacing a stub with a real symbol: release stub back to internal
+    // cache. The new symbol may be unmasked → choose parent + offset by id.
     if (isOldStub) {
-      const parent = oldSymbol.view.parent;
-      const y = oldSymbol.view.y;
       this._releaseOccupiedStub(oldSymbol);
       const newSymbol = this._symbolFactory.acquire(newSymbolId);
+      const newIsUnmasked = this._isUnmasked(newSymbolId);
       newSymbol.resize(this._symbolWidth, this._symbolHeight);
-      newSymbol.view.y = y;
-      newSymbol.view.x = 0;
+      this._placeSymbolView(newSymbol.view, reelLocalY, newIsUnmasked);
       newSymbol.view.alpha = 1;
       newSymbol.view.scale.set(1, 1);
       newSymbol.view.zIndex = 0;
-      if (parent) parent.addChild(newSymbol.view);
+      this._parentForSymbolId(newSymbolId).addChild(newSymbol.view);
       this.symbols[index] = newSymbol;
       this.events.emit('symbol:created', newSymbolId, index);
       return;
@@ -599,21 +658,16 @@ export class Reel implements Disposable {
       return;
     }
 
-    const parent = oldSymbol.view.parent;
-    const y = oldSymbol.view.y;
-
     this._symbolFactory.release(oldSymbol);
     const newSymbol = this._symbolFactory.acquire(newSymbolId);
+    const newIsUnmasked = this._isUnmasked(newSymbolId);
     newSymbol.resize(this._symbolWidth, this._symbolHeight);
-    newSymbol.view.y = y;
-    newSymbol.view.x = 0;
+    this._placeSymbolView(newSymbol.view, reelLocalY, newIsUnmasked);
     newSymbol.view.alpha = 1;
     newSymbol.view.scale.set(1, 1);
     newSymbol.view.zIndex = 0;
 
-    if (parent) {
-      parent.addChild(newSymbol.view);
-    }
+    this._parentForSymbolId(newSymbolId).addChild(newSymbol.view);
 
     this.symbols[index] = newSymbol;
     this.events.emit('symbol:created', newSymbolId, index);

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -552,6 +552,12 @@ export class Reel implements Disposable {
   private _replaceSymbol(index: number, newSymbolId: string): void {
     const oldSymbol = this.symbols[index];
     const isOldStub = oldSymbol instanceof OccupiedStub;
+    // Always parent into THIS reel's own container — the old symbol's
+    // `view.parent` is unsafe as a destination because the shared symbol
+    // pool can recycle a view across reels (or the spotlight may have
+    // promoted it above the mask), leaving `oldSymbol.view.parent`
+    // pointing at a foreign container.
+    const parent = this.container;
 
     // OCCUPIED: install a stub. Stubs are not pooled through SymbolFactory.
     if (newSymbolId === OCCUPIED_SENTINEL) {
@@ -559,7 +565,6 @@ export class Reel implements Disposable {
         oldSymbol.view.alpha = 0;
         return;
       }
-      const parent = oldSymbol.view.parent;
       const y = oldSymbol.view.y;
       this._symbolFactory.release(oldSymbol);
       const stub = this._acquireOccupiedStub();
@@ -568,14 +573,13 @@ export class Reel implements Disposable {
       stub.view.alpha = 0;
       stub.view.visible = true;
       stub.view.scale.set(1, 1);
-      if (parent && stub.view.parent !== parent) parent.addChild(stub.view);
+      if (stub.view.parent !== parent) parent.addChild(stub.view);
       this.symbols[index] = stub;
       return;
     }
 
     // Replacing a stub with a real symbol: release stub back to internal cache.
     if (isOldStub) {
-      const parent = oldSymbol.view.parent;
       const y = oldSymbol.view.y;
       this._releaseOccupiedStub(oldSymbol);
       const newSymbol = this._symbolFactory.acquire(newSymbolId);
@@ -585,21 +589,23 @@ export class Reel implements Disposable {
       newSymbol.view.alpha = 1;
       newSymbol.view.scale.set(1, 1);
       newSymbol.view.zIndex = 0;
-      if (parent) parent.addChild(newSymbol.view);
+      parent.addChild(newSymbol.view);
       this.symbols[index] = newSymbol;
       this.events.emit('symbol:created', newSymbolId, index);
       return;
     }
 
-    // Even if same symbolId, always reset visual state (alpha, scale, zIndex)
+    // Same id fast-path. Reset visual state and re-anchor the view to this
+    // reel's container in case the pool had moved it elsewhere since the
+    // last activation.
     if (oldSymbol.symbolId === newSymbolId) {
       oldSymbol.view.alpha = 1;
       oldSymbol.view.scale.set(1, 1);
       oldSymbol.view.zIndex = 0;
+      if (oldSymbol.view.parent !== parent) parent.addChild(oldSymbol.view);
       return;
     }
 
-    const parent = oldSymbol.view.parent;
     const y = oldSymbol.view.y;
 
     this._symbolFactory.release(oldSymbol);
@@ -611,9 +617,7 @@ export class Reel implements Disposable {
     newSymbol.view.scale.set(1, 1);
     newSymbol.view.zIndex = 0;
 
-    if (parent) {
-      parent.addChild(newSymbol.view);
-    }
+    parent.addChild(newSymbol.view);
 
     this.symbols[index] = newSymbol;
     this.events.emit('symbol:created', newSymbolId, index);

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -478,6 +478,18 @@ export class Reel implements Disposable {
   }
 
   /**
+   * Compute the canonical zIndex for a single symbol view at a given
+   * array index. Centralizes the formula used by both `refreshZIndex`
+   * (full rescan) and the per-swap activate path (so newly placed
+   * symbols land with their correct zIndex without the caller needing
+   * to remember to call `refreshZIndex` afterwards).
+   */
+  private _computeSymbolZIndex(symbolId: string, index: number): number {
+    const base = this._symbolsData[symbolId]?.zIndex ?? 0;
+    return base * 100 + index;
+  }
+
+  /**
    * Recompute `zIndex` for every symbol in the reel.
    *
    * Formula: `symbolData.zIndex ?? 0` (scaled by 100 to leave room for row
@@ -485,8 +497,12 @@ export class Reel implements Disposable {
    * render in front of top-row symbols and any symbol with a higher
    * configured base zIndex (e.g. wild, bonus) renders above its neighbors.
    *
-   * Called automatically after wraps, snaps, and direct placement. Call it
-   * manually after mutating `symbolsData.zIndex` at runtime.
+   * Called automatically after wraps, snaps, and direct placement. Also
+   * called inline by `_replaceSymbol` for the single newly-placed symbol —
+   * so consumers who swap one symbol at a time (via the public APIs that
+   * funnel into `_replaceSymbol`) get correct layering for free, no
+   * manual `refreshZIndex` required. Call it manually after mutating
+   * `symbolsData.zIndex` at runtime.
    */
   refreshZIndex(): void {
     for (let i = 0; i < this.symbols.length; i++) {
@@ -495,8 +511,7 @@ export class Reel implements Disposable {
         symbol.view.zIndex = i;
         continue;
       }
-      const base = this._symbolsData[symbol.symbolId]?.zIndex ?? 0;
-      symbol.view.zIndex = base * 100 + i;
+      symbol.view.zIndex = this._computeSymbolZIndex(symbol.symbolId, i);
     }
   }
 
@@ -568,6 +583,7 @@ export class Reel implements Disposable {
       stub.view.alpha = 0;
       stub.view.visible = true;
       stub.view.scale.set(1, 1);
+      stub.view.zIndex = index;
       if (parent && stub.view.parent !== parent) parent.addChild(stub.view);
       this.symbols[index] = stub;
       return;
@@ -584,7 +600,7 @@ export class Reel implements Disposable {
       newSymbol.view.x = 0;
       newSymbol.view.alpha = 1;
       newSymbol.view.scale.set(1, 1);
-      newSymbol.view.zIndex = 0;
+      newSymbol.view.zIndex = this._computeSymbolZIndex(newSymbolId, index);
       if (parent) parent.addChild(newSymbol.view);
       this.symbols[index] = newSymbol;
       this.events.emit('symbol:created', newSymbolId, index);
@@ -595,7 +611,7 @@ export class Reel implements Disposable {
     if (oldSymbol.symbolId === newSymbolId) {
       oldSymbol.view.alpha = 1;
       oldSymbol.view.scale.set(1, 1);
-      oldSymbol.view.zIndex = 0;
+      oldSymbol.view.zIndex = this._computeSymbolZIndex(newSymbolId, index);
       return;
     }
 
@@ -609,7 +625,7 @@ export class Reel implements Disposable {
     newSymbol.view.x = 0;
     newSymbol.view.alpha = 1;
     newSymbol.view.scale.set(1, 1);
-    newSymbol.view.zIndex = 0;
+    newSymbol.view.zIndex = this._computeSymbolZIndex(newSymbolId, index);
 
     if (parent) {
       parent.addChild(newSymbol.view);

--- a/packages/pixi-reels/src/spotlight/SymbolSpotlight.ts
+++ b/packages/pixi-reels/src/spotlight/SymbolSpotlight.ts
@@ -109,11 +109,14 @@ export class SymbolSpotlight implements Disposable {
       if (seen.has(key)) continue;
       seen.add(key);
 
-      const originalParent = symbol.view.parent;
-      this._promoted.push({ symbol, originalParent, position: pos });
-
+      // Track for hide() only when we're actually moving the view —
+      // otherwise the entry's `originalParent` would become stale if the
+      // shared symbol pool recycles this instance into a different reel
+      // before the next hide(), and `hide()` would reparent it back to a
+      // reel that no longer owns it (leaving a hole on the new owner).
       if (promoteAboveMask) {
-        // Re-parent to spotlight container (above mask)
+        const originalParent = symbol.view.parent;
+        this._promoted.push({ symbol, originalParent, position: pos });
         const globalPos = symbol.view.getGlobalPosition();
         this._viewport.spotlightContainer.addChild(symbol.view);
         const localPos = this._viewport.spotlightContainer.toLocal(globalPos);
@@ -139,9 +142,13 @@ export class SymbolSpotlight implements Disposable {
       this._cycleAbort = null;
     }
 
-    // Return promoted symbols
+    // Return promoted symbols. Skip any whose view has been moved out of
+    // the spotlight container — that means the shared symbol pool has
+    // recycled them into another reel since show(), and reparenting back
+    // to `originalParent` would steal them from their new owner.
     for (const { symbol, originalParent } of this._promoted) {
-      if (originalParent && symbol.view.parent !== originalParent) {
+      if (symbol.view.parent !== this._viewport.spotlightContainer) continue;
+      if (originalParent) {
         const globalPos = symbol.view.getGlobalPosition();
         originalParent.addChild(symbol.view);
         const localPos = originalParent.toLocal(globalPos);

--- a/packages/pixi-reels/tests/integration/autoZIndex.test.ts
+++ b/packages/pixi-reels/tests/integration/autoZIndex.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests for the auto-zIndex contract on `_replaceSymbol`.
+ *
+ * Contract: when a symbol is activated into a row (via any code path that
+ * funnels into `_replaceSymbol` — wrap callback, `placeSymbols`, etc.), its
+ * view's zIndex is set to the canonical formula
+ *   `(symbolData.zIndex ?? 0) * 100 + arrayIndex`
+ * automatically. Consumers should not need to call `refreshZIndex()`
+ * explicitly after a single in-place swap.
+ *
+ * This guards against regressions where the activate path falls back to
+ * `view.zIndex = 0`, which was a long-standing footgun: a wild registered
+ * with `zIndex: 5` would render *under* its neighbours until the next
+ * motion-wrap or snap re-ran `refreshZIndex` over the whole reel.
+ */
+import { describe, it, expect } from 'vitest';
+import { createTestReelSet } from '../../src/testing/index.js';
+
+const SYMBOLS = ['a', 'wild', 'b'];
+
+describe('auto-zIndex on _replaceSymbol', () => {
+  it('a newly-placed symbol gets the canonical zIndex without an explicit refresh', async () => {
+    const h = createTestReelSet({
+      reels: 3,
+      visibleRows: 3,
+      symbolIds: SYMBOLS,
+      symbolData: {
+        wild: { zIndex: 5 },
+      },
+    });
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'wild', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+
+      const reel = h.reelSet.reels[1];
+      const bufferAbove = reel.bufferAbove;
+      const wildArrayIndex = bufferAbove + 1; // visible row 1
+      const wildView = reel.symbols[wildArrayIndex].view;
+
+      // Canonical formula: (symbolData.zIndex ?? 0) * 100 + arrayIndex
+      expect(wildView.zIndex).toBe(5 * 100 + wildArrayIndex);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('a symbol with no zIndex override uses the builder default (1) plus arrayIndex', async () => {
+    // Builder defaults `symbolData.zIndex` to 1 for every registered symbol
+    // when no override is provided; auto-zIndex on activate must respect
+    // that default, not silently land symbols on layer 0.
+    const h = createTestReelSet({
+      reels: 3,
+      visibleRows: 3,
+      symbolIds: SYMBOLS,
+    });
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+
+      const reel = h.reelSet.reels[0];
+      const bufferAbove = reel.bufferAbove;
+
+      for (let row = 0; row < 3; row++) {
+        const arrayIndex = bufferAbove + row;
+        const view = reel.symbols[arrayIndex].view;
+        expect(view.zIndex).toBe(1 * 100 + arrayIndex);
+      }
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('zIndex is reapplied even when the same symbol id replaces itself', async () => {
+    const h = createTestReelSet({
+      reels: 3,
+      visibleRows: 3,
+      symbolIds: SYMBOLS,
+      symbolData: {
+        wild: { zIndex: 7 },
+      },
+    });
+    try {
+      // First spin: wild lands.
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'wild', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      // Manually corrupt the zIndex so we can verify the swap re-applies it.
+      const reel = h.reelSet.reels[1];
+      const bufferAbove = reel.bufferAbove;
+      const wildArrayIndex = bufferAbove + 1;
+      reel.symbols[wildArrayIndex].view.zIndex = -999;
+
+      // Second spin: wild lands at the same row again (same symbol id swap).
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'wild', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+
+      const wildView = reel.symbols[wildArrayIndex].view;
+      expect(wildView.zIndex).toBe(7 * 100 + wildArrayIndex);
+    } finally {
+      h.destroy();
+    }
+  });
+});

--- a/packages/pixi-reels/tests/integration/spotlight.test.ts
+++ b/packages/pixi-reels/tests/integration/spotlight.test.ts
@@ -1,0 +1,150 @@
+/**
+ * SymbolSpotlight integration tests — focused on the parent-restoration
+ * invariant that broke when symbols were pool-recycled across reels mid-
+ * spotlight.
+ */
+import { describe, it, expect } from 'vitest';
+import { createTestReelSet } from '../../src/testing/index.js';
+
+const SYMBOLS = ['a', 'b', 'c', 'wild'];
+
+function makeHarness() {
+  return createTestReelSet({
+    reels: 5,
+    visibleRows: 3,
+    symbolIds: SYMBOLS,
+  });
+}
+
+describe('SymbolSpotlight — symbol parent invariant after recycling', () => {
+  it('does not yank recycled symbols back to a stale parent (promoteAboveMask: false)', async () => {
+    const h = makeHarness();
+    try {
+      // Land a grid where reel 0 has a winner.
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['wild', 'wild', 'wild'],
+        ['a', 'b', 'c'],
+      ]);
+
+      // Fire a spotlight on reel 0 row 1. The ReelSet uses a shared symbol
+      // pool — the 'a' instance at reel 0 may end up reused on a different
+      // reel after the next placeSymbols call.
+      await h.reelSet.spotlight.show(
+        [{ reelIndex: 0, rowIndex: 1 }],
+        { promoteAboveMask: false },
+      );
+
+      // Land a different grid. Each reel's placeSymbols releases its old
+      // symbols to the pool and acquires fresh ones — guaranteeing the 'a'
+      // instance from reel 0 row 1 gets reassigned somewhere else.
+      await h.spinAndLand([
+        ['c', 'c', 'c'],
+        ['c', 'c', 'c'],
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['wild', 'wild', 'wild'],
+      ]);
+
+      // Calling show() (or hide() directly) re-runs spotlight cleanup.
+      // Before the fix, this reparented the recycled 'a' instance back to
+      // reel 0's container, leaving a hole on whichever reel now owns it
+      // and a stranger inside reel 0's container.
+      await h.reelSet.spotlight.show(
+        [{ reelIndex: 4, rowIndex: 0 }],
+        { promoteAboveMask: false },
+      );
+      h.reelSet.spotlight.hide();
+
+      // Invariant: every symbol's view.parent matches the container of the
+      // reel that owns it in `reels[i].symbols`.
+      for (let r = 0; r < 5; r++) {
+        const reel = h.reelSet.reels[r];
+        for (let i = 0; i < reel.symbols.length; i++) {
+          const sym = reel.symbols[i];
+          expect(sym.view.parent, `reel ${r} symbol[${i}] (${sym.symbolId}) parent`)
+            .toBe(reel.container);
+        }
+      }
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('does not yank recycled symbols back to a stale parent (promoteAboveMask: true)', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['wild', 'wild', 'wild'],
+        ['a', 'b', 'c'],
+      ]);
+
+      // Synchronously call show + immediately recycle by landing a new grid
+      // — the show's promoteAboveMask: true path stashes the promoted view
+      // in spotlightContainer, but if a follow-up placeSymbols (or the
+      // pool) yanks it back into a reel before hide() runs, hide() must
+      // not steal it from the new owner.
+      h.reelSet.spotlight.show(
+        [{ reelIndex: 0, rowIndex: 1 }],
+        { promoteAboveMask: true, playWinAnimation: false },
+      );
+      // Land a different grid that will exercise placeSymbols on every reel.
+      await h.spinAndLand([
+        ['c', 'c', 'c'],
+        ['c', 'c', 'c'],
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['wild', 'wild', 'wild'],
+      ]);
+      h.reelSet.spotlight.hide();
+
+      for (let r = 0; r < 5; r++) {
+        const reel = h.reelSet.reels[r];
+        for (let i = 0; i < reel.symbols.length; i++) {
+          const sym = reel.symbols[i];
+          expect(sym.view.parent, `reel ${r} symbol[${i}] (${sym.symbolId}) parent`)
+            .toBe(reel.container);
+        }
+      }
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('still restores promoted symbols when promoteAboveMask: true (regression)', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['wild', 'wild', 'wild'],
+        ['a', 'b', 'c'],
+      ]);
+
+      const reel0 = h.reelSet.reels[0];
+      const beforeSym = reel0.getSymbolAt(1);
+      const beforeParent = beforeSym.view.parent;
+
+      await h.reelSet.spotlight.show(
+        [{ reelIndex: 0, rowIndex: 1 }],
+        { promoteAboveMask: true },
+      );
+
+      // While promoted, the symbol is in the spotlight container.
+      expect(beforeSym.view.parent).not.toBe(beforeParent);
+
+      h.reelSet.spotlight.hide();
+
+      // Hide restores it to the original reel container.
+      expect(beforeSym.view.parent).toBe(beforeParent);
+    } finally {
+      h.destroy();
+    }
+  });
+});

--- a/packages/pixi-reels/tests/integration/unmask.test.ts
+++ b/packages/pixi-reels/tests/integration/unmask.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Integration tests for `SymbolData.unmask: true`.
+ *
+ * Contract: when a registered symbol has `unmask: true`, its view is
+ * parented to `viewport.unmaskedContainer` instead of the reel's masked
+ * container. This makes the symbol render above the reel mask — useful
+ * for oversized win animations.
+ *
+ * The reparenting must apply both at:
+ *   - `placeSymbols` (skip / turbo / cascade landing path), and
+ *   - normal stop landing once the target frame settles.
+ *
+ * The X position must match the reel's column (since unmaskedContainer
+ * sits at viewport-local 0,0). The Y must include the reel's container
+ * offset so the at-rest cell position is correct in viewport coords.
+ */
+import { describe, it, expect } from 'vitest';
+import { createTestReelSet } from '../../src/testing/index.js';
+
+const SYMBOLS = ['a', 'wild', 'b'];
+
+function makeHarness() {
+  return createTestReelSet({
+    reels: 3,
+    visibleRows: 3,
+    symbolIds: SYMBOLS,
+    symbolData: {
+      wild: { unmask: true },
+    },
+  });
+}
+
+describe('unmask: true reparents the symbol view to viewport.unmaskedContainer', () => {
+  it('a wild that lands in a cell sits in the unmasked container', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'wild', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+
+      const reel = h.reelSet.reels[1];
+      const visible = reel.getVisibleSymbols();
+      expect(visible[1]).toBe('wild');
+
+      const wildView = reel.getSymbolAt(1).view;
+      expect(wildView.parent).toBe(h.reelSet.viewport.unmaskedContainer);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('a normal symbol still sits in the reel container (the masked layer)', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+
+      const reel = h.reelSet.reels[0];
+      const view = reel.getSymbolAt(0).view;
+      expect(view.parent).toBe(reel.container);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('reparents back to the reel when an unmasked symbol is replaced by a masked one', async () => {
+    const h = makeHarness();
+    try {
+      // First spin: wild lands in middle row of reel 1 → unmasked.
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'wild', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      const reel = h.reelSet.reels[1];
+      expect(reel.getSymbolAt(1).view.parent).toBe(h.reelSet.viewport.unmaskedContainer);
+
+      // Second spin: middle row becomes a normal symbol → must end up in reel.container.
+      await h.spinAndLand([
+        ['b', 'b', 'b'],
+        ['b', 'b', 'b'],
+        ['b', 'b', 'b'],
+      ]);
+
+      expect(reel.getSymbolAt(1).view.parent).toBe(reel.container);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('aligns unmasked X with the reel column so it visually overlaps the right cell', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'wild'],
+      ]);
+
+      const reel = h.reelSet.reels[2];
+      const wildView = reel.getSymbolAt(2).view;
+
+      // X in the unmaskedContainer must equal the reel's container.x so the
+      // wild lines up under the rightmost reel column.
+      expect(wildView.x).toBe(reel.container.x);
+    } finally {
+      h.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Wires up `SymbolData.unmask: true` end-to-end. Until now the flag was accepted by the builder but never read by the engine — symbols always landed inside the reel's masked container regardless of the flag. Now every code path that places a symbol into a reel reparents to `viewport.unmaskedContainer` when the flag is set.
- The engine sets the unmasked view's X to `reel.container.x` and adds `reel.container.y` to the view's Y so the at-rest cell position aligns with the reel column (since `unmaskedContainer` sits at viewport-local `(0, 0)`).
- Documented limitation in `SymbolData.unmask` JSDoc: motion writes `view.y` in reel-local coords every frame, so an unmasked symbol on the strip will appear shifted vertically while the reel is spinning. Treat `unmask: true` as a *landed-state* flag. For mid-spin "stays visible above mask" overlays, use a cell pin instead.

## Files touched
- `src/config/types.ts` — full TSDoc on the `unmask` field covering coordinate space, motion limitation, and mask-strategy guidance.
- `src/core/Reel.ts` — new helpers `_isUnmasked(id)`, `_parentForSymbolId(id)`, `_placeSymbolView(view, y, isUnmasked)`, `_toReelLocalY(view)`. Threaded through `_setupSymbolPositions`, all three branches of `_replaceSymbol`, and `reshape`.
- `tests/integration/unmask.test.ts` — 4 new tests verifying parent + X position contract on land + recycle paths.
- `.changeset/feat-unmask-reparent.md` — minor bump.

## Test plan
- [x] `pnpm --filter pixi-reels typecheck`
- [x] `pnpm --filter pixi-reels test` — 218 tests pass (4 new in `unmask.test.ts`)
- [x] `pnpm check:lint`

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)