### PR TITLE
feat: add Reel.setSymbolAt(visibleRow, symbolId) for in-place swap

### DIFF
--- a/.changeset/feat-reel-set-symbol-at.md
+++ b/.changeset/feat-reel-set-symbol-at.md
@@ -1,0 +1,20 @@
+---
+'pixi-reels': minor
+---
+
+Add `Reel.setSymbolAt(visibleRow, symbolId)` — public API for swapping a single visible cell's symbol identity in place.
+
+Useful for live presentation effects that don't fit the `setResult` / `placeSymbols` flow:
+
+- converting a symbol to a wild after a cascade pop,
+- dropping in a "respin" symbol on a held reel,
+- swapping to a sticky variant after a win is paid out.
+
+The method funnels into the same internal activate path as the rest of the engine, so the swapped-in symbol gets its proper parent (masked vs unmasked container), `zIndex`, and visual reset for free — no follow-up `refreshZIndex` required.
+
+Validation:
+- throws if `visibleRow` is not an integer in `[0, visibleRows)`,
+- throws if `symbolId` is not registered,
+- throws if the target row is a non-anchor cell of a big-symbol block (you must swap the anchor row directly or rebuild the frame via `placeSymbols`).
+
+Emits `symbol:created` on the per-reel event bus, matching motion-driven swaps.

--- a/.changeset/feat-reel-set-symbol-at.md
+++ b/.changeset/feat-reel-set-symbol-at.md
@@ -2,19 +2,22 @@
 'pixi-reels': minor
 ---
 
-Add `Reel.setSymbolAt(visibleRow, symbolId)` — public API for swapping a single visible cell's symbol identity in place.
+Add `Reel.setSymbolAt(visibleRow, symbolId)` and `ReelSet.setSymbolAt(col, row, symbolId)` — public API for swapping a single visible cell's symbol identity in place at rest.
 
 Useful for live presentation effects that don't fit the `setResult` / `placeSymbols` flow:
 
 - converting a symbol to a wild after a cascade pop,
-- dropping in a "respin" symbol on a held reel,
 - swapping to a sticky variant after a win is paid out.
 
 The method funnels into the same internal activate path as the rest of the engine, so the swapped-in symbol gets its proper parent (masked vs unmasked container), `zIndex`, and visual reset for free — no follow-up `refreshZIndex` required.
 
-Validation:
-- throws if `visibleRow` is not an integer in `[0, visibleRows)`,
-- throws if `symbolId` is not registered,
-- throws if the target row is a non-anchor cell of a big-symbol block (you must swap the anchor row directly or rebuild the frame via `placeSymbols`).
+Validation (all guards fail loud):
+- throws if the reel is in motion (`speed !== 0` or `isStopping`) — a mid-spin swap would be overwritten by the next wrap/stop frame anyway.
+- throws if `visibleRow` is not an integer in `[0, visibleRows)`.
+- throws if `symbolId` is not registered.
+- throws if the target row is a non-anchor cell of a big-symbol block.
+- throws if the target row currently holds the anchor of a big-symbol block — big blocks span multiple cells (and possibly reels) and require `placeSymbols` plus the cross-reel OCCUPIED coordinator.
+- throws if `symbolId` itself is a big symbol — same reason.
+- `ReelSet.setSymbolAt` additionally throws if the cell currently has an active pin; call `unpin(col, row)` first to overwrite.
 
 Emits `symbol:created` on the per-reel event bus, matching motion-driven swaps.

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -391,6 +391,46 @@ export class Reel implements Disposable {
     this.refreshZIndex();
   }
 
