### PR TITLE
fix(spin): fire onReelSpinEnd and onReelLanded on slam-stop

### DIFF
--- a/.changeset/slam-stop-fires-lifecycle-hooks.md
+++ b/.changeset/slam-stop-fires-lifecycle-hooks.md
@@ -1,0 +1,7 @@
+---
+'pixi-reels': patch
+---
+
+`SpinController.skip()` now fires `onReelSpinEnd` and `onReelLanded` on every reel that hadn't already landed, regardless of which phase was active when the slam-stop arrived. Previously these symbol-level hooks fired only when the active phase happened to be `StopPhase` or `DropStopPhase` (their `onSkip()` called the notifications); a skip during `StartPhase` / `SpinPhase` / `AnticipationPhase` / `AdjustPhase` left visible symbols without an end-of-spin signal — most visibly, motion blur (or any other decoration attached in `onReelSpinStart`) stayed on the cell after the slam.
+
+The notifications moved out of `StopPhase.onSkip` / `DropStopPhase.onSkip` into the controller so there's a single source of truth and no double-fire. Natural-stop flow is unchanged — those phases still fire the hooks themselves before the bounce.

--- a/packages/pixi-reels/src/spin/SpinController.ts
+++ b/packages/pixi-reels/src/spin/SpinController.ts
@@ -247,6 +247,8 @@ export class SpinController implements Disposable {
         }
 
         reel.placeSymbols(decorated[i]);
+        reel.notifySpinEnd();
+        reel.notifyLanded();
         this._markLanded(i);
       }
     } else {
@@ -256,6 +258,8 @@ export class SpinController implements Disposable {
         reel.speed = 0;
         reel.isStopping = false;
         reel.snapToGrid();
+        reel.notifySpinEnd();
+        reel.notifyLanded();
         this._markLanded(i);
       }
     }

--- a/packages/pixi-reels/src/spin/phases/DropStopPhase.ts
+++ b/packages/pixi-reels/src/spin/phases/DropStopPhase.ts
@@ -156,8 +156,6 @@ export class DropStopPhase extends ReelPhase<DropStopPhaseConfig> {
       reel.placeSymbols(config.targetFrame.slice(bufferAbove, bufferAbove + visibleRows));
     }
 
-    reel.notifySpinEnd();
-    reel.notifyLanded();
     this._stage = 'done';
   }
 

--- a/packages/pixi-reels/src/spin/phases/StopPhase.ts
+++ b/packages/pixi-reels/src/spin/phases/StopPhase.ts
@@ -117,8 +117,6 @@ export class StopPhase extends ReelPhase<StopPhaseConfig> {
     }
     reel.snapToGrid();
     reel.container.y = this._baseY;
-    reel.notifySpinEnd();
-    reel.notifyLanded();
     this._stage = 'done';
   }
 

--- a/packages/pixi-reels/tests/unit/skipFiresLifecycleHooks.test.ts
+++ b/packages/pixi-reels/tests/unit/skipFiresLifecycleHooks.test.ts
@@ -1,0 +1,53 @@
+import type { Ticker } from 'pixi.js';
+import { describe, expect, it } from 'vitest';
+import { ReelSetBuilder } from '../../src/core/ReelSetBuilder.js';
+import { FakeTicker } from '../../src/testing/FakeTicker.js';
+import { HeadlessSymbol } from '../../src/testing/HeadlessSymbol.js';
+
+class CountingSymbol extends HeadlessSymbol {
+  public spinEndCount = 0;
+  public landedCount = 0;
+  override onReelSpinEnd(): void {
+    this.spinEndCount++;
+  }
+  override onReelLanded(): void {
+    this.landedCount++;
+  }
+}
+
+describe('SpinController.skip — symbol lifecycle hooks', () => {
+  it('fires onReelSpinEnd and onReelLanded once per visible-row symbol on slam-stop', async () => {
+    const ticker = new FakeTicker();
+    const reelSet = new ReelSetBuilder()
+      .reels(3)
+      .visibleSymbols(3)
+      .symbolSize(100, 100)
+      .ticker(ticker as unknown as Ticker)
+      .symbols((r) => {
+        r.register('a', CountingSymbol, {});
+        r.register('b', CountingSymbol, {});
+      })
+      .build();
+
+    const promise = reelSet.spin();
+    reelSet.setResult([
+      ['a', 'a', 'a'],
+      ['b', 'b', 'b'],
+      ['a', 'a', 'a'],
+    ]);
+    reelSet.skip();
+    await promise;
+
+    for (const reel of reelSet.reels) {
+      const visible = reel.symbols.slice(reel.bufferAbove, reel.bufferAbove + reel.visibleRows);
+      for (const sym of visible) {
+        expect(sym).toBeInstanceOf(CountingSymbol);
+        expect((sym as CountingSymbol).spinEndCount).toBe(1);
+        expect((sym as CountingSymbol).landedCount).toBe(1);
+      }
+    }
+
+    reelSet.destroy();
+    ticker.destroy();
+  });
+});


### PR DESCRIPTION
 ## Summary

  - `SpinController.skip()` now fires `onReelSpinEnd` + `onReelLanded` on every non-landed reel, regardless of active
  phase
  - Removed duplicate calls from `StopPhase.onSkip` and `DropStopPhase.onSkip` to avoid double-fire — single source of
  truth in the controller
  - Natural-stop flow unchanged (those phases still fire hooks themselves before the bounce)
  - Added unit coverage in `skipFiresLifecycleHooks.test.ts`

  ## Files touched

  - `packages/pixi-reels/src/spin/SpinController.ts` — fire hooks per non-landed reel inside `skip()`.
  - `packages/pixi-reels/src/spin/phases/StopPhase.ts` — drop hook calls from `onSkip`.
  - `packages/pixi-reels/src/spin/phases/DropStopPhase.ts` — same.
  - `packages/pixi-reels/tests/unit/skipFiresLifecycleHooks.test.ts` (new) — verifies hooks fire once per visible-row
  symbol after `skip()`.

  ## Test plan

  - [x] `pnpm --filter pixi-reels test` (215/215)
  - [x] `pnpm typecheck` + `pnpm check:lint`
  - [x] Verified in a downstream cluster-pays game: slam-stop during start/spin/anticipation phases now correctly clears
   motion blur on visible cells.