### PR TITLE
fix(symbols): reset view state on activate and deactivate

### DIFF
--- a/.changeset/reset-view-state-on-pool-recycle.md
+++ b/.changeset/reset-view-state-on-pool-recycle.md
@@ -1,0 +1,11 @@
+---
+'pixi-reels': patch
+---
+
+`ReelSymbol.activate()` and `ReelSymbol.deactivate()` now both reset the container's `alpha`, `scale`, `rotation`, `filters`, and `zIndex`. Previously a subclass that decorated `view` from a spin-lifecycle hook (e.g. attaching a `BlurFilter` in `onReelSpinStart`) had to remember to undo every property on its own — and any path that skipped a hook (a buffer cell that exited spin without `onReelSpinEnd`, a slam-stop that bypassed the lifecycle) left a recycled symbol carrying stale state into its next life. The most visible symptom was a "blurred" cell appearing after a cascade refill once a symbol had been pooled mid-spin.
+
+`ReelSymbol.destroy()` now inlines the lifecycle hooks (`stopAnimation`, `onDeactivate`) instead of going through `deactivate()`, so it doesn't try to reset transform / filter state on a view that was already torn down by a parent `container.destroy({ children: true })`.
+
+The same-id early-return path inside `Reel._setSymbolAt` bypasses the deactivate/activate cycle, so the matching reset has been added there too.
+
+No public API change. Subclasses that already cleared their own filter / transform state continue to work and just do a few redundant assignments.

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -591,10 +591,12 @@ export class Reel implements Disposable {
       return;
     }
 
-    // Even if same symbolId, always reset visual state (alpha, scale, zIndex)
+    // Even if same symbolId, always reset visual state (alpha, scale, rotation, filters, zIndex)
     if (oldSymbol.symbolId === newSymbolId) {
       oldSymbol.view.alpha = 1;
       oldSymbol.view.scale.set(1, 1);
+      oldSymbol.view.rotation = 0;
+      oldSymbol.view.filters = null;
       oldSymbol.view.zIndex = 0;
       return;
     }

--- a/packages/pixi-reels/src/symbols/ReelSymbol.ts
+++ b/packages/pixi-reels/src/symbols/ReelSymbol.ts
@@ -51,24 +51,36 @@ export abstract class ReelSymbol implements Disposable {
   }
 
   /**
-   * Activate the symbol with a new identity.
-   * Called when the symbol enters the visible reel or is recycled from the pool.
+   * Activate the symbol with a new identity. Called when the symbol enters
+   * the visible reel or is recycled from the pool. Resets container
+   * transform / filter state for parity with deactivate().
    */
   activate(symbolId: string): void {
     this._symbolId = symbolId;
     this.view.visible = true;
+    this.view.alpha = 1;
+    this.view.scale.set(1, 1);
+    this.view.rotation = 0;
+    this.view.filters = null;
+    this.view.zIndex = 0;
     this.onActivate(symbolId);
   }
 
   /**
-   * Deactivate the symbol before returning it to the pool.
-   * Stops any running animations and hides the view.
+   * Deactivate the symbol before returning it to the pool. Stops
+   * animations, hides the view, and resets container transform / filter
+   * state so subclass decorations don't leak across recycles.
    */
   deactivate(): void {
     this.stopAnimation();
     this.onDeactivate();
     this._symbolId = '';
     this.view.visible = false;
+    this.view.alpha = 1;
+    this.view.scale.set(1, 1);
+    this.view.rotation = 0;
+    this.view.filters = null;
+    this.view.zIndex = 0;
   }
 
   /** Pool reset — aliases deactivate. */