+  /**
+   * Swap the symbol at a single visible row in-place, without restarting
+   * the spin or rebuilding the rest of the strip.
+   *
+   * Useful for live presentation effects — converting a wild after a
+   * cascade pop, dropping in a "respin" symbol on a held reel, swapping
+   * to a sticky variant after a win — without going through the full
+   * `placeSymbols` / `setResult` paths.
+   *
+   * The symbol's `zIndex`, parent (masked vs unmasked), and visual state
+   * are reset by `_replaceSymbol` so callers don't need to follow up
+   * with `refreshZIndex`. The motion layer is **not** snapped — call
+   * `snapToGrid()` separately if you need to re-grid.
+   *
+   * Throws if `visibleRow` is out of `[0, visibleRows)` or if `symbolId`
+   * is not registered. **Big-symbol anchors are not supported** — pass
+   * a normal cell row, not a non-anchor cell of a block.
+   */
+  setSymbolAt(visibleRow: number, symbolId: string): void {
+    if (!Number.isInteger(visibleRow) || visibleRow < 0 || visibleRow >= this._visibleRows) {
+      throw new Error(
+        `setSymbolAt: visibleRow ${visibleRow} is out of range [0, ${this._visibleRows}).`,
+      );
+    }
+    if (!Object.prototype.hasOwnProperty.call(this._symbolsData, symbolId)) {
+      throw new Error(
+        `setSymbolAt: symbolId '${symbolId}' is not registered. Register it via builder.symbols(...).`,
+      );
+    }
+    const occ = this._occupancy[visibleRow];
+    if (occ) {
+      throw new Error(
+        `setSymbolAt: visible row ${visibleRow} is a non-anchor cell of a big symbol (anchor at row ${occ.anchorRow}). ` +
+        `Swap the anchor row directly, or use placeSymbols to rebuild the frame.`,
+      );
+    }
+    const arrayIndex = this._bufferAbove + visibleRow;
+    this._replaceSymbol(arrayIndex, symbolId);
+  }
+
   /** Place symbols immediately at target positions (for skip/turbo). */
   placeSymbols(symbolIds: string[]): void {
     const totalSlots = this.symbols.length;

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -395,21 +395,38 @@ export class Reel implements Disposable {
    * Swap the symbol at a single visible row in-place, without restarting
    * the spin or rebuilding the rest of the strip.
    *
-   * Useful for live presentation effects — converting a wild after a
-   * cascade pop, dropping in a "respin" symbol on a held reel, swapping
-   * to a sticky variant after a win — without going through the full
-   * `placeSymbols` / `setResult` paths.
+   * Useful for live presentation effects at rest — converting a wild
+   * after a cascade pop, swapping to a sticky variant after a win —
+   * without going through the full `placeSymbols` / `setResult` paths.
    *
    * The symbol's `zIndex`, parent (masked vs unmasked), and visual state
    * are reset by `_replaceSymbol` so callers don't need to follow up
    * with `refreshZIndex`. The motion layer is **not** snapped — call
    * `snapToGrid()` separately if you need to re-grid.
    *
-   * Throws if `visibleRow` is out of `[0, visibleRows)` or if `symbolId`
-   * is not registered. **Big-symbol anchors are not supported** — pass
-   * a normal cell row, not a non-anchor cell of a block.
+   * Throws if:
+   *   - the reel is currently moving (`speed !== 0` or `isStopping`).
+   *     A mid-spin swap would be overwritten by the next wrap/stop frame
+   *     anyway; the fail-loud throw spares the caller the silent loss.
+   *   - `visibleRow` is out of `[0, visibleRows)`.
+   *   - `symbolId` is not registered.
+   *   - the row is a non-anchor cell of an existing big-symbol block.
+   *   - the row currently holds the anchor of a big-symbol block — big
+   *     blocks span multiple cells (and possibly reels) and require
+   *     `placeSymbols` + the cross-reel OCCUPIED coordinator.
+   *   - `symbolId` itself is a big symbol — same reason.
+   *
+   * Pin overlap is **not** detected at this layer (Reel doesn't see the
+   * pin map). Use `ReelSet.setSymbolAt(col, row, id)` for the safe
+   * caller-facing surface that also throws on pinned cells.
    */
   setSymbolAt(visibleRow: number, symbolId: string): void {
+    if (this.speed !== 0 || this._isStopping) {
+      throw new Error(
+        `setSymbolAt: cannot swap mid-spin (speed=${this.speed}, isStopping=${this._isStopping}). ` +
+        `Wait for the spin to land before calling, or use the result grid via setResult().`,
+      );
+    }
     if (!Number.isInteger(visibleRow) || visibleRow < 0 || visibleRow >= this._visibleRows) {
       throw new Error(
         `setSymbolAt: visibleRow ${visibleRow} is out of range [0, ${this._visibleRows}).`,
@@ -424,10 +441,26 @@ export class Reel implements Disposable {
     if (occ) {
       throw new Error(
         `setSymbolAt: visible row ${visibleRow} is a non-anchor cell of a big symbol (anchor at row ${occ.anchorRow}). ` +
-        `Swap the anchor row directly, or use placeSymbols to rebuild the frame.`,
+        `Use placeSymbols to rebuild the frame.`,
       );
     }
     const arrayIndex = this._bufferAbove + visibleRow;
+    const oldSym = this.symbols[arrayIndex];
+    const oldMeta = this._symbolsData[oldSym.symbolId];
+    if (oldMeta?.size && (oldMeta.size.w > 1 || oldMeta.size.h > 1)) {
+      throw new Error(
+        `setSymbolAt: row ${visibleRow} currently holds the anchor of big symbol ` +
+        `'${oldSym.symbolId}' (${oldMeta.size.w}x${oldMeta.size.h}). Big blocks span multiple ` +
+        `cells (and possibly reels); use placeSymbols + the OCCUPIED coordinator instead.`,
+      );
+    }
+    const newMeta = this._symbolsData[symbolId];
+    if (newMeta?.size && (newMeta.size.w > 1 || newMeta.size.h > 1)) {
+      throw new Error(
+        `setSymbolAt: '${symbolId}' is a big symbol (${newMeta.size.w}x${newMeta.size.h}). ` +
+        `Use placeSymbols + the OCCUPIED coordinator instead.`,
+      );
+    }
     this._replaceSymbol(arrayIndex, symbolId);
   }
 

--- a/packages/pixi-reels/src/core/ReelSet.ts
+++ b/packages/pixi-reels/src/core/ReelSet.ts
@@ -282,6 +282,35 @@ export class ReelSet extends Container implements Disposable {
   }
 
   /**
+   * Swap the symbol at a single grid cell in-place, at rest.
+   *
+   * Caller-facing wrapper over `Reel.setSymbolAt` that ALSO refuses
+   * pinned cells (since `Reel` itself can't see the pin map). Use this
+   * for live presentation effects — sticky-after-win, mid-feature
+   * rewrites — without going through `setResult()`.
+   *
+   * Throws (in addition to the per-reel guards documented on
+   * `Reel.setSymbolAt`) if `(col, row)` currently has an active pin.
+   * Use `unpin(col, row)` first if you intentionally want to overwrite it.
+   *
+   * @example
+   * await reelSet.spin(); // landed
+   * reelSet.setSymbolAt(2, 1, 'wild'); // swap centre cell to wild
+   */
+  setSymbolAt(col: number, row: number, symbolId: string): void {
+    if (col < 0 || col >= this._reels.length) {
+      throw new RangeError(`setSymbolAt: col ${col} out of range [0, ${this._reels.length})`);
+    }
+    if (this._pins.has(pinKey(col, row))) {
+      throw new Error(
+        `setSymbolAt: cell (${col}, ${row}) has an active pin. Call unpin(col, row) ` +
+        `first if you intend to overwrite it.`,
+      );
+    }
+    this._reels[col].setSymbolAt(row, symbolId);
+  }
+
+  /**
    * Set the drop order for cascade drop-in mechanics.
    *
    * A convenience wrapper over setStopDelays() for common patterns.

--- a/packages/pixi-reels/tests/integration/setSymbolAt.test.ts
+++ b/packages/pixi-reels/tests/integration/setSymbolAt.test.ts
@@ -115,4 +115,83 @@ describe('Reel.setSymbolAt', () => {
       h.destroy();
     }
   });
+
+  it('throws when called while reel is moving', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      const reel = h.reelSet.reels[0];
+      // The reel exposes `speed` and `isStopping` as the in-motion
+      // markers; setSymbolAt's guard checks both. Toggle each in turn
+      // and confirm the guard fires, then restore.
+      reel.speed = 5;
+      expect(() => reel.setSymbolAt(0, 'wild')).toThrow(/cannot swap mid-spin/);
+      reel.speed = 0;
+
+      reel.isStopping = true;
+      expect(() => reel.setSymbolAt(0, 'wild')).toThrow(/cannot swap mid-spin/);
+      reel.isStopping = false;
+
+      // After clearing both, the swap goes through.
+      reel.setSymbolAt(0, 'wild');
+      expect(reel.getVisibleSymbols()[0]).toBe('wild');
+    } finally {
+      h.destroy();
+    }
+  });
+});
+
+describe('ReelSet.setSymbolAt', () => {
+  it('delegates to the reel and swaps the cell', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      h.reelSet.setSymbolAt(1, 1, 'wild');
+      expect(h.reelSet.getVisibleGrid()[1][1]).toBe('wild');
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('throws on out-of-range column', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      expect(() => h.reelSet.setSymbolAt(-1, 0, 'a')).toThrow(/out of range/);
+      expect(() => h.reelSet.setSymbolAt(99, 0, 'a')).toThrow(/out of range/);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('refuses to overwrite a pinned cell', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      h.reelSet.pin(1, 1, 'wild');
+      expect(() => h.reelSet.setSymbolAt(1, 1, 'b')).toThrow(/has an active pin/);
+      // After unpin, the same call should succeed.
+      h.reelSet.unpin(1, 1);
+      h.reelSet.setSymbolAt(1, 1, 'b');
+      expect(h.reelSet.getVisibleGrid()[1][1]).toBe('b');
+    } finally {
+      h.destroy();
+    }
+  });
 });

--- a/packages/pixi-reels/tests/integration/setSymbolAt.test.ts
+++ b/packages/pixi-reels/tests/integration/setSymbolAt.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Integration tests for `Reel.setSymbolAt(visibleRow, id)` — the public
+ * single-cell swap API.
+ *
+ * Contract: the row's symbol identity changes immediately, the new
+ * symbol's view is correctly parented and zIndex'd, the rest of the
+ * reel is untouched, and a `symbol:created` event fires.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createTestReelSet } from '../../src/testing/index.js';
+
+const SYMBOLS = ['a', 'b', 'wild'];
+
+function makeHarness() {
+  return createTestReelSet({
+    reels: 3,
+    visibleRows: 3,
+    symbolIds: SYMBOLS,
+    symbolData: {
+      wild: { zIndex: 5 },
+    },
+  });
+}
+
+describe('Reel.setSymbolAt', () => {
+  it('swaps a visible row in-place', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+
+      h.reelSet.reels[1].setSymbolAt(1, 'wild');
+
+      expect(h.reelSet.reels[1].getVisibleSymbols()[1]).toBe('wild');
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('emits symbol:created on the per-reel event bus', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      const reel = h.reelSet.reels[2];
+      const fn = vi.fn();
+      reel.events.on('symbol:created', fn);
+
+      reel.setSymbolAt(0, 'wild');
+
+      expect(fn).toHaveBeenCalledWith('wild', reel.bufferAbove + 0);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('leaves other rows untouched', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      const reel = h.reelSet.reels[0];
+      const before = reel.getVisibleSymbols();
+
+      reel.setSymbolAt(1, 'b');
+
+      const after = reel.getVisibleSymbols();
+      expect(after[0]).toBe(before[0]);
+      expect(after[1]).toBe('b');
+      expect(after[2]).toBe(before[2]);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('throws on out-of-range row', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      const reel = h.reelSet.reels[0];
+
+      expect(() => reel.setSymbolAt(-1, 'a')).toThrow(/out of range/);
+      expect(() => reel.setSymbolAt(99, 'a')).toThrow(/out of range/);
+      expect(() => reel.setSymbolAt(1.5, 'a')).toThrow(/out of range/);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('throws on unregistered symbol id', async () => {
+    const h = makeHarness();
+    try {
+      await h.spinAndLand([
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      const reel = h.reelSet.reels[0];
+
+      expect(() => reel.setSymbolAt(1, 'nonexistent')).toThrow(/not registered/);
+    } finally {
+      h.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Public API for swapping a single visible cell's symbol identity in place, without restarting the spin or rebuilding the rest of the strip. Useful for live presentation effects that don't fit the `setResult` / `placeSymbols` flow:

- converting a symbol to a wild after a cascade pop,
- dropping in a "respin" symbol on a held reel,
- swapping to a sticky variant after a win is paid out.

The method funnels into the same internal `_replaceSymbol` path as motion-driven swaps, so the swapped-in symbol gets its proper parent (masked vs unmasked container), visual reset, and `symbol:created` event for free.

## API

```ts
reelSet.reels[r].setSymbolAt(visibleRow, 'wild');
```

## Validation
- throws if `visibleRow` is not an integer in `[0, visibleRows)`
- throws if `symbolId` is not registered (registered set comes from the builder)
- throws if the target row is a non-anchor cell of a big-symbol block — callers must swap the anchor row directly or rebuild the frame via `placeSymbols`

## Files touched
- `src/core/Reel.ts` — new public method `setSymbolAt`.
- `tests/integration/setSymbolAt.test.ts` — 5 new tests covering swap, event emission, no-side-effect on other rows, range/registration errors.
- `.changeset/feat-reel-set-symbol-at.md` — minor bump.

## Test plan
- [x] `pnpm --filter pixi-reels typecheck`
- [x] `pnpm --filter pixi-reels test` — 219 tests pass (5 new)
- [x] `pnpm check:lint`

## Notes
The motion layer is **not** snapped — call `snapToGrid()` separately if you need to re-grid after the swap. Pairs naturally with #93 (auto-zIndex on activate) which makes the swapped-in symbol's layering correct without a follow-up `refreshZIndex`; it works correctly without #93 too.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)