### PR TITLE
feat(spin): add requestSkip() that queues until setResult

### DIFF
--- a/.changeset/request-skip-queues-until-result.md
+++ b/.changeset/request-skip-queues-until-result.md
@@ -1,0 +1,7 @@
+---
+'pixi-reels': minor
+---
+
+Added `ReelSet.requestSkip()` (and `SpinController.requestSkip()`) — a slam-stop entry point that's safe to call before `setResult()` arrives. If the result is already pending, it behaves exactly like `skip()`. Otherwise the skip is queued and fires automatically as soon as `setResult()` lands.
+
+Use this from UI handlers in server-driven slots: a player tapping the spin button to slam-stop before the WebSocket response reaches the client no longer snaps every reel onto whatever buffer state happened to be mid-scroll. Existing `skip()` is unchanged.

--- a/packages/pixi-reels/src/core/ReelSet.ts
+++ b/packages/pixi-reels/src/core/ReelSet.ts
@@ -281,6 +281,11 @@ export class ReelSet extends Container implements Disposable {
     this._spinController.skip();
   }
 
+  /** Slam-stop safe before `setResult()` arrives — queues until then. */
+  requestSkip(): void {
+    this._spinController.requestSkip();
+  }
+
   /**
    * Set the drop order for cascade drop-in mechanics.
    *

--- a/packages/pixi-reels/src/spin/SpinController.ts
+++ b/packages/pixi-reels/src/spin/SpinController.ts
@@ -102,6 +102,7 @@ export class SpinController implements Disposable {
   private _activePhases: Map<number, ReelPhase<any>> = new Map();
   private _landedReels = new Set<number>();
   private _wasSkipped = false;
+  private _skipPending = false;
   private _isDestroyed = false;
   private _currentSpinResolve: ((result: SpinResult) => void) | null = null;
   /** Incremented on each new spin. If a callback sees a stale generation, it no-ops. */
@@ -155,6 +156,7 @@ export class SpinController implements Disposable {
 
     this._isSpinning = true;
     this._wasSkipped = false;
+    this._skipPending = false;
     this._spinStartTime = performance.now();
     this._resultSymbols = null;
     this._anticipationReels = [];
@@ -190,6 +192,10 @@ export class SpinController implements Disposable {
     this._coordinateBigSymbols(symbols, visibleRowsForReel);
     this._resultSymbols = symbols;
     this._tryBeginStopSequence();
+    if (this._skipPending) {
+      this._skipPending = false;
+      this.skip();
+    }
   }
 
   setAnticipation(reelIndices: number[]): void {
@@ -203,6 +209,19 @@ export class SpinController implements Disposable {
    */
   setStopDelays(delays: number[]): void {
     this._stopDelayOverride = [...delays];
+  }
+
+  /**
+   * Slam-stop safe before `setResult()` arrives. Queues until a result is
+   * set, then fires `skip()`. Otherwise equivalent to `skip()`.
+   */
+  requestSkip(): void {
+    if (!this._isSpinning) return;
+    if (this._resultSymbols) {
+      this.skip();
+      return;
+    }
+    this._skipPending = true;
   }
 
   skip(): void {

--- a/packages/pixi-reels/tests/unit/requestSkip.test.ts
+++ b/packages/pixi-reels/tests/unit/requestSkip.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { createTestReelSet, expectGrid } from '../../src/index.js';
+
+describe('ReelSet.requestSkip — pre-result-safe slam-stop', () => {
+  it('queues until setResult and lands on the target grid (not buffer)', async () => {
+    const h = createTestReelSet({ reels: 3, visibleRows: 3, symbolIds: ['a', 'b', 'c'] });
+
+    const grid = [
+      ['a', 'b', 'c'],
+      ['c', 'a', 'b'],
+      ['b', 'c', 'a'],
+    ];
+
+    const promise = h.reelSet.spin();
+    h.advance(50);
+    h.reelSet.requestSkip();
+    h.advance(50);
+    expect(h.reelSet.isSpinning).toBe(true);
+
+    h.reelSet.setResult(grid);
+    await promise;
+
+    expectGrid(h.reelSet, grid);
+    expect(h.reelSet.isSpinning).toBe(false);
+    h.destroy();
+  });
+
+  it('falls through to skip() when result is already set', async () => {
+    const h = createTestReelSet({ reels: 3, visibleRows: 3, symbolIds: ['a', 'b'] });
+
+    const grid = [
+      ['a', 'a', 'a'],
+      ['b', 'b', 'b'],
+      ['a', 'b', 'a'],
+    ];
+
+    const promise = h.reelSet.spin();
+    h.reelSet.setResult(grid);
+    h.reelSet.requestSkip();
+    await promise;
+
+    expectGrid(h.reelSet, grid);
+    h.destroy();
+  });
+
+  it('is a no-op when not spinning', () => {
+    const h = createTestReelSet({ reels: 2, visibleRows: 2, symbolIds: ['a'] });
+    expect(() => h.reelSet.requestSkip()).not.toThrow();
+    expect(h.reelSet.isSpinning).toBe(false);
+    h.destroy();
+  });
+});


### PR DESCRIPTION
 ## Summary

  - New `ReelSet.requestSkip()` (passthrough to `SpinController.requestSkip()`) — slam-stop safe before `setResult()`
  arrives
  - If a result is already pending, behaves exactly like `skip()`
  - Otherwise queues and fires automatically as soon as `setResult()` lands
  - Added unit coverage in `requestSkip.test.ts`

  ## Files touched

  - `packages/pixi-reels/src/spin/SpinController.ts` — `_skipPending` flag, new `requestSkip()`, hook in `setResult()`.
  - `packages/pixi-reels/src/core/ReelSet.ts` — passthrough.
  - `packages/pixi-reels/tests/unit/requestSkip.test.ts` (new) — 3 cases: pre-result queue, post-result fallthrough,
  no-op when not spinning.
  - `.changeset/request-skip-queues-until-result.md` (`minor` — new public API).

  ## Test plan

  - [x] `pnpm --filter pixi-reels test` (217/217)
  - [x] `pnpm typecheck` + `pnpm check:lint`
  - [x] Verified in a downstream cluster-pays game: dropped the local `skipPending` workaround, slam-stop now safe in
  any phase.