### PR TITLE
ci(changeset-gate): exempt auto-generated Version Packages PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,15 @@ jobs:
 
   changeset-gate:
     # Fails the PR when library source changed but no changeset file was added.
-    # Escape hatch: apply the `skip-changeset` label (docs/CI-only PRs, reverts).
-    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changeset')
+    # Escape hatches:
+    #   - `skip-changeset` label (docs/CI-only PRs, reverts, dependabot dev-dep bumps).
+    #   - `changeset-release/main` head ref (the auto-generated "Version Packages" PR
+    #     from changesets/action only DELETES changesets to consume them, so it
+    #     would otherwise be perpetually red).
+    if: >-
+      github.event_name == 'pull_request'
+      && !contains(github.event.pull_request.labels.*.name, 'skip-changeset')
+      && github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Every release cycle, [`changesets/action`](https://github.com/changesets/action) opens a PR titled "chore: version packages" on the `changeset-release/main` branch. That PR's whole job is to **consume** every pending \`.changeset/*.md\` file — deleting them, bumping \`packages/pixi-reels/package.json\`, and appending \`CHANGELOG.md\`. The current changeset-gate trips on it because:

1. \`packages/pixi-reels/package.json\` is modified (the version field).
2. \`git diff --diff-filter=A -- '.changeset/*.md'\` returns zero — the bot only deletes.

So the gate fails on every release PR. We've been working around it manually with the \`skip-changeset\` label (e.g. [#117](https://github.com/schmooky/pixi-reels/pull/117) just now), but that requires remembering to label every time.

## Fix

Add a second skip condition keyed on the head ref:

\`\`\`yaml
if: >-
  github.event_name == 'pull_request'
  && !contains(github.event.pull_request.labels.*.name, 'skip-changeset')
  && github.head_ref != 'changeset-release/main'
\`\`\`

Narrower than \`actor == 'github-actions[bot]'\` — won't accidentally exempt dependabot or other bots. The branch name is what \`changesets/action\` actually uses (\`changeset-release/<base-branch>\`).

## Why not just always label?

The label still works as a per-PR escape hatch (we use it for dependabot dev-dep bumps too, e.g. [#107](https://github.com/schmooky/pixi-reels/pull/107)). This adds a permanent carve-out for the **one** PR pattern that's mechanically guaranteed to fail the gate, so the release flow doesn't require human label-toggling every cycle.

## Test plan

- [x] \`yaml\` parses (the change is one-line in spirit, wrapped for readability).
- [ ] CI runs on this PR — should pass cleanly since this PR doesn't touch \`packages/pixi-reels/**\` so the gate is a no-op anyway.
- [ ] Next release cycle: the auto-generated Version Packages PR should land green without needing the \`skip-changeset\` label.

## Changeset

None — this is CI-only, no library change. \`skip-changeset\` label applied accordingly.