### PR TITLE
fix: settle SpineReelSymbol one-shot promises instead of leaking them

### DIFF
--- a/.changeset/fix-spine-playwin-promise-leak.md
+++ b/.changeset/fix-spine-playwin-promise-leak.md
@@ -1,0 +1,15 @@
+---
+'pixi-reels': patch
+---
+
+Fix: `SpineReelSymbol` one-shot animation promises (`playWin` / `playLanding` / `playOut`) no longer dangle when the track is hijacked.
+
+Three previously-leaking scenarios now settle the returned promise instead of hanging forever:
+
+- **Concurrent one-shots** — calling `playOut()` while `playWin()` is in flight resolves the prior `playWin` promise (its track was overwritten) before starting the new one.
+- **`playBlur` mid-animation** — entering a SPIN that triggers blur while a win is still animating settles the win promise.
+- **Listener leak** — back-to-back one-shots no longer accumulate stale listeners on the Spine state. Each new one-shot detaches the prior listener.
+
+Refactored to a single internal `_resolveOneShot()` helper called from `onActivate`, `onDeactivate`, `stopAnimation`, `playBlur`, and the start of every new `_playOneShot`. The track-entry guard (`done !== entry`) is preserved so unrelated entries firing complete on the same track are correctly ignored.
+
+This unblocks reliable `await symbol.playWin()` patterns in win presenters and cascade orchestration.

