### PR TITLE
fix(frame): initialFrame negative indices now populate buffer-above slots

### DIFF
--- a/.changeset/frame-builder-negative-index-buffer-above.md
+++ b/.changeset/frame-builder-negative-index-buffer-above.md
@@ -2,4 +2,4 @@
 'pixi-reels': patch
 ---
 
-Fix: negative indices in `initialFrame` and `setResult` now correctly populate buffer-above slots. Setting `frame[col][-1]` (or `[-2]` for deeper buffers) places the symbol in the corresponding buffer-above cell instead of being silently ignored.
+Fix: negative indices in `initialFrame` now correctly populate buffer-above slots. Setting `frame[col][-1]` (or `[-2]` for deeper buffers) places the symbol in the corresponding buffer-above cell instead of being silently ignored.

--- a/.changeset/frame-builder-negative-index-buffer-above.md
+++ b/.changeset/frame-builder-negative-index-buffer-above.md
@@ -1,0 +1,5 @@
+---
+'pixi-reels': patch
+---
+
+Fix: negative indices in `initialFrame` and `setResult` now correctly populate buffer-above slots. Setting `frame[col][-1]` (or `[-2]` for deeper buffers) places the symbol in the corresponding buffer-above cell instead of being silently ignored.

--- a/packages/pixi-reels/src/frame/FrameBuilder.ts
+++ b/packages/pixi-reels/src/frame/FrameBuilder.ts
@@ -154,9 +154,9 @@ class TargetPlacementMiddleware implements FrameMiddleware {
 
   process(context: FrameContext, next: () => void): void {
     if (context.targetSymbols) {
-      for (let row = 0; row < context.targetSymbols.length; row++) {
+      for (let row = -context.bufferAbove; row < context.targetSymbols.length; row++) {
         const idx = context.bufferAbove + row;
-        if (idx < context.symbols.length) {
+        if (context.targetSymbols[row] && idx < context.symbols.length) {
           context.symbols[idx] = context.targetSymbols[row];
         }
       }

--- a/packages/pixi-reels/tests/unit/FrameBuilder.test.ts
+++ b/packages/pixi-reels/tests/unit/FrameBuilder.test.ts
@@ -73,6 +73,37 @@ describe('FrameBuilder', () => {
     expect(order).toEqual([5, 20]);
   });
 
+  it('places target symbol in buffer-above slot via negative index', () => {
+    const builder = createBuilder();
+    const target = ['x', 'y', 'z'];
+    target[-1] = 'bufAbove'; // JS string property "-1" — buffer-above convention
+    const frame = builder.build(0, 3, 1, 1, target);
+    expect(frame[0]).toBe('bufAbove'); // slot 0 = buffer above
+    expect(frame[1]).toBe('x');
+    expect(frame[2]).toBe('y');
+    expect(frame[3]).toBe('z');
+  });
+
+  it('places target symbols in multiple buffer-above slots (bufferAbove = 2)', () => {
+    const builder = createBuilder();
+    const target = ['x', 'y', 'z'];
+    target[-1] = 'above1'; // closest to visible area  →  symbols[1]
+    target[-2] = 'above2'; // furthest above            →  symbols[0]
+    const frame = builder.build(0, 3, 2, 1, target); // bufferAbove = 2, total = 6
+    expect(frame[0]).toBe('above2');
+    expect(frame[1]).toBe('above1');
+    expect(frame[2]).toBe('x');
+    expect(frame[3]).toBe('y');
+    expect(frame[4]).toBe('z');
+  });
+
+  it('places target symbol in buffer-below slot via index >= visibleRows', () => {
+    const builder = createBuilder();
+    const target = ['x', 'y', 'z', 'bufBelow'];
+    const frame = builder.build(0, 3, 1, 1, target);
+    expect(frame[4]).toBe('bufBelow'); // buffer below
+  });
+
   it('remove middleware works', () => {
     const builder = createBuilder();
     const fn = vi.fn();


### PR DESCRIPTION
JS stores `arr[-1]` as the string property `"-1"` on the array object — a standard for-loop starting at `0` never visits it, so buffer-above cells were silently skipped while buffer-below (`arr[visibleRows]`) worked fine.

Fix: start the `TargetPlacementMiddleware` loop at `-bufferAbove` so that `arr[-1]`, `arr[-2]`, … are visited via their string properties and mapped to the correct buffer-above slots.

## Summary

`TargetPlacementMiddleware` silently dropped buffer-above symbols set via negative indices (`initialFrame[col][-1]`). In JS, `arr[-1] = 'X'` sets a string property `"-1"` on the array object — a loop starting at `0` never visits it. Buffer-below worked because `arr[visibleRows]` is a real numeric index.

## Changes

- `packages/pixi-reels/src/frame/FrameBuilder.ts` — start `TargetPlacementMiddleware` loop at `-bufferAbove` instead of `0`; add truthiness guard so unset negative slots fall through to random fill
- `packages/pixi-reels/tests/unit/FrameBuilder.test.ts` — three new cases: buffer-above with `bufferAbove=1`, buffer-above with `bufferAbove=2`, buffer-below regression

## Test plan

- [x] `pnpm test` — 290 passed
- [x] `pnpm --filter pixi-reels typecheck` — clean

## Changeset

- [x] This PR ships user-visible changes in a publishable package and a `.changeset/*.md` file is included.

## Related issues

Closes #114