@@ -78,9 +90,10 @@ export abstract class ReelSymbol implements Disposable {
 
   destroy(): void {
     if (this._isDestroyed) return;
-    this.deactivate();
+    this.stopAnimation();
+    this.onDeactivate();
     this.onDestroy();
-    this.view.destroy({ children: true });
+    if (!this.view.destroyed) this.view.destroy({ children: true });
     this._isDestroyed = true;
   }
 

--- a/packages/pixi-reels/tests/unit/symbolPoolRecycle.test.ts
+++ b/packages/pixi-reels/tests/unit/symbolPoolRecycle.test.ts
@@ -1,0 +1,66 @@
+import type { Filter } from 'pixi.js';
+import { describe, expect, it } from 'vitest';
+import { HeadlessSymbol, SymbolFactory, SymbolRegistry } from '../../src/index.js';
+
+// Stub — real filters need document/WebGL.
+const stubFilter = {} as Filter;
+
+describe('ReelSymbol pool recycle — view state reset', () => {
+  it('clears alpha, scale, rotation, filters, zIndex on deactivate', () => {
+    const symbol = new HeadlessSymbol();
+    symbol.activate('a');
+
+    symbol.view.alpha = 0.35;
+    symbol.view.scale.set(1.4, 0.8);
+    symbol.view.rotation = 0.5;
+    symbol.view.filters = [stubFilter];
+    symbol.view.zIndex = 7;
+
+    symbol.deactivate();
+
+    expect(symbol.view.alpha).toBe(1);
+    expect(symbol.view.scale.x).toBe(1);
+    expect(symbol.view.scale.y).toBe(1);
+    expect(symbol.view.rotation).toBe(0);
+    expect(symbol.view.filters).toBeNull();
+    expect(symbol.view.zIndex).toBe(0);
+  });
+
+  it('clears alpha, scale, rotation, filters, zIndex on activate', () => {
+    const symbol = new HeadlessSymbol();
+
+    symbol.view.alpha = 0.5;
+    symbol.view.scale.set(2, 0.5);
+    symbol.view.rotation = 1.2;
+    symbol.view.filters = [stubFilter];
+    symbol.view.zIndex = 9;
+
+    symbol.activate('a');
+
+    expect(symbol.view.alpha).toBe(1);
+    expect(symbol.view.scale.x).toBe(1);
+    expect(symbol.view.scale.y).toBe(1);
+    expect(symbol.view.rotation).toBe(0);
+    expect(symbol.view.filters).toBeNull();
+    expect(symbol.view.zIndex).toBe(0);
+  });
+
+  it('does not leak filter / transform state across acquire/release cycles', () => {
+    const registry = new SymbolRegistry();
+    registry.register('a', HeadlessSymbol, {});
+    const factory = new SymbolFactory(registry);
+
+    const first = factory.acquire('a');
+    first.view.filters = [stubFilter];
+    first.view.alpha = 0.2;
+    first.view.scale.set(2, 2);
+    factory.release(first);
+
+    const second = factory.acquire('a');
+    expect(second).toBe(first);
+    expect(second.view.filters).toBeNull();
+    expect(second.view.alpha).toBe(1);
+    expect(second.view.scale.x).toBe(1);
+    expect(second.view.scale.y).toBe(1);
+  });
+});


### PR DESCRIPTION
 ## Summary 

 - `ReelSymbol.activate()` and `deactivate()` now reset alpha/scale/rotation/filters/zIndex
  - `Reel._setSymbolAt` same-id early-return resets the same set
  - `destroy()` no longer routes through `deactivate()` (avoids touching scale/filters on a torn-down view during
  teardown)
  - Added unit coverage in `symbolPoolRecycle.test.ts`
 
 ## Files touched

  - `packages/pixi-reels/src/symbols/ReelSymbol.ts` — view-state reset in `activate()` / `deactivate()`; `destroy()`
  inlines lifecycle hooks instead of calling `deactivate()`.
  - `packages/pixi-reels/src/core/Reel.ts` — same-id early-return path also resets `rotation` / `filters`.
  - `packages/pixi-reels/tests/unit/symbolPoolRecycle.test.ts` (new) — 3 cases covering deactivate, activate, and a full
   release/acquire cycle.
  - `.changeset/reset-view-state-on-pool-recycle.md` (new) — patch.

  ## Test plan

  - [x] `pnpm --filter pixi-reels test` (217/217)
  - [x] `pnpm typecheck` + `pnpm check:lint`
  - [x] Integration check in a downstream 6x5 cluster-pays cascade game: dropped the local
  `BlurSpriteSymbol.onActivate/onDeactivate` workarounds, no leak after cascade refill.