### PR TITLE
feat(spin): per-spin mode override via spin({ mode })

### DIFF
--- a/.changeset/per-spin-mode.md
+++ b/.changeset/per-spin-mode.md
@@ -1,0 +1,9 @@
+---
+'pixi-reels': minor
+---
+
+`reelSet.spin()` accepts an optional `{ mode: 'standard' | 'cascade' }` argument that picks the phase chain for a single spin. Tumble-cascade slots can now do classic strip-spin + bounce on the first round and drop-in tumble on subsequent waves.
+
+`.cascade(...)` on the builder still wires the drop-in phases — but they are now registered under `dropStart` / `dropStop` keys instead of overwriting `start` / `stop`. The default mode flips to `'cascade'` when `.cascade(...)` was called, so existing callers that just call `spin()` without args see no change.
+
+Calling `spin({ mode: 'cascade' })` on a builder that didn't configure `.cascade(...)` throws a clear error. The new `SpinOptions` type is exported from the package barrel.

--- a/packages/pixi-reels/src/config/types.ts
+++ b/packages/pixi-reels/src/config/types.ts
@@ -1,5 +1,14 @@
 import type { Container, Ticker } from 'pixi.js';
 
+/** Optional overrides for a single `spin()` call. */
+export interface SpinOptions {
+  /**
+   * Phase chain selector for this spin.
+   * `'cascade'` requires `.cascade(...)` on the builder.
+   */
+  mode?: 'standard' | 'cascade';
+}
+
 /** Timing and animation profile for a speed mode. */
 export interface SpeedProfile {
   readonly name: string;

--- a/packages/pixi-reels/src/core/ReelSet.ts
+++ b/packages/pixi-reels/src/core/ReelSet.ts
@@ -1,6 +1,6 @@
 import { Container } from 'pixi.js';
 import type { Disposable } from '../utils/Disposable.js';
-import type { ReelSetInternalConfig, CellBounds, SymbolData } from '../config/types.js';
+import type { ReelSetInternalConfig, CellBounds, SymbolData, SpinOptions } from '../config/types.js';
 import { EventEmitter } from '../events/EventEmitter.js';
 import type { ReelSetEvents, SpinResult, } from '../events/ReelEvents.js';
 import { Reel, } from './Reel.js';
@@ -26,6 +26,7 @@ export interface ReelSetParams {
   frameBuilder: FrameBuilder;
   phaseFactory: PhaseFactory;
   spinningMode: SpinningMode;
+  defaultSpinMode: 'standard' | 'cascade';
 }
 
 /**
@@ -204,6 +205,7 @@ export class ReelSet extends Container implements Disposable {
       this._events,
       params.config.ticker,
       params.spinningMode,
+      params.defaultSpinMode,
       {
         isMultiWaysSlot: this._isMultiWaysSlot,
         symbolsData: this._symbolsData,
@@ -241,9 +243,14 @@ export class ReelSet extends Container implements Disposable {
 
   // ─── Spin API ─────────────────────────────────────────────
 
-  /** Start spinning all reels. Returns a promise that resolves when all reels land. */
-  async spin(): Promise<SpinResult> {
-    return this._spinController.spin();
+  /**
+   * Start spinning all reels. Returns a promise that resolves when all
+   * reels land. Pass `{ mode: 'standard' | 'cascade' }` to override the
+   * builder-time default for a single spin (e.g. classic strip-spin on
+   * the first round, drop-in on the cascade waves).
+   */
+  async spin(opts?: SpinOptions): Promise<SpinResult> {
+    return this._spinController.spin(opts);
   }
 
   /**

--- a/packages/pixi-reels/src/core/ReelSetBuilder.ts
+++ b/packages/pixi-reels/src/core/ReelSetBuilder.ts
@@ -78,6 +78,7 @@ export class ReelSetBuilder {
   private _initialFrame?: string[][];
   private _symbolDataOverrides: Record<string, Partial<SymbolData>> = {};
   private _cascadeDropConfig?: CascadeDropConfig;
+  private _defaultSpinMode: 'standard' | 'cascade' = 'standard';
   /** Per-reel static row counts (jagged shapes like 3-5-5-5-3). */
   private _visibleRowsPerReel?: number[];
   /** Per-reel pixel-box heights — used for both pyramids and MultiWays. */
@@ -342,6 +343,7 @@ export class ReelSetBuilder {
    */
   cascade(config: CascadeDropConfig): this {
     this._cascadeDropConfig = config;
+    this._defaultSpinMode = 'cascade';
     return this;
   }
 
@@ -458,11 +460,14 @@ export class ReelSetBuilder {
       frameBuilder.use(mw);
     }
 
-    // Wire cascade drop-in phases if configured
+    // Wire cascade drop-in phases under cascade-specific keys so the
+    // standard 'start' / 'stop' phases stay available. The default spin
+    // mode flips to 'cascade' when .cascade() was called, preserving
+    // existing behaviour for callers that don't pass `spin({ mode })`.
     if (this._cascadeDropConfig) {
       const dropConfig = this._cascadeDropConfig;
-      this._phaseFactory.register('start', DropStartPhase);
-      this._phaseFactory.registerFactory('stop', (reel, speed) => new DropStopPhase(reel, speed, dropConfig));
+      this._phaseFactory.register('dropStart', DropStartPhase);
+      this._phaseFactory.registerFactory('dropStop', (reel, speed) => new DropStopPhase(reel, speed, dropConfig));
     }
 
     // MultiWays: wire AdjustPhase. Stay out of non-MultiWays chains entirely
@@ -560,6 +565,7 @@ export class ReelSetBuilder {
       frameBuilder,
       phaseFactory: this._phaseFactory,
       spinningMode: this._spinningMode,
+      defaultSpinMode: this._defaultSpinMode,
     };
 
     return new ReelSet(params);

--- a/packages/pixi-reels/src/index.ts
+++ b/packages/pixi-reels/src/index.ts
@@ -29,6 +29,7 @@ export type {
   ResolvedReelGridConfig,
   MultiWaysConfig,
   ReelAnchor,
+  SpinOptions,
 } from './config/types.js';
 export type { ReelMaskRect, MaskStrategy } from './core/ReelViewport.js';
 export { RectMaskStrategy, SharedRectMaskStrategy } from './core/ReelViewport.js';

--- a/packages/pixi-reels/src/spin/SpinController.ts
+++ b/packages/pixi-reels/src/spin/SpinController.ts
@@ -15,6 +15,7 @@ import type { AnticipationPhaseConfig } from './phases/AnticipationPhase.js';
 import type { AdjustPhaseConfig } from './phases/AdjustPhase.js';
 import type { SpinningMode } from './modes/SpinningMode.js';
 import { StandardMode } from './modes/StandardMode.js';
+import type { SpinOptions } from '../config/types.js';
 import type { Disposable } from '../utils/Disposable.js';
 import { TickerRef } from '../utils/TickerRef.js';
 import { OCCUPIED_SENTINEL } from '../core/Reel.js';
@@ -92,6 +93,8 @@ export class SpinController implements Disposable {
   private _events: EventEmitter<ReelSetEvents>;
   private _tickerRef: TickerRef;
   private _spinningMode: SpinningMode;
+  private _defaultSpinMode: 'standard' | 'cascade';
+  private _currentSpinMode: 'standard' | 'cascade' = 'standard';
   private _hooks: SpinControllerHooks;
 
   private _isSpinning = false;
@@ -115,6 +118,7 @@ export class SpinController implements Disposable {
     events: EventEmitter<ReelSetEvents>,
     ticker: Ticker,
     spinningMode?: SpinningMode,
+    defaultSpinMode: 'standard' | 'cascade' = 'standard',
     hooks?: SpinControllerHooks,
   ) {
     this._reels = reels;
@@ -124,6 +128,7 @@ export class SpinController implements Disposable {
     this._events = events;
     this._tickerRef = new TickerRef(ticker);
     this._spinningMode = spinningMode ?? new StandardMode();
+    this._defaultSpinMode = defaultSpinMode;
     this._hooks = hooks ?? {
       isMultiWaysSlot: false,
       symbolsData: {},
@@ -148,10 +153,18 @@ export class SpinController implements Disposable {
     return this._isDestroyed;
   }
 
-  async spin(): Promise<SpinResult> {
+  async spin(opts?: SpinOptions): Promise<SpinResult> {
     if (this._isSpinning) {
       throw new Error('Cannot start a new spin while one is in progress.');
     }
+
+    const mode = opts?.mode ?? this._defaultSpinMode;
+    if (mode === 'cascade' && !this._phaseFactory.has('dropStart')) {
+      throw new Error(
+        "spin({ mode: 'cascade' }) requires .cascade(...) on the builder.",
+      );
+    }
+    this._currentSpinMode = mode;
 
     this._isSpinning = true;
     this._wasSkipped = false;
@@ -317,8 +330,12 @@ export class SpinController implements Disposable {
 
     const reel = this._reels[reelIndex];
 
+    const phaseKeys = this._currentSpinMode === 'cascade'
+      ? { start: 'dropStart', stop: 'dropStop' }
+      : { start: 'start', stop: 'stop' };
+
     // START → SPIN: chain via phase.run() promises (no busy-polling).
-    const startPhase = this._phaseFactory.create<any>('start', reel, speed);
+    const startPhase = this._phaseFactory.create<any>(phaseKeys.start, reel, speed);
     this._activePhases.set(reelIndex, startPhase);
     await startPhase.run({
       spinningMode: this._spinningMode,
@@ -366,7 +383,7 @@ export class SpinController implements Disposable {
       this._events.emit('spin:stopping', reelIndex);
     }
 
-    const stopPhase = this._phaseFactory.create<any>('stop', reel, speed);
+    const stopPhase = this._phaseFactory.create<any>(phaseKeys.stop, reel, speed);
     this._activePhases.set(reelIndex, stopPhase);
     await stopPhase.run({ targetFrame, delay: stopDelay } as StopPhaseConfig);
     if (generation !== this._spinGeneration) return;

--- a/packages/pixi-reels/tests/unit/perSpinMode.test.ts
+++ b/packages/pixi-reels/tests/unit/perSpinMode.test.ts
@@ -1,0 +1,80 @@
+import type { Ticker } from 'pixi.js';
+import { describe, expect, it } from 'vitest';
+import { ReelSetBuilder } from '../../src/core/ReelSetBuilder.js';
+import { DropRecipes } from '../../src/cascade/DropRecipes.js';
+import { FakeTicker } from '../../src/testing/FakeTicker.js';
+import { HeadlessSymbol } from '../../src/testing/HeadlessSymbol.js';
+
+interface Harness {
+  reelSet: ReturnType<ReelSetBuilder['build']>;
+  ticker: FakeTicker;
+  created: string[];
+  destroy(): void;
+}
+
+function buildHarness(opts: { withCascade: boolean }): Harness {
+  const ticker = new FakeTicker();
+  const created: string[] = [];
+  const builder = new ReelSetBuilder()
+    .reels(1)
+    .visibleSymbols(2)
+    .symbolSize(100, 100)
+    .ticker(ticker as unknown as Ticker)
+    .symbols((r) => r.register('a', HeadlessSymbol, {}))
+    .phases((factory) => {
+      const original = factory.create.bind(factory);
+      factory.create = ((name: string, reel, speed) => {
+        const phase = original(name, reel, speed);
+        created.push(`${name}:${phase.constructor.name}`);
+        return phase;
+      }) as typeof factory.create;
+    });
+  if (opts.withCascade) builder.cascade(DropRecipes.cascadeDrop);
+  const reelSet = builder.build();
+  return {
+    reelSet,
+    ticker,
+    created,
+    destroy() {
+      reelSet.destroy();
+      ticker.destroy();
+    },
+  };
+}
+
+async function runSkippedSpin(h: Harness, mode?: 'standard' | 'cascade'): Promise<void> {
+  const p = mode ? h.reelSet.spin({ mode }) : h.reelSet.spin();
+  h.reelSet.setResult([['a', 'a']]);
+  h.reelSet.skip();
+  await p;
+}
+
+describe('ReelSet.spin — per-spin mode', () => {
+  it('throws if cascade mode is requested without .cascade(...)', async () => {
+    const h = buildHarness({ withCascade: false });
+    await expect(h.reelSet.spin({ mode: 'cascade' })).rejects.toThrow(/cascade/);
+    h.destroy();
+  });
+
+  it('switches phase chain per spin via opts.mode', async () => {
+    const h = buildHarness({ withCascade: true });
+
+    await runSkippedSpin(h, 'standard');
+    expect(h.created).toContain('start:StartPhase');
+
+    h.created.length = 0;
+    await runSkippedSpin(h, 'cascade');
+    expect(h.created).toContain('dropStart:DropStartPhase');
+
+    h.destroy();
+  });
+
+  it('uses cascade as the default when .cascade(...) was called', async () => {
+    const h = buildHarness({ withCascade: true });
+
+    await runSkippedSpin(h);
+    expect(h.created).toContain('dropStart:DropStartPhase');
+
+    h.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

  - New `ReelSet.spin({ mode: 'standard' | 'cascade' })` overrides the phase chain for a single spin
  - `.cascade(...)` registers drop-in phases under `dropStart` / `dropStop` keys — no longer overwrites `start` / `stop`
  - Default mode flips to `'cascade'` when `.cascade(...)` was called, preserving existing behaviour for callers that
  don't pass `{ mode }`
  - `spin({ mode: 'cascade' })` without `.cascade(...)` configured throws a clear error
  - New `SpinOptions` type exported from the barrel

  ## Files touched

  - `packages/pixi-reels/src/config/types.ts` — `SpinOptions` (with inline `mode?: 'standard' | 'cascade'`).
  - `packages/pixi-reels/src/spin/SpinController.ts` — `defaultSpinMode` ctor arg, `spin(opts)` signature, per-spin
  phase-key resolution.
  - `packages/pixi-reels/src/core/ReelSetBuilder.ts` — `.cascade(...)` registers under `dropStart` / `dropStop` and
  flips default mode.
  - `packages/pixi-reels/src/core/ReelSet.ts` — `spin(opts)` passthrough, `defaultSpinMode` wired.
  - `packages/pixi-reels/src/index.ts` — re-export `SpinOptions`.
  - `packages/pixi-reels/tests/unit/perSpinMode.test.ts` (new) — 3 cases.

  ## Test plan

  - [x] `pnpm --filter pixi-reels test` (217/217)
  - [x] `pnpm typecheck` + `pnpm check:lint`
  - [x] Manually verified in a downstream game: classic strip-spin on `mode: 'standard'`, cascade drop-in on `mode:
  'cascade'`.