### PR TITLE
feat: auto-pick SharedRectMaskStrategy on registered unmask symbols

### DIFF
--- a/.changeset/feat-auto-shared-mask-on-unmask.md
+++ b/.changeset/feat-auto-shared-mask-on-unmask.md
@@ -1,0 +1,15 @@
+---
+'pixi-reels': minor
+---
+
+Auto-pick `SharedRectMaskStrategy` when any registered symbol has `unmask: true` and `symbolGap.x > 0`.
+
+The default `RectMaskStrategy` draws one mask rect per reel, with the gaps between reels NOT clipped — fine in the common case. But when an `unmask: true` symbol renders above the reel mask, neighboring (still-masked) symbols on adjacent reels visibly clip at the column gap, and players see a half-cropped neighbor next to the unmasked overlay.
+
+The auto-pick now triggers in either case:
+- **big symbols** registered (`SymbolData.size` with `w > 1` or `h > 1`), or
+- **unmasked symbols** registered (`SymbolData.unmask: true`),
+
+provided the layout has a horizontal gap (`symbolGap.x > 0`). Explicit `.maskStrategy(...)` calls always win.
+
+Console emits a one-line `console.info` hint identifying which condition triggered the auto-pick. Pairs with the existing big-symbol auto-pick — the same mechanism, broader trigger set.

