### PR TITLE
fix: set canonical zIndex inline on every symbol activation

### DIFF
--- a/.changeset/feat-auto-zindex-on-replace.md
+++ b/.changeset/feat-auto-zindex-on-replace.md
@@ -1,0 +1,11 @@
+---
+'pixi-reels': patch
+---
+
+Fix: `Reel._replaceSymbol` now sets the canonical zIndex inline on every symbol activation.
+
+Previously the activate path set `view.zIndex = 0` and relied on a follow-up `refreshZIndex()` call to apply the real formula `(symbolData.zIndex ?? 0) * 100 + arrayIndex`. All current callers happen to call `refreshZIndex` after, but the contract was fragile: any future caller that swapped a single symbol via the activate path would see the wrong layering until the next motion-wrap.
+
+A new private helper `_computeSymbolZIndex(symbolId, index)` centralizes the formula and is used by both `refreshZIndex` (full rescan) and `_replaceSymbol` (single-symbol activate). OCCUPIED stubs receive `arrayIndex` directly, matching what `refreshZIndex` would assign.
+
+No public API change. The fix unblocks future single-symbol swap APIs (e.g. a public `setSymbolAt`) without forcing every caller to remember to `refreshZIndex` afterwards.

--- a/.changeset/fix-symbol-parent-recycle.md
+++ b/.changeset/fix-symbol-parent-recycle.md
@@ -1,0 +1,12 @@
+---
+"pixi-reels": patch
+---
+
+Fix: stop reparenting recycled symbols on spotlight hide and always anchor `Reel._replaceSymbol` to its own container.
+
+Two related bugs caused symbols to render in the wrong reel after rapid spin/skip cycles, particularly when the win spotlight runs alongside an expanding-wild mechanic that triggers many `placeSymbols` calls in quick succession:
+
+- `SymbolSpotlight.hide()` reparented every symbol it had ever tracked back to its `originalParent`, even when `promoteAboveMask: false` (no reparenting on `show()`) or after the shared symbol pool had recycled the instance into a different reel. The recycled symbol got yanked from its new owner, leaving a hole there and a stranger in the original reel.
+- `Reel._replaceSymbol` used the captured `oldSymbol.view.parent` as the destination for the replacement view. If the old symbol had been moved (by the spotlight or by pool recycling), the new symbol landed in a foreign container — symbols accumulated in the wrong reel across spins.
+
+Both paths now anchor to the reel's own container; the spotlight only reparents symbols whose view is still in `spotlightContainer` (i.e., never recycled away).

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -552,6 +552,12 @@ export class Reel implements Disposable {
   private _replaceSymbol(index: number, newSymbolId: string): void {
     const oldSymbol = this.symbols[index];
     const isOldStub = oldSymbol instanceof OccupiedStub;
+    // Always parent into THIS reel's own container — the old symbol's
+    // `view.parent` is unsafe as a destination because the shared symbol
+    // pool can recycle a view across reels (or the spotlight may have
+    // promoted it above the mask), leaving `oldSymbol.view.parent`
+    // pointing at a foreign container.
+    const parent = this.container;
 
     // OCCUPIED: install a stub. Stubs are not pooled through SymbolFactory.
     if (newSymbolId === OCCUPIED_SENTINEL) {
@@ -559,7 +565,6 @@ export class Reel implements Disposable {
         oldSymbol.view.alpha = 0;
         return;
       }
-      const parent = oldSymbol.view.parent;
       const y = oldSymbol.view.y;
       this._symbolFactory.release(oldSymbol);
       const stub = this._acquireOccupiedStub();
@@ -568,14 +573,13 @@ export class Reel implements Disposable {
       stub.view.alpha = 0;
       stub.view.visible = true;
       stub.view.scale.set(1, 1);
-      if (parent && stub.view.parent !== parent) parent.addChild(stub.view);
+      if (stub.view.parent !== parent) parent.addChild(stub.view);
       this.symbols[index] = stub;
       return;
     }
 
     // Replacing a stub with a real symbol: release stub back to internal cache.
     if (isOldStub) {
-      const parent = oldSymbol.view.parent;
       const y = oldSymbol.view.y;
       this._releaseOccupiedStub(oldSymbol);
       const newSymbol = this._symbolFactory.acquire(newSymbolId);
@@ -585,21 +589,23 @@ export class Reel implements Disposable {
       newSymbol.view.alpha = 1;
       newSymbol.view.scale.set(1, 1);
       newSymbol.view.zIndex = 0;
-      if (parent) parent.addChild(newSymbol.view);
+      parent.addChild(newSymbol.view);
       this.symbols[index] = newSymbol;
       this.events.emit('symbol:created', newSymbolId, index);
       return;
     }
 
-    // Even if same symbolId, always reset visual state (alpha, scale, zIndex)
+    // Same id fast-path. Reset visual state and re-anchor the view to this
+    // reel's container in case the pool had moved it elsewhere since the
+    // last activation.
     if (oldSymbol.symbolId === newSymbolId) {
       oldSymbol.view.alpha = 1;
       oldSymbol.view.scale.set(1, 1);
       oldSymbol.view.zIndex = 0;
+      if (oldSymbol.view.parent !== parent) parent.addChild(oldSymbol.view);
       return;
     }
 
-    const parent = oldSymbol.view.parent;
     const y = oldSymbol.view.y;
 
     this._symbolFactory.release(oldSymbol);
@@ -611,9 +617,7 @@ export class Reel implements Disposable {
     newSymbol.view.scale.set(1, 1);
     newSymbol.view.zIndex = 0;
 
-    if (parent) {
-      parent.addChild(newSymbol.view);
-    }
+    parent.addChild(newSymbol.view);
 
     this.symbols[index] = newSymbol;
     this.events.emit('symbol:created', newSymbolId, index);

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -478,6 +478,18 @@ export class Reel implements Disposable {
   }
 
   /**
+   * Compute the canonical zIndex for a single symbol view at a given
+   * array index. Centralizes the formula used by both `refreshZIndex`
+   * (full rescan) and the per-swap activate path (so newly placed
+   * symbols land with their correct zIndex without the caller needing
+   * to remember to call `refreshZIndex` afterwards).
+   */
+  private _computeSymbolZIndex(symbolId: string, index: number): number {
+    const base = this._symbolsData[symbolId]?.zIndex ?? 0;
+    return base * 100 + index;
+  }
+
+  /**
    * Recompute `zIndex` for every symbol in the reel.
    *
    * Formula: `symbolData.zIndex ?? 0` (scaled by 100 to leave room for row
@@ -485,8 +497,12 @@ export class Reel implements Disposable {
    * render in front of top-row symbols and any symbol with a higher
    * configured base zIndex (e.g. wild, bonus) renders above its neighbors.
    *
-   * Called automatically after wraps, snaps, and direct placement. Call it
-   * manually after mutating `symbolsData.zIndex` at runtime.
+   * Called automatically after wraps, snaps, and direct placement. Also
+   * called inline by `_replaceSymbol` for the single newly-placed symbol —
+   * so consumers who swap one symbol at a time (via the public APIs that
+   * funnel into `_replaceSymbol`) get correct layering for free, no
+   * manual `refreshZIndex` required. Call it manually after mutating
+   * `symbolsData.zIndex` at runtime.
    */
   refreshZIndex(): void {
     for (let i = 0; i < this.symbols.length; i++) {
@@ -495,8 +511,7 @@ export class Reel implements Disposable {
         symbol.view.zIndex = i;
         continue;
       }
-      const base = this._symbolsData[symbol.symbolId]?.zIndex ?? 0;
-      symbol.view.zIndex = base * 100 + i;
+      symbol.view.zIndex = this._computeSymbolZIndex(symbol.symbolId, i);
     }
   }
 
@@ -568,6 +583,7 @@ export class Reel implements Disposable {
       stub.view.alpha = 0;
       stub.view.visible = true;
       stub.view.scale.set(1, 1);
+      stub.view.zIndex = index;
       if (parent && stub.view.parent !== parent) parent.addChild(stub.view);
       this.symbols[index] = stub;
       return;
@@ -584,7 +600,7 @@ export class Reel implements Disposable {
       newSymbol.view.x = 0;
       newSymbol.view.alpha = 1;
       newSymbol.view.scale.set(1, 1);
-      newSymbol.view.zIndex = 0;
+      newSymbol.view.zIndex = this._computeSymbolZIndex(newSymbolId, index);
       if (parent) parent.addChild(newSymbol.view);
       this.symbols[index] = newSymbol;
       this.events.emit('symbol:created', newSymbolId, index);
@@ -595,7 +611,7 @@ export class Reel implements Disposable {
     if (oldSymbol.symbolId === newSymbolId) {
       oldSymbol.view.alpha = 1;
       oldSymbol.view.scale.set(1, 1);
-      oldSymbol.view.zIndex = 0;
+      oldSymbol.view.zIndex = this._computeSymbolZIndex(newSymbolId, index);
       return;
     }
 
@@ -609,7 +625,7 @@ export class Reel implements Disposable {
     newSymbol.view.x = 0;
     newSymbol.view.alpha = 1;
     newSymbol.view.scale.set(1, 1);
-    newSymbol.view.zIndex = 0;
+    newSymbol.view.zIndex = this._computeSymbolZIndex(newSymbolId, index);
 
     if (parent) {
       parent.addChild(newSymbol.view);

--- a/packages/pixi-reels/src/spotlight/SymbolSpotlight.ts
+++ b/packages/pixi-reels/src/spotlight/SymbolSpotlight.ts
@@ -109,11 +109,14 @@ export class SymbolSpotlight implements Disposable {
       if (seen.has(key)) continue;
       seen.add(key);
 
-      const originalParent = symbol.view.parent;
-      this._promoted.push({ symbol, originalParent, position: pos });
-
+      // Track for hide() only when we're actually moving the view —
+      // otherwise the entry's `originalParent` would become stale if the
+      // shared symbol pool recycles this instance into a different reel
+      // before the next hide(), and `hide()` would reparent it back to a
+      // reel that no longer owns it (leaving a hole on the new owner).
       if (promoteAboveMask) {
-        // Re-parent to spotlight container (above mask)
+        const originalParent = symbol.view.parent;
+        this._promoted.push({ symbol, originalParent, position: pos });
         const globalPos = symbol.view.getGlobalPosition();
         this._viewport.spotlightContainer.addChild(symbol.view);
         const localPos = this._viewport.spotlightContainer.toLocal(globalPos);
@@ -139,9 +142,13 @@ export class SymbolSpotlight implements Disposable {
       this._cycleAbort = null;
     }
 
-    // Return promoted symbols
+    // Return promoted symbols. Skip any whose view has been moved out of
+    // the spotlight container — that means the shared symbol pool has
+    // recycled them into another reel since show(), and reparenting back
+    // to `originalParent` would steal them from their new owner.
     for (const { symbol, originalParent } of this._promoted) {
-      if (originalParent && symbol.view.parent !== originalParent) {
+      if (symbol.view.parent !== this._viewport.spotlightContainer) continue;
+      if (originalParent) {
         const globalPos = symbol.view.getGlobalPosition();
         originalParent.addChild(symbol.view);
         const localPos = originalParent.toLocal(globalPos);

--- a/packages/pixi-reels/tests/integration/autoZIndex.test.ts
+++ b/packages/pixi-reels/tests/integration/autoZIndex.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests for the auto-zIndex contract on `_replaceSymbol`.
+ *
+ * Contract: when a symbol is activated into a row (via any code path that
+ * funnels into `_replaceSymbol` — wrap callback, `placeSymbols`, etc.), its
+ * view's zIndex is set to the canonical formula
+ *   `(symbolData.zIndex ?? 0) * 100 + arrayIndex`
+ * automatically. Consumers should not need to call `refreshZIndex()`
+ * explicitly after a single in-place swap.
+ *
+ * This guards against regressions where the activate path falls back to
+ * `view.zIndex = 0`, which was a long-standing footgun: a wild registered
+ * with `zIndex: 5` would render *under* its neighbours until the next
+ * motion-wrap or snap re-ran `refreshZIndex` over the whole reel.
+ */
+import { describe, it, expect } from 'vitest';
+import { createTestReelSet } from '../../src/testing/index.js';
+
+const SYMBOLS = ['a', 'wild', 'b'];
+
+describe('auto-zIndex on _replaceSymbol', () => {
+  it('a newly-placed symbol gets the canonical zIndex without an explicit refresh', async () => {
+    const h = createTestReelSet({
+      reels: 3,
+      visibleRows: 3,
+      symbolIds: SYMBOLS,
+      symbolData: {
+        wild: { zIndex: 5 },
+      },
+    });
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'wild', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+
+      const reel = h.reelSet.reels[1];
+      const bufferAbove = reel.bufferAbove;
+      const wildArrayIndex = bufferAbove + 1; // visible row 1
+      const wildView = reel.symbols[wildArrayIndex].view;
+
+      // Canonical formula: (symbolData.zIndex ?? 0) * 100 + arrayIndex
+      expect(wildView.zIndex).toBe(5 * 100 + wildArrayIndex);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('a symbol with no zIndex override uses the builder default (1) plus arrayIndex', async () => {
+    // Builder defaults `symbolData.zIndex` to 1 for every registered symbol
+    // when no override is provided; auto-zIndex on activate must respect
+    // that default, not silently land symbols on layer 0.
+    const h = createTestReelSet({
+      reels: 3,
+      visibleRows: 3,
+      symbolIds: SYMBOLS,
+    });
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+
+      const reel = h.reelSet.reels[0];
+      const bufferAbove = reel.bufferAbove;
+
+      for (let row = 0; row < 3; row++) {
+        const arrayIndex = bufferAbove + row;
+        const view = reel.symbols[arrayIndex].view;
+        expect(view.zIndex).toBe(1 * 100 + arrayIndex);
+      }
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('zIndex is reapplied even when the same symbol id replaces itself', async () => {
+    const h = createTestReelSet({
+      reels: 3,
+      visibleRows: 3,
+      symbolIds: SYMBOLS,
+      symbolData: {
+        wild: { zIndex: 7 },
+      },
+    });
+    try {
+      // First spin: wild lands.
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'wild', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      // Manually corrupt the zIndex so we can verify the swap re-applies it.
+      const reel = h.reelSet.reels[1];
+      const bufferAbove = reel.bufferAbove;
+      const wildArrayIndex = bufferAbove + 1;
+      reel.symbols[wildArrayIndex].view.zIndex = -999;
+
+      // Second spin: wild lands at the same row again (same symbol id swap).
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'wild', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+
+      const wildView = reel.symbols[wildArrayIndex].view;
+      expect(wildView.zIndex).toBe(7 * 100 + wildArrayIndex);
+    } finally {
+      h.destroy();
+    }
+  });
+});

--- a/packages/pixi-reels/tests/integration/spotlight.test.ts
+++ b/packages/pixi-reels/tests/integration/spotlight.test.ts
@@ -1,0 +1,150 @@
+/**
+ * SymbolSpotlight integration tests — focused on the parent-restoration
+ * invariant that broke when symbols were pool-recycled across reels mid-
+ * spotlight.
+ */
+import { describe, it, expect } from 'vitest';
+import { createTestReelSet } from '../../src/testing/index.js';
+
+const SYMBOLS = ['a', 'b', 'c', 'wild'];
+
+function makeHarness() {
+  return createTestReelSet({
+    reels: 5,
+    visibleRows: 3,
+    symbolIds: SYMBOLS,
+  });
+}
+
+describe('SymbolSpotlight — symbol parent invariant after recycling', () => {
+  it('does not yank recycled symbols back to a stale parent (promoteAboveMask: false)', async () => {
+    const h = makeHarness();
+    try {
+      // Land a grid where reel 0 has a winner.
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['wild', 'wild', 'wild'],
+        ['a', 'b', 'c'],
+      ]);
+
+      // Fire a spotlight on reel 0 row 1. The ReelSet uses a shared symbol
+      // pool — the 'a' instance at reel 0 may end up reused on a different
+      // reel after the next placeSymbols call.
+      await h.reelSet.spotlight.show(
+        [{ reelIndex: 0, rowIndex: 1 }],
+        { promoteAboveMask: false },
+      );
+
+      // Land a different grid. Each reel's placeSymbols releases its old
+      // symbols to the pool and acquires fresh ones — guaranteeing the 'a'
+      // instance from reel 0 row 1 gets reassigned somewhere else.
+      await h.spinAndLand([
+        ['c', 'c', 'c'],
+        ['c', 'c', 'c'],
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['wild', 'wild', 'wild'],
+      ]);
+
+      // Calling show() (or hide() directly) re-runs spotlight cleanup.
+      // Before the fix, this reparented the recycled 'a' instance back to
+      // reel 0's container, leaving a hole on whichever reel now owns it
+      // and a stranger inside reel 0's container.
+      await h.reelSet.spotlight.show(
+        [{ reelIndex: 4, rowIndex: 0 }],
+        { promoteAboveMask: false },
+      );
+      h.reelSet.spotlight.hide();
+
+      // Invariant: every symbol's view.parent matches the container of the
+      // reel that owns it in `reels[i].symbols`.
+      for (let r = 0; r < 5; r++) {
+        const reel = h.reelSet.reels[r];
+        for (let i = 0; i < reel.symbols.length; i++) {
+          const sym = reel.symbols[i];
+          expect(sym.view.parent, `reel ${r} symbol[${i}] (${sym.symbolId}) parent`)
+            .toBe(reel.container);
+        }
+      }
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('does not yank recycled symbols back to a stale parent (promoteAboveMask: true)', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['wild', 'wild', 'wild'],
+        ['a', 'b', 'c'],
+      ]);
+
+      // Synchronously call show + immediately recycle by landing a new grid
+      // — the show's promoteAboveMask: true path stashes the promoted view
+      // in spotlightContainer, but if a follow-up placeSymbols (or the
+      // pool) yanks it back into a reel before hide() runs, hide() must
+      // not steal it from the new owner.
+      h.reelSet.spotlight.show(
+        [{ reelIndex: 0, rowIndex: 1 }],
+        { promoteAboveMask: true, playWinAnimation: false },
+      );
+      // Land a different grid that will exercise placeSymbols on every reel.
+      await h.spinAndLand([
+        ['c', 'c', 'c'],
+        ['c', 'c', 'c'],
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['wild', 'wild', 'wild'],
+      ]);
+      h.reelSet.spotlight.hide();
+
+      for (let r = 0; r < 5; r++) {
+        const reel = h.reelSet.reels[r];
+        for (let i = 0; i < reel.symbols.length; i++) {
+          const sym = reel.symbols[i];
+          expect(sym.view.parent, `reel ${r} symbol[${i}] (${sym.symbolId}) parent`)
+            .toBe(reel.container);
+        }
+      }
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('still restores promoted symbols when promoteAboveMask: true (regression)', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['b', 'b', 'b'],
+        ['c', 'c', 'c'],
+        ['wild', 'wild', 'wild'],
+        ['a', 'b', 'c'],
+      ]);
+
+      const reel0 = h.reelSet.reels[0];
+      const beforeSym = reel0.getSymbolAt(1);
+      const beforeParent = beforeSym.view.parent;
+
+      await h.reelSet.spotlight.show(
+        [{ reelIndex: 0, rowIndex: 1 }],
+        { promoteAboveMask: true },
+      );
+
+      // While promoted, the symbol is in the spotlight container.
+      expect(beforeSym.view.parent).not.toBe(beforeParent);
+
+      h.reelSet.spotlight.hide();
+
+      // Hide restores it to the original reel container.
+      expect(beforeSym.view.parent).toBe(beforeParent);
+    } finally {
+      h.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `Reel._replaceSymbol` previously set `view.zIndex = 0` and relied on a follow-up `refreshZIndex()` call to apply the real formula `(symbolData.zIndex ?? 0) * 100 + arrayIndex`. All current callers happen to call `refreshZIndex` after, but the contract was fragile.
- New private helper `_computeSymbolZIndex(symbolId, index)` centralizes the formula. `refreshZIndex` (full rescan) and `_replaceSymbol` (single-symbol activate) both use it. OCCUPIED stubs receive `arrayIndex` directly, matching what `refreshZIndex` would assign.
- No public API change. Unblocks future single-symbol swap APIs (e.g. a public `setSymbolAt`) without forcing callers to remember the manual refresh.

## Files touched
- `src/core/Reel.ts` — extract `_computeSymbolZIndex` helper, use it inline in `_replaceSymbol` (all three branches: OCCUPIED stub install, stub→real swap, normal swap, and the same-id reset).
- `tests/integration/autoZIndex.test.ts` — 3 new tests covering: zIndex override symbol, default-zIndex symbol, and same-id swap re-applying zIndex.
- `.changeset/feat-auto-zindex-on-replace.md` — patch bump.

## Test plan
- [x] `pnpm --filter pixi-reels typecheck`
- [x] `pnpm --filter pixi-reels test` — 217 tests pass (3 new in `autoZIndex.test.ts`)
- [x] `pnpm check:lint`

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)