### PR TITLE
fix: clamp ReelSetBuilder.bufferSymbols below 1 to 1 with one-shot warn

### DIFF
--- a/.changeset/feat-buffer-symbols-clamp.md
+++ b/.changeset/feat-buffer-symbols-clamp.md
@@ -1,0 +1,9 @@
+---
+'pixi-reels': patch
+---
+
+Fix: `ReelSetBuilder.bufferSymbols(count)` now clamps `0`, negative numbers, `NaN`, and non-finite values to the minimum of 1, with a single console warning per process.
+
+Buffer rows are off-screen cells the reel keeps around the visible window so symbols can fade/slide in cleanly. The motion layer's wrap detection assumes at least one buffer row above and one below — passing `0` would produce an inconsistent state that surfaced later as visible flicker on motion-wrap, not as a clear configuration error at build time.
+
+The clamp is preferred over a thrown error so existing user code that accidentally passed `0` keeps running. The warning fires once per process (regardless of how many builders hit the bad value) so logs stay readable when a faulty default is wired into a loop.

--- a/packages/pixi-reels/src/core/ReelSetBuilder.ts
+++ b/packages/pixi-reels/src/core/ReelSetBuilder.ts
@@ -251,11 +251,34 @@ export class ReelSetBuilder {
     return this;
   }
 
-  /** Set number of buffer symbols above/below visible area. Default: 1. */
+  /**
+   * Set number of buffer symbols above/below the visible area. Default: 1.
+   *
+   * Buffer rows are off-screen cells the reel keeps around the visible
+   * window so symbols can fade/slide in cleanly. The motion layer's wrap
+   * detection assumes at least one buffer row above and one below — the
+   * minimum supported value is **1**. Passing `0` (or a negative number)
+   * is clamped to `1` and a single console warning is printed; the
+   * builder does not throw, so existing user code keeps running.
+   */
   bufferSymbols(count: number): this {
+    if (!Number.isFinite(count) || count < 1) {
+      if (!ReelSetBuilder._bufferWarnedThisProcess) {
+        ReelSetBuilder._bufferWarnedThisProcess = true;
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[pixi-reels] bufferSymbols(${count}) is below the minimum of 1; clamping to 1. ` +
+            `The motion layer needs at least one buffer row above and below the visible window for wrap detection.`,
+        );
+      }
+      this._bufferSymbols = 1;
+      return this;
+    }
     this._bufferSymbols = count;
     return this;
   }
+  /** One-shot guard so we don't spam consoles when builders are constructed in a loop. */
+  private static _bufferWarnedThisProcess = false;
 
   /** Configure symbols via a registry callback. */
   symbols(configurator: (registry: SymbolRegistry) => void): this {

--- a/packages/pixi-reels/tests/unit/bufferSymbolsClamp.test.ts
+++ b/packages/pixi-reels/tests/unit/bufferSymbolsClamp.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for `ReelSetBuilder.bufferSymbols(count)` clamp behaviour.
+ *
+ * Contract: passing `0`, a negative number, `NaN`, or `Infinity` is
+ * clamped to the minimum of 1 (the motion layer needs at least one
+ * buffer row above and below the visible window for wrap detection).
+ * The builder warns once per process via `console.warn` and does not
+ * throw, so existing user code that accidentally passed `0` keeps
+ * running rather than crashing at build time.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('ReelSetBuilder.bufferSymbols clamp', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    // Re-import so the module-level `_bufferWarnedThisProcess` flag is
+    // freshly false for each test. Vitest module-cache reset via vi.resetModules.
+    vi.resetModules();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('accepts a positive integer unchanged', async () => {
+    const { ReelSetBuilder } = await import('../../src/core/ReelSetBuilder.js');
+    const b = new ReelSetBuilder();
+    b.bufferSymbols(3);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((b as any)._bufferSymbols).toBe(3);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('clamps 0 to 1 and warns once', async () => {
+    const { ReelSetBuilder } = await import('../../src/core/ReelSetBuilder.js');
+    const b = new ReelSetBuilder();
+    b.bufferSymbols(0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((b as any)._bufferSymbols).toBe(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/clamping to 1/);
+  });
+
+  it('clamps a negative count to 1', async () => {
+    const { ReelSetBuilder } = await import('../../src/core/ReelSetBuilder.js');
+    const b = new ReelSetBuilder();
+    b.bufferSymbols(-2);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((b as any)._bufferSymbols).toBe(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clamps NaN to 1', async () => {
+    const { ReelSetBuilder } = await import('../../src/core/ReelSetBuilder.js');
+    const b = new ReelSetBuilder();
+    b.bufferSymbols(Number.NaN);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((b as any)._bufferSymbols).toBe(1);
+  });
+
+  it('warns only once per process across multiple builders', async () => {
+    const { ReelSetBuilder } = await import('../../src/core/ReelSetBuilder.js');
+    new ReelSetBuilder().bufferSymbols(0);
+    new ReelSetBuilder().bufferSymbols(0);
+    new ReelSetBuilder().bufferSymbols(-1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the builder for chaining', async () => {
+    const { ReelSetBuilder } = await import('../../src/core/ReelSetBuilder.js');
+    const b = new ReelSetBuilder();
+    expect(b.bufferSymbols(0)).toBe(b);
+    expect(b.bufferSymbols(2)).toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary
Buffer rows are off-screen cells the reel keeps around the visible window so symbols can fade/slide in cleanly. The motion layer's wrap detection assumes at least one buffer row above and one below — passing `0` would produce an inconsistent state that surfaced later as visible flicker on motion-wrap, not as a clear configuration error at build time.

This change makes `ReelSetBuilder.bufferSymbols(count)`:

- Clamp `0`, negative numbers, `NaN`, and non-finite values to the minimum of 1.
- Emit a single `console.warn` per process when clamping (one-shot guard so logs stay readable when a faulty default is wired into a loop).
- Not throw — existing user code that accidentally passed 0 keeps running.

## Files touched
- `src/core/ReelSetBuilder.ts` — clamp + warn in `bufferSymbols`. Static `_bufferWarnedThisProcess` flag for the one-shot guard.
- `tests/unit/bufferSymbolsClamp.test.ts` — 6 new tests covering positive pass-through, 0 / negative / NaN clamps, one-shot warn semantics across multiple builders, and chaining.
- `.changeset/feat-buffer-symbols-clamp.md` — patch bump.

## Test plan
- [x] `pnpm --filter pixi-reels typecheck`
- [x] `pnpm --filter pixi-reels test` — 220 tests pass (6 new)
- [x] `pnpm check:lint`

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)