--- a/packages/pixi-reels/src/config/types.ts
+++ b/packages/pixi-reels/src/config/types.ts
@@ -31,7 +31,17 @@ export interface SymbolData {
   weight: number;
   /** Display layering order. Higher = in front. */
   zIndex?: number;
-  /** If true, this symbol renders above the reel mask (for oversized animations). */
+  /**
+   * If true, this symbol renders above the reel mask (for oversized
+   * animations).
+   *
+   * **Mask-strategy auto-pick:** when any registered symbol sets
+   * `unmask: true` and `symbolGap.x > 0`, the builder switches the
+   * default `RectMaskStrategy` to `SharedRectMaskStrategy` so that
+   * neighboring (masked) symbols don't get clipped at the column gap
+   * next to the unmasked overlay. Passing `.maskStrategy(...)`
+   * explicitly always wins.
+   */
   unmask?: boolean;
   /**
    * Footprint in cells. Default `{ w: 1, h: 1 }`. When `w * h > 1` this

--- a/packages/pixi-reels/src/core/ReelSetBuilder.ts
+++ b/packages/pixi-reels/src/core/ReelSetBuilder.ts
@@ -480,24 +480,36 @@ export class ReelSetBuilder {
     const viewportWidth = reelCount * (symbolWidth + this._symbolGap.x) - this._symbolGap.x;
     const viewportHeight = tallest;
 
-    // Auto-pick `SharedRectMaskStrategy` when big symbols are registered AND
-    // there's a horizontal gap. The default per-reel mask would clip cross-
-    // reel big symbols at every column gap (visible vertical strips through
-    // the symbol). The shared mask draws one bounding rect so the symbol
-    // stays whole. Explicit `.maskStrategy(...)` calls always win.
+    // Auto-pick `SharedRectMaskStrategy` when the layout has horizontal
+    // gaps AND any registered symbol needs to span across reel boundaries:
+    //
+    //   - **big symbols** (footprint w > 1 or h > 1) — the per-reel mask
+    //     would clip cross-reel big symbols at every column gap (visible
+    //     vertical strips through the symbol), so we share a single mask.
+    //   - **unmasked symbols** (`SymbolData.unmask: true`) — these render
+    //     above the per-reel mask anyway, but neighboring (masked)
+    //     symbols still get clipped at the gap. Players see a
+    //     half-cropped neighbor next to the unmasked overlay. Sharing
+    //     one mask removes the gap stripe.
+    //
+    // Explicit `.maskStrategy(...)` calls always win.
     const hasBigSymbols = Object.values(symbolsData).some(
       (d) => d.size && (d.size.w > 1 || d.size.h > 1),
     );
+    const hasUnmaskedSymbols = Object.values(symbolsData).some((d) => d.unmask);
     if (
       !this._maskStrategyExplicit &&
-      hasBigSymbols &&
+      (hasBigSymbols || hasUnmaskedSymbols) &&
       this._symbolGap.x > 0
     ) {
       this._maskStrategy = new SharedRectMaskStrategy();
       // Heads-up so devs see the auto-pick in their console.
+      const reason = hasBigSymbols
+        ? 'big symbols are registered'
+        : 'one or more symbols use `unmask: true`';
       // eslint-disable-next-line no-console
       console.info(
-        '[pixi-reels] auto-selected SharedRectMaskStrategy because big symbols are registered ' +
+        `[pixi-reels] auto-selected SharedRectMaskStrategy because ${reason} ` +
         'and symbolGap.x > 0. Pass .maskStrategy(...) explicitly to override.',
       );
     }

--- a/packages/pixi-reels/tests/unit/maskStrategy.test.ts
+++ b/packages/pixi-reels/tests/unit/maskStrategy.test.ts
@@ -186,6 +186,62 @@ describe('mask strategies', () => {
     }
   });
 
+  it('auto-picks SharedRectMaskStrategy when any symbol has unmask: true + symbolGap.x > 0', () => {
+    const consoleInfo = console.info;
+    const captured: unknown[][] = [];
+    console.info = (...args: unknown[]) => { captured.push(args); };
+    try {
+      const reelSet = new ReelSetBuilder()
+        .reels(5)
+        .visibleRows(3)
+        .symbolSize(80, 80)
+        .symbolGap(4, 4)
+        .symbols((r) => {
+          r.register('a', HeadlessSymbol, {});
+          r.register('wild', HeadlessSymbol, {});
+        })
+        .symbolData({ wild: { unmask: true } })
+        .ticker(new FakeTicker() as unknown as Ticker)
+        .build();
+      try {
+        // Single bounding rect ⇒ getLocalBounds covers full viewport.
+        const bounds = reelSet.viewport.maskGraphics.getLocalBounds();
+        const totalW = 5 * (80 + 4) - 4; // 416
+        expect(bounds.width).toBe(totalW);
+        // Console hint surfaced AND mentions the unmask reason.
+        expect(captured.some((args) => {
+          const msg = String(args[0]);
+          return msg.includes('SharedRectMaskStrategy') && msg.includes('unmask');
+        })).toBe(true);
+      } finally {
+        reelSet.destroy();
+      }
+    } finally {
+      console.info = consoleInfo;
+    }
+  });
+
+  it('does NOT auto-pick SharedRectMaskStrategy on unmask if symbolGap.x === 0', () => {
+    const reelSet = new ReelSetBuilder()
+      .reels(5)
+      .visibleRows(3)
+      .symbolSize(80, 80)
+      .symbolGap(0, 4) // zero horizontal gap — per-reel rects are contiguous
+      .symbols((r) => {
+        r.register('a', HeadlessSymbol, {});
+        r.register('wild', HeadlessSymbol, {});
+      })
+      .symbolData({ wild: { unmask: true } })
+      .ticker(new FakeTicker() as unknown as Ticker)
+      .build();
+    try {
+      // Per-reel RectMaskStrategy still in effect (5 rects, one per reel).
+      expect(reelSet.viewport.maskRects).toHaveLength(5);
+    } finally {
+      reelSet.destroy();
+    }
+  });
+
   it('explicit .maskStrategy() always wins over the auto-pick', () => {
     const reelSet = new ReelSetBuilder()
       .reels(5)


### PR DESCRIPTION
## Summary
The default `RectMaskStrategy` draws one mask rect per reel, with the gaps between reels NOT clipped. This is fine in the common case, but when an `unmask: true` symbol renders above the reel mask, neighboring (still-masked) symbols on adjacent reels visibly clip at the column gap — players see a half-cropped neighbor next to the unmasked overlay.

The auto-pick now triggers in either case:

- **big symbols** registered (`SymbolData.size` with `w > 1` or `h > 1`), or
- **unmasked symbols** registered (`SymbolData.unmask: true`),

provided the layout has a horizontal gap (`symbolGap.x > 0`). Explicit `.maskStrategy(...)` calls always win.

The console.info hint identifies which condition triggered the auto-pick. The `SymbolData.unmask` JSDoc is updated to mention the auto-pick behaviour.

## Files touched
- `src/core/ReelSetBuilder.ts` — extend the auto-pick condition; expanded reason in the console hint.
- `src/config/types.ts` — JSDoc on `SymbolData.unmask` documents the auto-pick.
- `tests/unit/maskStrategy.test.ts` — 2 new tests: auto-pick on `unmask + gap`; no auto-pick when `gap.x === 0`.
- `.changeset/feat-auto-shared-mask-on-unmask.md` — minor bump.

## Test plan
- [x] `pnpm --filter pixi-reels typecheck`
- [x] `pnpm --filter pixi-reels test` — 216 tests pass (2 new in `maskStrategy.test.ts`)
- [x] `pnpm check:lint`

## Notes
Independent of #92 (which makes `unmask` actually re-parent at runtime). Even before #92 lands, registering `unmask: true` is a meaningful intent signal — the auto-pick prepares the mask for that intent.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)