### PR TITLE
docs: clarify setStopDelays is delay-not-hold; point at holdReels

### DIFF
--- a/packages/pixi-reels/src/core/ReelSet.ts
+++ b/packages/pixi-reels/src/core/ReelSet.ts
@@ -265,12 +265,30 @@ export class ReelSet extends Container implements Disposable {
   }
 
   /**
-   * Override the per-reel stop delay for the current spin (in ms).
-   * Pass one value per reel. Cleared at the start of each new spin.
+   * Override the per-reel stop delay for the current spin, in
+   * milliseconds. Pass one value per reel; cleared at the start of each
+   * new spin.
+   *
+   * **This is delay, not hold.** A large value (e.g. `999999`) only
+   * postpones a reel's stop — the reel still spins, still consumes its
+   * target frame from the StopSequencer, still emits `spin:reelLanded`
+   * eventually. If you want to keep a reel motionless across the spin
+   * (its current visible frame stays put — classic Hold & Win), pass it
+   * via {@link spin}'s `holdReels` instead:
+   *
+   * ```ts
+   * reelSet.spin({ holdReels: [4] });
+   * ```
+   *
+   * `setStopDelays` is for visual stagger (left-to-right sweep, dramatic
+   * pause on the last reel, etc.) — not for skipping a reel's spin.
    *
    * @example
    * // Stagger the last two reels more than the default for dramatic effect:
    * reelSet.setStopDelays([0, 140, 280, 600, 1100]);
+   *
+   * @see {@link spin} — `holdReels` skips the spin entirely.
+   * @see {@link setDropOrder} — convenience wrapper for cascade drop patterns.
    */
   setStopDelays(delays: number[]): void {
     this._spinController.setStopDelays(delays);

--- a/packages/pixi-reels/src/spin/SpinController.ts
+++ b/packages/pixi-reels/src/spin/SpinController.ts
@@ -200,6 +200,13 @@ export class SpinController implements Disposable {
    * Override the per-reel stop delay (in ms). Pass one value per reel.
    * When set, these replace the staggered `reelIndex * speed.stopDelay`
    * pattern for the current spin. Cleared at the start of each new spin.
+   *
+   * **Delay, not hold.** A large value postpones a reel's stop — the
+   * reel still spins, still consumes its target from the StopSequencer,
+   * still emits `spin:reelLanded`. To keep a reel motionless across an
+   * entire spin (its visible frame stays put), pass it via
+   * `spin({ holdReels: [...] })` instead. `setStopDelays` is for visual
+   * stagger only.
    */
   setStopDelays(delays: number[]): void {
     this._stopDelayOverride = [...delays];


### PR DESCRIPTION
## Summary
A common misconception is that `setStopDelays([0, 0, 0, 0, 999999])` would freeze the last reel — i.e., never stop it. It doesn't: it only postpones the stop. The reel still spins, still consumes its target from the StopSequencer, still emits `spin:reelLanded` once the delay elapses.

To keep a reel motionless across an entire spin (its visible frame stays put — classic Hold & Win), the right tool is `spin({ holdReels: [...] })` (see #78 for that API).

This PR updates the JSDoc on both `ReelSet.setStopDelays` and `SpinController.setStopDelays` to make the distinction explicit and to forward-reference `holdReels` and `setDropOrder`.

## Files touched
- `src/core/ReelSet.ts` — expanded TSDoc on `setStopDelays`.
- `src/spin/SpinController.ts` — short clarification on the internal counterpart.

## Why no changeset
Pure documentation change — no library behavior or public-API surface alters. Apply the `skip-changeset` PR label per [CLAUDE.md §5](../blob/main/CLAUDE.md).

## Test plan
- [x] `pnpm --filter pixi-reels typecheck`
- [x] `pnpm --filter pixi-reels test` — 214 tests pass
- [x] `pnpm check:lint`

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)