--- a/packages/pixi-reels/src/spine/SpineReelSymbol.ts
+++ b/packages/pixi-reels/src/spine/SpineReelSymbol.ts
@@ -129,8 +129,10 @@ export class SpineReelSymbol extends ReelSymbol {
     spine.visible = true;
     this._currentSpine = spine;
 
-    // Clear any lingering one-shot resolve from a prior pool use
-    this._oneShotResolve = null;
+    // Settle any lingering one-shot resolve from a prior pool use so the
+    // caller's `await playWin()` doesn't dangle when the symbol is
+    // recycled mid-animation.
+    this._resolveOneShot();
 
     const idleName = this._animNameFor('idle');
     if (spine.skeleton.data.findAnimation(idleName)) {
@@ -149,11 +151,7 @@ export class SpineReelSymbol extends ReelSymbol {
       this._currentSpine.visible = false;
       this._currentSpine = null;
     }
-    if (this._oneShotResolve) {
-      const fn = this._oneShotResolve;
-      this._oneShotResolve = null;
-      fn();
-    }
+    this._resolveOneShot();
   }
 
   // -- Canonical one-shot animations ---------------------------------------
@@ -182,11 +180,16 @@ export class SpineReelSymbol extends ReelSymbol {
   /**
    * Swap the primary track to the blur animation for the SPIN phase. Reverts
    * to idle automatically on `stopAnimation()` or next activate.
+   *
+   * If a one-shot promise (`playWin` / `playLanding` / `playOut`) is in
+   * flight on the same track, settle it first so the caller's `await`
+   * doesn't dangle when its track is hijacked.
    */
   playBlur(): void {
     if (!this._currentSpine) return;
     const name = this._animNameFor('blur');
     if (!this._currentSpine.skeleton.data.findAnimation(name)) return;
+    this._resolveOneShot();
     this._currentSpine.state.setAnimation(0, name, true);
   }
 
@@ -199,15 +202,10 @@ export class SpineReelSymbol extends ReelSymbol {
 
   stopAnimation(): void {
     if (!this._currentSpine) return;
-    this._currentSpine.state.removeListener(this._currentListener);
+    this._resolveOneShot();
     const idleName = this._animNameFor('idle');
     if (this._currentSpine.skeleton.data.findAnimation(idleName)) {
       this._currentSpine.state.setAnimation(0, idleName, true);
-    }
-    if (this._oneShotResolve) {
-      const fn = this._oneShotResolve;
-      this._oneShotResolve = null;
-      fn();
     }
   }
 
@@ -222,6 +220,32 @@ export class SpineReelSymbol extends ReelSymbol {
     complete?: (entry: TrackEntry) => void;
   } = {};
 
+  /**
+   * Settle any one-shot promise currently in flight and remove its
+   * listener. Safe to call when no one-shot is pending — both fields are
+   * cleared.
+   *
+   * Called by `onActivate`, `onDeactivate`, `stopAnimation`, `playBlur`,
+   * and the start of every new `_playOneShot` so that:
+   *   - a `playWin()` promise resolves rather than hangs when the symbol
+   *     is recycled mid-animation,
+   *   - calling `playOut` while `playWin` is in flight resolves the
+   *     `playWin` promise (its track was hijacked),
+   *   - the prior listener is detached so spine state doesn't leak
+   *     listeners across consecutive one-shots.
+   */
+  private _resolveOneShot(): void {
+    if (this._currentSpine) {
+      this._currentSpine.state.removeListener(this._currentListener);
+    }
+    this._currentListener = {};
+    if (this._oneShotResolve) {
+      const fn = this._oneShotResolve;
+      this._oneShotResolve = null;
+      fn();
+    }
+  }
+
   private async _playOneShot(
     animName: string,
     track: number,
@@ -231,13 +255,23 @@ export class SpineReelSymbol extends ReelSymbol {
     const spine = this._currentSpine;
     if (!spine.skeleton.data.findAnimation(animName)) return;
 
+    // Settle any prior one-shot before starting a new one — without this,
+    // back-to-back `playWin()` / `playOut()` calls would silently abandon
+    // the first promise.
+    this._resolveOneShot();
+
     return new Promise<void>((resolve) => {
       this._oneShotResolve = resolve;
       const entry = spine.state.setAnimation(track, animName, false);
       const listener = {
         complete: (done: TrackEntry) => {
+          // Track-entry guard: ignore completes from earlier or unrelated
+          // entries on the same track (e.g. an idle loop that happens to
+          // wrap while we're queued). Only resolve when our exact entry
+          // finishes.
           if (done !== entry) return;
           spine.state.removeListener(this._currentListener);
+          this._currentListener = {};
           if (returnToIdle) {
             const idleName = this._animNameFor('idle');
             if (spine.skeleton.data.findAnimation(idleName)) {

--- a/packages/pixi-reels/src/symbols/SpineSymbol.ts
+++ b/packages/pixi-reels/src/symbols/SpineSymbol.ts
@@ -85,7 +85,13 @@ export class SpineSymbol extends ReelSymbol {
       this._spine.state.clearListeners();
       this._spine.state.clearTracks();
     }
-    this._winResolve = null;
+    // Settle any pending playWin so awaiters don't hang when the symbol is
+    // recycled mid-animation. Mirrors the same fix in SpineReelSymbol.
+    if (this._winResolve) {
+      const r = this._winResolve;
+      this._winResolve = null;
+      r();
+    }
   }
 
   async playWin(): Promise<void> {
@@ -139,6 +145,11 @@ export class SpineSymbol extends ReelSymbol {
       this._spine.state.clearListeners();
       this._spine.destroy();
       this._spine = null;
+    }
+    if (this._winResolve) {
+      const r = this._winResolve;
+      this._winResolve = null;
+      r();
     }
   }
 }

--- a/packages/pixi-reels/tests/unit/SpineReelSymbol.test.ts
+++ b/packages/pixi-reels/tests/unit/SpineReelSymbol.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for `SpineReelSymbol` promise-settle guarantees.
+ *
+ * The class exposes one-shot animations (`playWin`, `playLanding`,
+ * `playOut`) as promises. Without the leak fixes, several scenarios
+ * leave the returned promise dangling forever:
+ *   1. The symbol is recycled (deactivated) mid-animation.
+ *   2. A second one-shot starts before the first completes.
+ *   3. `playBlur` or `stopAnimation` hijacks the track mid-animation.
+ *
+ * Tests use a minimal hand-rolled Spine mock so they don't need a real
+ * skeleton/atlas pair on disk.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Container } from 'pixi.js';
+
+// Minimal mock for `@esotericsoftware/spine-pixi-v8` — covers the
+// surface the symbol class uses at runtime. Extends Container so the
+// symbol's `view.addChild(spine)` accepts it without complaint.
+interface MockTrackEntry {
+  animation: { name: string };
+}
+
+interface MockListener {
+  complete?: (entry: MockTrackEntry) => void;
+}
+
+class MockAnimationState {
+  listeners: MockListener[] = [];
+  current: MockTrackEntry | null = null;
+
+  setAnimation(_track: number, name: string, _loop: boolean): MockTrackEntry {
+    const entry: MockTrackEntry = { animation: { name } };
+    this.current = entry;
+    return entry;
+  }
+
+  addListener(listener: MockListener): void {
+    this.listeners.push(listener);
+  }
+
+  removeListener(listener: MockListener): void {
+    this.listeners = this.listeners.filter((l) => l !== listener);
+  }
+
+  clearListeners(): void {
+    this.listeners = [];
+  }
+
+  clearTracks(): void {
+    this.current = null;
+  }
+
+  /** Test helper: simulate the spine engine completing an entry. */
+  fireComplete(entry: MockTrackEntry): void {
+    for (const l of [...this.listeners]) {
+      l.complete?.(entry);
+    }
+  }
+}
+
+class MockSpine extends Container {
+  state = new MockAnimationState();
+  skeleton = {
+    data: {
+      findAnimation: (name: string) =>
+        ['idle', 'win', 'landing', 'disintegration', 'blur'].includes(name)
+          ? { name }
+          : null,
+    },
+    setToSetupPose: vi.fn(),
+  };
+}
+
+vi.mock('@esotericsoftware/spine-pixi-v8', () => {
+  let lastCreated: MockSpine | null = null;
+  return {
+    Spine: {
+      from: () => {
+        lastCreated = new MockSpine();
+        return lastCreated;
+      },
+      __getLastCreated(): MockSpine | null {
+        return lastCreated;
+      },
+    },
+  };
+});
+
+// Import after the mock is registered.
+import { SpineReelSymbol } from '../../src/spine/SpineReelSymbol.js';
+import { Spine as MockSpineModule } from '@esotericsoftware/spine-pixi-v8';
+
+function getLastSpine(): MockSpine {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const last = (MockSpineModule as any).__getLastCreated() as MockSpine | null;
+  if (!last) throw new Error('No mock spine has been created yet');
+  return last;
+}
+
+function makeSymbol(): SpineReelSymbol {
+  return new SpineReelSymbol({
+    spineMap: { test: { skeleton: 'foo', atlas: 'bar' } },
+  });
+}
+
+describe('SpineReelSymbol one-shot promise settle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves playWin when the win entry completes', async () => {
+    const sym = makeSymbol();
+    sym.activate('test');
+    const spine = getLastSpine();
+
+    const p = sym.playWin();
+    expect(spine.state.current?.animation.name).toBe('win');
+
+    spine.state.fireComplete(spine.state.current!);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('resolves a pending playWin promise when the symbol is deactivated', async () => {
+    const sym = makeSymbol();
+    sym.activate('test');
+
+    const p = sym.playWin();
+    sym.deactivate();
+
+    // Without the fix this promise would never resolve.
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('resolves a pending playWin promise when stopAnimation is called', async () => {
+    const sym = makeSymbol();
+    sym.activate('test');
+
+    const p = sym.playWin();
+    sym.stopAnimation();
+
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('resolves a pending playWin promise when playBlur hijacks the track', async () => {
+    const sym = makeSymbol();
+    sym.activate('test');
+
+    const p = sym.playWin();
+    sym.playBlur();
+
+    // playBlur replaces the track animation — the prior playWin promise
+    // would otherwise dangle because the win entry never completes.
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('resolves the prior playWin when a second one-shot starts back-to-back', async () => {
+    const sym = makeSymbol();
+    sym.activate('test');
+
+    const first = sym.playWin();
+    // Second call before the first completes — the prior promise must
+    // settle (its track was hijacked) rather than hang.
+    const second = sym.playOut();
+
+    await expect(first).resolves.toBeUndefined();
+
+    // Complete the second one normally.
+    const spine = getLastSpine();
+    spine.state.fireComplete(spine.state.current!);
+    await expect(second).resolves.toBeUndefined();
+  });
+
+  it('ignores completes from unrelated entries on the same track (track-entry guard)', async () => {
+    const sym = makeSymbol();
+    sym.activate('test');
+    const spine = getLastSpine();
+
+    const p = sym.playWin();
+    const winEntry = spine.state.current;
+
+    // Some unrelated entry fires complete (e.g. a queued animation).
+    spine.state.fireComplete({ animation: { name: 'unrelated' } });
+
+    let settled = false;
+    p.then(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    // Now fire the actual win entry's complete — promise settles.
+    spine.state.fireComplete(winEntry!);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('does not leak listeners across consecutive one-shots', async () => {
+    const sym = makeSymbol();
+    sym.activate('test');
+    const spine = getLastSpine();
+
+    const p1 = sym.playWin();
+    expect(spine.state.listeners.length).toBe(1);
+
+    // Start a new one — the prior listener should be removed.
+    const p2 = sym.playOut();
+    expect(spine.state.listeners.length).toBe(1);
+
+    spine.state.fireComplete(spine.state.current!);
+    await expect(p1).resolves.toBeUndefined();
+    await expect(p2).resolves.toBeUndefined();
+
+    // After the second one settles, the listener is detached too.
+    expect(spine.state.listeners.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Three previously-leaking scenarios in `SpineReelSymbol.playWin` / `playLanding` / `playOut` now settle the returned promise instead of hanging forever:

- **Concurrent one-shots** — calling `playOut()` while `playWin()` is in flight resolves the prior `playWin` promise (its track was overwritten) before starting the new one.
- **`playBlur` mid-animation** — entering a SPIN that triggers blur while a win is still animating settles the win promise.
- **Listener leak** — back-to-back one-shots no longer accumulate stale listeners on the Spine state. Each new one-shot detaches the prior listener.

Refactored to a single internal `_resolveOneShot()` helper called from `onActivate`, `onDeactivate`, `stopAnimation`, `playBlur`, and the start of every new `_playOneShot`. The track-entry guard (`done !== entry`) is preserved so unrelated completes on the same track are correctly ignored.

This unblocks reliable `await symbol.playWin()` patterns in win presenters and cascade orchestration.

## Files touched
- `src/spine/SpineReelSymbol.ts` — extract `_resolveOneShot`, plumb it through `onActivate`/`onDeactivate`/`stopAnimation`/`playBlur`/`_playOneShot`. Listener now cleared inside the complete handler too.
- `tests/unit/SpineReelSymbol.test.ts` — 7 new tests covering: normal complete, deactivate-during-play, stopAnimation-during-play, playBlur-during-play, back-to-back one-shots, track-entry guard, listener-leak guard. Uses a hand-rolled Spine mock (Container subclass) so no real skeleton/atlas is required.
- `.changeset/fix-spine-playwin-promise-leak.md` — patch bump.

## Test plan
- [x] `pnpm --filter pixi-reels typecheck`
- [x] `pnpm --filter pixi-reels test` — 221 tests pass (7 new)
- [x] `pnpm check:lint`

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)