### PR TITLE
feat(big-symbols): support buffer-row anchors (partial-visibility landings)

### DIFF
--- a/.changeset/big-symbols-in-buffer.md
+++ b/.changeset/big-symbols-in-buffer.md
@@ -10,4 +10,6 @@ The validation error message changed: `exceeds reel height` was visible-only; no
 
 `getSymbolFootprint` may return a negative `anchor.row` for blocks anchored in bufferAbove. `getBlockBounds` handles this by computing pixel coordinates from the row offset directly rather than delegating to `getCellBounds` (which still rejects negative rows). Consumers reading `anchor.row` should accept negative values.
 
-Live recipe: `/recipes/big-symbol-partial-land/`.
+Fix: `ReelMotion._maxY` was hard-coded to `(visibleRows + 1) * slotH`, which collapsed to `strip[last].y` exactly when `bufferBelow >= 2` and fired a phantom wrap on the first nudge displacement — the anchor landed one strip slot too far. The threshold now scales with `bufferBelow` (`maxY = (visibleRows + bufferBelow) * slotH`), symmetric with the existing `minY = -(bufferAbove + 1) * slotH`. Nudges with `bufferBelow >= 2` now match the documented survival math.
+
+Live recipes: `/recipes/big-symbol-partial-land/`, `/recipes/big-symbol-held-respin/`.

--- a/.changeset/big-symbols-in-buffer.md
+++ b/.changeset/big-symbols-in-buffer.md
@@ -1,0 +1,13 @@
+---
+'pixi-reels': minor
+---
+
+Add: big-symbol anchors can now sit in bufferAbove or bufferBelow. The classic UK fruit-machine landing — a 1xH wild lands with most of it hidden above the visible window, only the bottom cell ("the tail") shows at row 0 — works end-to-end through `setResult`, `refill`, and `nudge`.
+
+`_coordinateBigSymbols` now iterates the full strip range (`-bufferAbove` to `visibleRows + bufferBelow`) and validates against strip capacity instead of just visible. Anchors at any strip slot are accepted as long as the block fits end-to-end. Pass an anchor at `bufferAbove[i]` via the explicit `ColumnTarget` form (`{ visible: [...], bufferAbove: [...] }`) or via the legacy `frame[col][-1]` negative-index form; the coordinator paints OCCUPIED stubs at the rest of the block's cells (in buffer, visible, or buffer-below as needed).
+
+The validation error message changed: `exceeds reel height` was visible-only; now reads `extends past the bottom of the strip` with the exact computed values. The new check is more permissive — a 1x4 block on a 3-visible-row reel with 1 bufferBelow is now LEGAL where it previously threw.
+
+`getSymbolFootprint` may return a negative `anchor.row` for blocks anchored in bufferAbove. `getBlockBounds` handles this by computing pixel coordinates from the row offset directly rather than delegating to `getCellBounds` (which still rejects negative rows). Consumers reading `anchor.row` should accept negative values.
+
+Live recipe: `/recipes/big-symbol-partial-land/`.

--- a/.changeset/big-symbols-internal-comments.md
+++ b/.changeset/big-symbols-internal-comments.md
@@ -4,5 +4,7 @@
 
 Internal: sharpen comments around the big-symbol coordinator's
 uniform-buffer assumption and `_finalizeFrame`'s scan asymmetry — both
-were silently load-bearing on contracts that weren't spelled out. No
-runtime change.
+were silently load-bearing on contracts that weren't spelled out.
+Also extends `ColumnTarget.bufferAbove` / `bufferBelow` JSDoc to
+explicitly document the big-symbol anchor capability — discoverable
+in IDE tooltips. No runtime change.

--- a/.changeset/big-symbols-internal-comments.md
+++ b/.changeset/big-symbols-internal-comments.md
@@ -1,0 +1,8 @@
+---
+'pixi-reels': patch
+---
+
+Internal: sharpen comments around the big-symbol coordinator's
+uniform-buffer assumption and `_finalizeFrame`'s scan asymmetry — both
+were silently load-bearing on contracts that weren't spelled out. No
+runtime change.

--- a/.changeset/columntarget-buffer-overflow-throw.md
+++ b/.changeset/columntarget-buffer-overflow-throw.md
@@ -1,0 +1,11 @@
+---
+'pixi-reels': patch
+---
+
+Fix: `ReelSet.setResult` and `ReelSetBuilder.initialFrame` now throw a `RangeError` when a `ColumnTarget.bufferAbove` / `bufferBelow` carries more entries than the engine's configured `bufferSymbols(...)`, instead of silently dropping the extras.
+
+Previously, calling `.bufferSymbols(1)` and passing `bufferAbove: ['X', 'Y']` would materialize both `arr[-1]='X'` and `arr[-2]='Y'`, but the next clone (`cloneColumn`) only iterates `-1..-bufferAbove` — `Y` was written to the array, dropped on the next pass, and never reached the reel. No error, no warning; the only symptom was "my targeted symbol never lands." Same problem on the `bufferBelow` side via indices past `visible + bufferBelow`.
+
+The check now fails fast at the API entry point with a column-pointing message: `setResult column 2: bufferAbove has 2 entries but engine bufferSymbols=1 — extra entries would be silently dropped. Increase bufferSymbols(...) on the builder or remove the extra entries.` The legacy `frame[col][-k]` form is also validated for negative-index keys beyond `-bufferAbove`. The legacy form's array `length` is intentionally not checked — in MultiWays the per-reel `visibleRows` changes between `setShape()` and `setResult()`, and any length-based check would false-positive on legitimate post-reshape calls.
+
+This is user-visible error behavior: input that previously silently failed now throws. Callers passing more entries than the configured buffer size should either increase `bufferSymbols(...)` or trim the extra entries.

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -6,7 +6,7 @@ Site: https://pixi-reels.schmooky.dev
 Repo: https://github.com/schmooky/pixi-reels
 Package: https://www.npmjs.com/package/pixi-reels
 
-Generated: 2026-05-17T11:31:54.688Z
+Generated: 2026-05-21T21:45:33.313Z
 
 ## Quick start
 
@@ -61,6 +61,10 @@ Install pixi-reels and run your first reel set in under 2 minutes.
 ### MultiWays
 URL: https://pixi-reels.schmooky.dev/guides/multiways/
 Per-spin row variation. Each reel can land on a different row count between minRows and maxRows, with cell height derived from a fixed reel pixel height. The engine reshapes each reel between SPIN and STOP and AdjustPhase tweens any pin overlays; pins migrate via originRow.
+
+### Nudge
+URL: https://pixi-reels.schmooky.dev/guides/nudge/
+Push a reel down or up by one or more positions after it has stopped — the classic UK fruit-machine nudge.
 
 ### Per-reel geometry
 URL: https://pixi-reels.schmooky.dev/guides/per-reel-geometry/
@@ -157,6 +161,28 @@ Steps:
   - Call setAnticipation([...reels]) to slow specific reels before they land
   - Set result[col][-1] = HIGH_VALUE on those same reels to pin a symbol just above the visible area
   - During the anticipation decelerate, the symbol is visible at the top edge of the reel
+
+### Hold a buffer-anchored big symbol across a respin
+URL: https://pixi-reels.schmooky.dev/recipes/big-symbol-held-respin/
+A tall wild lands with its anchor in bufferAbove (tail visible at row 0). Hold that reel via spin holdReels, respin the others, then nudge to drag the wild into full view. The held reel preserves the block end-to-end across the no-op spin.
+Tags: big-symbols, buffer, hold-reels, respin, nudge
+APIs: ReelSet.spin, SpinOptions.holdReels, ReelSet.setResult, ColumnTarget.bufferAbove, ReelSet.nudge
+Steps:
+  - Land a 1xH wild with its anchor in bufferAbove on the trigger reel — only the bottom cell of the block shows at row 0
+  - Call reelSet.spin with holdReels including the trigger reel to skip START/SPIN/STOP on that column
+  - Pass a full-width grid to setResult — the held column entry is ignored
+  - Nudge the held reel after the respin to drag the full block into visibility
+
+### Land a big symbol partially in buffer
+URL: https://pixi-reels.schmooky.dev/recipes/big-symbol-partial-land/
+A tall 1xH block lands with its anchor in bufferAbove — only the bottom cell shows at the top of the visible window. Nudge to drag the rest into view. Works end-to-end through setResult, refill, nudge, and the cross-reel resolver.
+Tags: big-symbols, buffer, nudge, recent
+APIs: ReelSet.setResult, SymbolData.size, ColumnTarget.bufferAbove, ColumnTarget.bufferBelow, ReelSet.getSymbolFootprint
+Steps:
+  - Pass an anchor at `bufferAbove[i]` via the explicit `ColumnTarget` form (or row `-i-1` via legacy negative-index)
+  - Coordinator paints OCCUPIED at the rest of the block's cells (negative rows, visible rows, or bufferBelow as needed)
+  - `_finalizeFrame` sizes the anchor sprite to span the whole block; the mask clips the off-screen portion
+  - `getVisibleSymbols` resolves visible cells to the anchor id via a NEGATIVE `anchorRow` in `_occupancy`
 
 ### MxN big symbols — every shape
 URL: https://pixi-reels.schmooky.dev/recipes/big-symbols-mxn/
@@ -344,6 +370,72 @@ Steps:
   - Build a result grid with count - 1 scatters, none on the near reel
   - setAnticipation([nearReelIndex]) BEFORE setResult()
   - Let the player feel the hold on the last reel
+
+### How to nudge a reel
+URL: https://pixi-reels.schmooky.dev/recipes/nudge/
+Shift one reel down or up by N positions after it has landed — the classic UK fruit-machine nudge, with the reveal symbols supplied by the caller.
+Tags: nudge, fruit-machine, recent
+APIs: ReelSet.nudge, NudgeOptions, nudge:start, nudge:complete
+Steps:
+  - Wait for spin() to land
+  - Call reelSet.nudge(col, { distance, direction, incoming }) — incoming is required, top-down order of the new visible positions
+  - Await the promise to read the new visible column for re-running win detection
+  - For multi-reel beats, wrap several nudge() calls in Promise.all([...])
+
+### Abort a nudge
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-abort/
+Cancel a running nudge via AbortSignal — the strip still snaps to its deterministic landed position, but the `nudge()` promise rejects with `AbortError` and `nudge:cancelled` fires on the bus.
+Tags: nudge, abort, cancellation, signal, recent
+APIs: NudgeOptions.signal, AbortController, nudge:cancelled
+Steps:
+  - Wire an `AbortController` into `NudgeOptions.signal`
+  - Trigger the abort while the tween is running
+  - Catch `AbortError` to take the cancellation path; non-abort errors re-throw
+  - `nudge:cancelled` fires on the bus carrying the cancellation reason
+
+### Nudge through a big symbol
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-big-symbol/
+A 1xH block on the target reel is nudged through as a unit. The engine survival-checks anchor + h fits on the strip post-rotation; cross-reel (w>1) blocks still throw.
+Tags: nudge, big-symbols, block, recent
+APIs: ReelSet.nudge, SymbolData.size
+Steps:
+  - Land with a 1x2 MEGA wild at column 2, rows 0+1
+  - Nudge column 2 DOWN by 2 — block survives (`1 + 2 - 1 + 2 < 5`) and anchor lands at row 2 with stub in bufferBelow
+  - Nudge column 2 UP by 1 — block returns to rows 1+2, fully visible
+  - The whole block moves as a unit; the wrap mechanism never splits anchor from stubs
+
+### Skip an in-flight nudge
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-skip/
+Fast-forward a running nudge tween to its landed state with `reelSet.skipNudge(col)`. The original `nudge()` promise resolves normally — the consumer's success path still runs.
+Tags: nudge, skip, ux, recent
+APIs: ReelSet.skipNudge, Reel.isNudging
+Steps:
+  - Run a long sequential nudge (1.5s per reel) so the player has time to react
+  - The canvas button morphs into a skip icon while the recipe handler is running
+  - Tap during a nudge — the RecipeRunner detects an in-flight nudge and calls `reelSet.skipNudge()`
+  - The original `nudge()` promise resolves at the deterministic landed position
+
+### Spotlight after a nudge
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-spotlight/
+Land a near-miss, nudge three reels down by one to complete a wild line across the top row, then run SymbolSpotlight on the new winners — the canonical "rescue spin via nudge, then celebrate" beat.
+Tags: nudge, spotlight, wins, fruit-machine, recent
+APIs: ReelSet.nudge, ReelSet.spotlight.show, ReelSet.spotlight.hide, nudge:complete
+Steps:
+  - Spin and land on a flat result with no wilds anywhere
+  - Promise.all three `reelSet.nudge(col, ...)` calls so the middle reels drop in `wild` at row 0 together
+  - Build the winning cells (row 0 on each nudged reel) and call `reelSet.spotlight.show(cells, ...)`
+  - Await spotlight completion, then `spotlight.hide()` to return the symbols to the grid
+
+### Staggered nudge — wave reveal
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-stagger/
+Use `NudgeOptions.startDelay` inside a `Promise.all([...])` to dispatch parallel nudges with a per-reel offset. Reads as a wave — faster than sequential, more theatrical than synchronised parallel.
+Tags: nudge, stagger, wave, ux, recent
+APIs: ReelSet.nudge, NudgeOptions.startDelay
+Steps:
+  - Map over the target reels with `Promise.all(cols.map(...))`
+  - Pass `startDelay: i * STAGGER_MS` per call so each reel waits a beat longer to begin
+  - All tweens run concurrently — total wall time = last reel's delay + duration
+  - Validation throws still fire synchronously; only the mutation is deferred
 
 ### Custom per-symbol animation
 URL: https://pixi-reels.schmooky.dev/recipes/paylines-custom-animation/
@@ -720,6 +812,255 @@ return {
     reelSet.setAnticipation([3, 4]);
     reelSet.setResult(result);
     await p;
+  },
+};
+```
+
+### big-symbol-held-respin
+URL: https://pixi-reels.schmooky.dev/recipes/big-symbol-held-respin/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   PIXI, app
+
+// HELD-REEL RESPIN with a buffer-anchored big symbol.
+//
+// Classic UK fruit-machine bonus: reel 3 lands with a tall wild whose
+// anchor sits in bufferAbove (only the tail of the block shows at row 0
+// — "the wild is peeking in from the top"). The player gets a re-spin of
+// the OTHER reels; reel 3 is held. The held reel preserves the block
+// across spins because `SpinOptions.holdReels` skips START/SPIN/STOP on
+// the held column — the strip array, the anchor's size, and the
+// occupancy map all carry through.
+//
+// Sequence:
+//   1. Spin all reels; land tail-visible 1x3 wild on reel 2 (column index 2).
+//   2. Respin reels 0, 1, 3, 4 with `holdReels: [2]`. Reel 2 stays put
+//      (block intact, tail visible).
+//   3. Player nudges reel 2 down by 2 to drag the block into full view.
+//
+// What this proves:
+//   - `holdReels` + buffer-anchored block: the held reel's `_finalizeFrame`
+//     state is preserved (occupancy + anchor size).
+//   - `_coordinateBigSymbols` runs on the result grid passed by the
+//     player for the non-held reels; the held column's placeholder entry
+//     is ignored.
+//   - A nudge AFTER the respin still moves the held block intact —
+//     proving the strip layout survived the no-op spin.
+
+const TALL = { id: 'tall', color: 0xff8c42, label: 'TALL', textColor: 0x4a1d00, w: 1, h: 3 };
+const REELS = 5;
+const HELD_REEL = 2;
+const ROWS = 3;
+const SIZE = 80;
+const GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS)
+  .visibleSymbols(ROWS)
+  // bufferAbove >= 2 lets the 1x3 anchor sit at row -2 (block extends
+  // through row 0 — tail visible).
+  .bufferSymbols(2)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .symbols((registry) => {
+    for (const card of CARD_DECK) {
+      registry.register(card.id, CardSymbol, {
+        color: card.color, label: card.label, textColor: card.textColor,
+      });
+    }
+    registry.register(TALL.id, CardSymbol, {
+      color: TALL.color, label: TALL.label, textColor: TALL.textColor,
+    });
+  })
+  .weights(Object.fromEntries(CARD_DECK.map((c, i) => [c.id, 12 - i])))
+  .symbolData({ [TALL.id]: { weight: 0, zIndex: 5, size: { w: TALL.w, h: TALL.h } } })
+  .speed('normal', { ...SpeedPresets.NORMAL, bounceDistance: 0, bounceDuration: 0 })
+  .ticker(app.ticker)
+  .build();
+
+const FILLER_IDS = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER_IDS[Math.floor(Math.random() * FILLER_IDS.length)];
+const ct = () => ({ visible: [filler(), filler(), filler()] });
+
+return {
+  reelSet,
+  onSpin: async () => {
+    // ── 1. Initial spin lands the tail-visible wild on reel 2. ──────
+    const initialGrid = [
+      ct(), ct(),
+      // Reel 2: anchor at bufferAbove[1] = row -2. Block spans rows
+      // -2, -1, 0. Only row 0 shows the block's bottom cell.
+      { visible: [filler(), filler(), filler()], bufferAbove: [undefined, TALL.id] },
+      ct(), ct(),
+    ];
+    const spin1 = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 240));
+    reelSet.setResult(initialGrid);
+    await spin1;
+    await new Promise((r) => setTimeout(r, 900));
+
+    // ── 2. Respin everything EXCEPT reel 2. ─────────────────────────
+    //
+    // `holdReels: [HELD_REEL]` tells the engine to skip START/SPIN/STOP
+    // on reel 2 entirely. The grid we pass below MUST include all 5
+    // columns (every shipped slot expects a full grid), but the entry at
+    // index 2 is ignored — the held reel keeps whatever it had.
+    //
+    // The block on reel 2 (anchor at strip[0], stubs at strip[1..2])
+    // survives because:
+    //   - no motion runs on reel 2 (strip array unchanged)
+    //   - `_finalizeFrame` doesn't re-run (occupancy unchanged)
+    //   - the anchor's sized sprite stays at its post-land dimensions
+    //
+    // We hand the held column a ColumnTarget so the input shape is
+    // homogeneous — `setResult` rejects mixed `string[] | ColumnTarget`
+    // grids. The held entry's contents are not validated against the
+    // current strip; they're simply dropped during frame building.
+    const respinGrid = [
+      ct(), ct(),
+      ct(), // ignored — reel 2 is held
+      ct(), ct(),
+    ];
+    const spin2 = reelSet.spin({ holdReels: [HELD_REEL] });
+    await new Promise((r) => setTimeout(r, 240));
+    reelSet.setResult(respinGrid);
+    await spin2;
+    await new Promise((r) => setTimeout(r, 900));
+
+    // ── 3. Nudge the held reel DOWN by 2 to reveal the full block. ──
+    //
+    // Survival check (down): anchor strip index (0) + h - 1 + distance =
+    // 0 + 3 - 1 + 2 = 4 < total 7 ✓. The block moves as a unit from
+    // strip[0..2] to strip[2..4]. Visible[0..2] = ['tall', 'tall', 'tall'].
+    await reelSet.nudge(HELD_REEL, {
+      distance: 2,
+      direction: 'down',
+      incoming: [filler(), filler()],
+      duration: 620,
+    });
+  },
+};
+```
+
+### big-symbol-partial-land
+URL: https://pixi-reels.schmooky.dev/recipes/big-symbol-partial-land/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   PIXI, app
+
+// PARTIAL-LAND pattern.
+//
+// A tall 1x3 wild lands with its ANCHOR in bufferAbove — most of the
+// block is hidden above the visible window, only its bottom cell shows
+// at row 0 ("tail visible"). The player nudges DOWN by 2 to drag the
+// whole block into view, then nudges UP by 2 to push it back into
+// hiding. The classic "the big symbol is peeking — nudge to reveal"
+// fruit-machine beat.
+//
+// This is enabled by:
+//   - `_coordinateBigSymbols` scans the full strip range (including
+//     bufferAbove and bufferBelow) for big-symbol anchors. The user
+//     supplies the anchor at `bufferAbove[1]`; the engine paints
+//     OCCUPIED at `bufferAbove[0]` and `visible[0]` automatically.
+//   - `_finalizeFrame` sizes anchors that sit in bufferAbove with the
+//     block's body extending into visible. The mask clips the off-screen
+//     portion; the visible portion of the sprite shows through.
+//   - `getVisibleSymbols` resolves visible row 0 to the anchor's id via
+//     a NEGATIVE `anchorRow` in `_occupancy`.
+
+const TALL = { id: 'tall', color: 0xff8c42, label: 'TALL', textColor: 0x4a1d00, w: 1, h: 3 };
+const REELS = 5;
+const ROWS = 3;
+const SIZE = 80;
+const GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS)
+  .visibleSymbols(ROWS)
+  // Need bufferAbove >= 2 so the 1x3 block's anchor can sit at row -2
+  // with the block extending through row 0.
+  .bufferSymbols(2)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .symbols((registry) => {
+    for (const card of CARD_DECK) {
+      registry.register(card.id, CardSymbol, {
+        color: card.color, label: card.label, textColor: card.textColor,
+      });
+    }
+    registry.register(TALL.id, CardSymbol, {
+      color: TALL.color, label: TALL.label, textColor: TALL.textColor,
+    });
+  })
+  .weights(Object.fromEntries(CARD_DECK.map((c, i) => [c.id, 12 - i])))
+  .symbolData({ [TALL.id]: { weight: 0, zIndex: 5, size: { w: TALL.w, h: TALL.h } } })
+  // Big symbols don't tolerate the default landing bounce — zero it.
+  .speed('normal', { ...SpeedPresets.NORMAL, bounceDistance: 0, bounceDuration: 0 })
+  .ticker(app.ticker)
+  .build();
+
+const FILLER_IDS = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER_IDS[Math.floor(Math.random() * FILLER_IDS.length)];
+const ct = () => ({ visible: [filler(), filler(), filler()] });
+
+return {
+  reelSet,
+  onSpin: async () => {
+    // 1. Land the 1x3 TALL with anchor at `bufferAbove[1]` (= row -2).
+    //    Block spans rows -2, -1, 0. Only visible row 0 shows the block's
+    //    bottom cell; rows 1 and 2 are random fillers.
+    //
+    //    The engine paints OCCUPIED at row -1 and row 0 automatically;
+    //    we leave `bufferAbove[0]` undefined and `visible[0]` as filler
+    //    (both get overwritten by the coordinator).
+    //
+    //    NOTE: `setResult` requires every column to use the same input
+    //    shape (string[] OR ColumnTarget — never mixed). The other reels
+    //    are also ColumnTargets even though they don't need buffer entries.
+    const grid = [
+      ct(), ct(),
+      { visible: [filler(), filler(), filler()], bufferAbove: [undefined, TALL.id] },
+      ct(), ct(),
+    ];
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 220));
+    reelSet.setResult(grid);
+    await p;
+    await new Promise((r) => setTimeout(r, 700));
+
+    // 2. Nudge DOWN by 2 — anchor moves from row -2 to row 0; block now
+    //    fills visible rows 0, 1, 2. Fully visible.
+    //
+    //    Survival check (down): anchor strip index + h - 1 + distance < total
+    //    (0 + 3 - 1 + 2 = 4 < 7) — total = bufferAbove(2) + visibleRows(3) +
+    //    bufferBelow(2). The block stays on the strip end-to-end.
+    //
+    //    `incoming` is the new visible-area content arriving from the top.
+    //    Buffer slots and big-symbol cells (anchor / OCCUPIED stubs) are
+    //    protected during pre-placement, so any incoming entries that would
+    //    land on a protected slot are dropped. Here every visible row is
+    //    consumed by the block, so the incoming pair is consumed by the
+    //    wrap pipeline (queue → random buffer fill) rather than appearing
+    //    on screen. Pass real ids regardless; the engine ignores unused ones.
+    await reelSet.nudge(2, {
+      distance: 2,
+      direction: 'down',
+      incoming: [filler(), filler()],
+      duration: 640,
+    });
+    await new Promise((r) => setTimeout(r, 800));
+
+    // 3. Nudge UP by 2 — anchor moves back from row 0 to row -2.
+    //    Survival check (up): anchor strip index - distance >= 0 (2 - 2 = 0).
+    //    Block returns to tail-visible state.
+    await reelSet.nudge(2, {
+      distance: 2,
+      direction: 'up',
+      incoming: [filler(), filler()],
+      duration: 540,
+    });
   },
 };
 ```
@@ -3067,6 +3408,712 @@ return {
     reelSet.setAnticipation([4]);
     reelSet.setResult(GRID);
     await p;
+  },
+};
+```
+
+### nudge-abort
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-abort/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   WILD_CARD, app
+
+// ABORT NUDGE pattern.
+//
+// The handler kicks off a 2s nudge with an AbortController whose signal
+// is wired into the call. ~700ms later the controller aborts — the GSAP
+// tween is killed, the strip still snaps to the deterministic landed
+// position (the contract is "incoming lands at these positions"), and
+// the `nudge()` promise REJECTS with an `AbortError`.
+//
+// The handler catches the AbortError, logs it, and moves on. `nudge:cancelled`
+// fires on the bus carrying the reason. Use abort for "tear it all down"
+// semantics — error path runs, follow-up steps are skipped. Use skipNudge
+// for "land it now" semantics (see /recipes/nudge-skip/) where the
+// success path should still run.
+
+const SYMBOLS = [...CARD_DECK, WILD_CARD];
+const FILLER = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER[Math.floor(Math.random() * FILLER.length)];
+const col3 = () => [filler(), filler(), filler()];
+
+const reelSet = new ReelSetBuilder()
+  .reels(5)
+  .visibleSymbols(3)
+  .symbolSize(72, 72)
+  .symbolGap(4, 4)
+  .symbols((r) => {
+    for (const sym of SYMBOLS) {
+      r.register(sym.id, CardSymbol, {
+        color: sym.color,
+        label: sym.label,
+        textColor: sym.textColor,
+      });
+    }
+  })
+  .speed('normal', SpeedPresets.NORMAL)
+  .ticker(app.ticker)
+  .build();
+
+reelSet.events.on('nudge:cancelled', (info) => {
+  console.log('[nudge:cancelled]', info);
+});
+
+return {
+  reelSet,
+  onSpin: async () => {
+    const p = reelSet.spin();
+    await new Promise((resolve) => setTimeout(resolve, 220));
+    reelSet.setResult([col3(), col3(), col3(), col3(), col3()]);
+    await p;
+    await new Promise((resolve) => setTimeout(resolve, 320));
+
+    const controller = new AbortController();
+    // Abort the nudge ~700ms in — the tween will be killed mid-flight.
+    setTimeout(() => {
+      console.log('aborting nudge after 700ms');
+      controller.abort();
+    }, 700);
+
+    try {
+      await reelSet.nudge(2, {
+        distance: 1,
+        direction: 'down',
+        incoming: ['wild'],
+        duration: 2000,
+        signal: controller.signal,
+      });
+      // Not reached on abort.
+      console.log('nudge completed normally');
+    } catch (err) {
+      if (err && err.name === 'AbortError') {
+        // Expected — clean up here. Strip is at its post-nudge landing
+        // position regardless, so subsequent reads are deterministic.
+        console.log('caught AbortError; strip still snapped to landed:', err.message);
+      } else {
+        throw err;
+      }
+    }
+  },
+};
+```
+
+### nudge-big-symbol
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-big-symbol/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   PIXI, app
+
+// NUDGE THROUGH A BIG SYMBOL.
+//
+// Demonstrates that a 1xH block on the target reel is nudged as a unit
+// when the rotation preserves the block. Sequence:
+//
+//   1. Land with a 1x2 "MEGA" wild at rows 0+1 (anchor at row 0).
+//   2. Nudge DOWN by 2 — anchor moves to row 2, stub spills into
+//      bufferBelow. Only the TOP half of the block is visible.
+//   3. Nudge UP by 1 — block snaps back into full visibility at rows 1+2.
+//
+// Survival check (down direction): anchorRow + h - 1 + distance < total.
+// For the down-by-2 step: 1 + 2 - 1 + 2 = 4 < 5 (with bufferAbove=1,
+// visibleRows=3, bufferBelow=1, total=5) — block fits.
+//
+// Cross-reel blocks (w > 1) throw; that case is intentionally excluded.
+
+const MEGA = { id: 'mega', color: 0xff8c42, label: 'MEGA', textColor: 0x4a1d00, w: 1, h: 2 };
+const REELS = 5;
+const ROWS = 3;
+const SIZE = 80;
+const GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS)
+  .visibleSymbols(ROWS)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .symbols((registry) => {
+    for (const card of CARD_DECK) {
+      registry.register(card.id, CardSymbol, {
+        color: card.color, label: card.label, textColor: card.textColor,
+      });
+    }
+    registry.register(MEGA.id, CardSymbol, {
+      color: MEGA.color, label: MEGA.label, textColor: MEGA.textColor,
+    });
+  })
+  .weights(Object.fromEntries(CARD_DECK.map((c, i) => [c.id, 12 - i])))
+  .symbolData({
+    [MEGA.id]: { weight: 0, zIndex: 5, size: { w: MEGA.w, h: MEGA.h } },
+  })
+  // Big symbols don't tolerate the default 56px landing bounce — zero it
+  // so the anchor lands flush on grid.
+  .speed('normal', { ...SpeedPresets.NORMAL, bounceDistance: 0, bounceDuration: 0 })
+  .ticker(app.ticker)
+  .build();
+
+const FILLER_IDS = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER_IDS[Math.floor(Math.random() * FILLER_IDS.length)];
+const col3 = () => [filler(), filler(), filler()];
+
+return {
+  reelSet,
+  onSpin: async () => {
+    // 1. Land a 1x2 MEGA wild at column 2, rows 0+1. The OCCUPIED stub
+    //    at row 1 is placed by the big-symbol coordinator inside setResult.
+    const grid = [col3(), col3(), [MEGA.id, MEGA.id, filler()], col3(), col3()];
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 220));
+    reelSet.setResult(grid);
+    await p;
+    await new Promise((r) => setTimeout(r, 500));
+
+    // 2. Nudge column 2 DOWN by 2. Survival: 1 + 2 - 1 + 2 = 4 < 5 ✓.
+    //    After: anchor at row 2, stub at bufferBelow → only top half of
+    //    the block is visible.
+    await reelSet.nudge(2, {
+      distance: 2,
+      direction: 'down',
+      incoming: [filler(), filler()],
+      duration: 600,
+    });
+    await new Promise((r) => setTimeout(r, 700));
+
+    // 3. Nudge UP by 1 to bring the full block back into view at rows 1+2.
+    //    Survival up: anchorRow (3) >= distance (1) ✓.
+    await reelSet.nudge(2, {
+      distance: 1,
+      direction: 'up',
+      incoming: [filler()],
+      duration: 480,
+    });
+  },
+};
+```
+
+### nudge-parallel
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-parallel/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   WILD_CARD, app
+
+// PARALLEL nudges — every reel's tween fires at the same frame via
+// `Promise.all([...])`. Reads as one synchronised beat; the whole row
+// of wilds drops into place together. Total time = duration (regardless
+// of how many reels you're nudging).
+
+const SYMBOLS = [...CARD_DECK, WILD_CARD];
+const FILLER = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER[Math.floor(Math.random() * FILLER.length)];
+const col3 = () => [filler(), filler(), filler()];
+
+const NUDGE_COLS = [1, 2, 3];
+const NUDGE_DURATION = 480;
+
+const reelSet = new ReelSetBuilder()
+  .reels(5)
+  .visibleSymbols(3)
+  .symbolSize(72, 72)
+  .symbolGap(4, 4)
+  .symbols((r) => {
+    for (const sym of SYMBOLS) {
+      r.register(sym.id, CardSymbol, {
+        color: sym.color,
+        label: sym.label,
+        textColor: sym.textColor,
+      });
+    }
+  })
+  .speed('normal', SpeedPresets.NORMAL)
+  .ticker(app.ticker)
+  .build();
+
+reelSet.events.on('nudge:start', (info) => {
+  console.log(`[par] nudge:start reel=${info.reelIndex}`);
+});
+reelSet.events.on('nudge:complete', (info) => {
+  console.log(`[par] nudge:complete reel=${info.reelIndex}`);
+});
+
+return {
+  reelSet,
+  onSpin: async () => {
+    const p = reelSet.spin();
+    await new Promise((resolve) => setTimeout(resolve, 220));
+    reelSet.setResult([col3(), col3(), col3(), col3(), col3()]);
+    await p;
+
+    // Let the eye settle on the landed board before the nudges begin.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // PARALLEL — every call fires synchronously; `Promise.all` only waits
+    // for the slowest one to finish. Total wall time = NUDGE_DURATION.
+    await Promise.all(
+      NUDGE_COLS.map((col) =>
+        reelSet.nudge(col, {
+          distance: 1,
+          direction: 'down',
+          incoming: ['wild'],
+          duration: NUDGE_DURATION,
+        }),
+      ),
+    );
+  },
+};
+```
+
+### nudge-sequential
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-sequential/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   WILD_CARD, app
+
+// SEQUENTIAL nudges — each reel waits for the previous reel's nudge to
+// land before starting. Reads as three deliberate beats; players can
+// follow each reveal individually. Total time = N * duration.
+
+const SYMBOLS = [...CARD_DECK, WILD_CARD];
+const FILLER = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER[Math.floor(Math.random() * FILLER.length)];
+const col3 = () => [filler(), filler(), filler()];
+
+const NUDGE_COLS = [1, 2, 3];
+const NUDGE_DURATION = 480;
+
+const reelSet = new ReelSetBuilder()
+  .reels(5)
+  .visibleSymbols(3)
+  .symbolSize(72, 72)
+  .symbolGap(4, 4)
+  .symbols((r) => {
+    for (const sym of SYMBOLS) {
+      r.register(sym.id, CardSymbol, {
+        color: sym.color,
+        label: sym.label,
+        textColor: sym.textColor,
+      });
+    }
+  })
+  .speed('normal', SpeedPresets.NORMAL)
+  .ticker(app.ticker)
+  .build();
+
+reelSet.events.on('nudge:start', (info) => {
+  console.log(`[seq] nudge:start reel=${info.reelIndex}`);
+});
+reelSet.events.on('nudge:complete', (info) => {
+  console.log(`[seq] nudge:complete reel=${info.reelIndex}`);
+});
+
+return {
+  reelSet,
+  onSpin: async () => {
+    const p = reelSet.spin();
+    await new Promise((resolve) => setTimeout(resolve, 220));
+    reelSet.setResult([col3(), col3(), col3(), col3(), col3()]);
+    await p;
+
+    // Let the eye settle on the landed board before the nudges begin.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // SEQUENTIAL — each `await` blocks the next iteration until this
+    // reel's tween finishes. Total wall time = NUDGE_COLS.length * NUDGE_DURATION.
+    for (const col of NUDGE_COLS) {
+      await reelSet.nudge(col, {
+        distance: 1,
+        direction: 'down',
+        incoming: ['wild'],
+        duration: NUDGE_DURATION,
+      });
+    }
+  },
+};
+```
+
+### nudge-skip
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-skip/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   WILD_CARD, app
+
+// SKIP NUDGE pattern.
+//
+// The handler runs a deliberately slow 1500ms-per-reel sequential nudge.
+// While it's mid-tween the spin button morphs into a skip button — one
+// tap calls `reelSet.skipNudge()` which fast-forwards the active tween
+// to its landed state. The `nudge()` promise still resolves normally,
+// so the consumer's success path (win re-detect, spotlight, whatever)
+// runs unchanged — only the animation got cut short.
+
+const SYMBOLS = [...CARD_DECK, WILD_CARD];
+const FILLER = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER[Math.floor(Math.random() * FILLER.length)];
+const col3 = () => [filler(), filler(), filler()];
+
+const NUDGE_COLS = [1, 2, 3];
+const NUDGE_DURATION = 1500;
+
+const reelSet = new ReelSetBuilder()
+  .reels(5)
+  .visibleSymbols(3)
+  .symbolSize(72, 72)
+  .symbolGap(4, 4)
+  .symbols((r) => {
+    for (const sym of SYMBOLS) {
+      r.register(sym.id, CardSymbol, {
+        color: sym.color,
+        label: sym.label,
+        textColor: sym.textColor,
+      });
+    }
+  })
+  .speed('normal', SpeedPresets.NORMAL)
+  .ticker(app.ticker)
+  .build();
+
+return {
+  reelSet,
+  onSpin: async () => {
+    const p = reelSet.spin();
+    await new Promise((resolve) => setTimeout(resolve, 220));
+    reelSet.setResult([col3(), col3(), col3(), col3(), col3()]);
+    await p;
+    await new Promise((resolve) => setTimeout(resolve, 320));
+
+    // Sequential nudges, each 1.5s long. Tap the canvas button during
+    // any of them to fast-forward — the loop's `await` resolves
+    // immediately at that tween's landed state and the loop continues
+    // with the next reel.
+    for (const col of NUDGE_COLS) {
+      await reelSet.nudge(col, {
+        distance: 1,
+        direction: 'down',
+        incoming: ['wild'],
+        duration: NUDGE_DURATION,
+      });
+    }
+  },
+  // No `onSkip` override needed — the RecipeRunner's built-in fallback
+  // detects an in-flight nudge and calls `reelSet.skipNudge()` for us.
+  // The recipe deliberately leaves the default behaviour in place so
+  // readers can copy the minimal pattern.
+};
+```
+
+### nudge-spotlight
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-spotlight/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   WILD_CARD, app
+
+// NUDGE → SPOTLIGHT pattern.
+//
+// The handler lands a flat near-miss, nudges three reels down by one so
+// the centre row turns into WILD-WILD-WILD, then runs SymbolSpotlight on
+// the new winning line. Demonstrates the canonical "rescue spin via
+// nudge, then celebrate" beat.
+
+const SYMBOLS = [...CARD_DECK, WILD_CARD];
+const FILLER = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER[Math.floor(Math.random() * FILLER.length)];
+const col3 = () => [filler(), filler(), filler()];
+
+const NUDGE_COLS = [1, 2, 3];
+const NUDGE_DURATION = 380;
+const WIN_ROW = 0; // After down-nudge, incoming[0] lands at visible row 0.
+
+const reelSet = new ReelSetBuilder()
+  .reels(5)
+  .visibleSymbols(3)
+  .symbolSize(72, 72)
+  .symbolGap(4, 4)
+  .symbols((r) => {
+    for (const sym of SYMBOLS) {
+      r.register(sym.id, CardSymbol, {
+        color: sym.color,
+        label: sym.label,
+        textColor: sym.textColor,
+      });
+    }
+  })
+  .speed('normal', SpeedPresets.NORMAL)
+  .ticker(app.ticker)
+  .build();
+
+return {
+  reelSet,
+  onSpin: async () => {
+    // 1. Land on a near-miss: no wilds anywhere.
+    const p = reelSet.spin();
+    await new Promise((resolve) => setTimeout(resolve, 220));
+    reelSet.setResult([col3(), col3(), col3(), col3(), col3()]);
+    await p;
+    await new Promise((resolve) => setTimeout(resolve, 320));
+
+    // 2. Parallel nudge of the middle three reels — `wild` lands at the
+    //    top of each nudged column. After this, visible row 0 reads
+    //    [..., wild, wild, wild, ...].
+    await Promise.all(
+      NUDGE_COLS.map((col) =>
+        reelSet.nudge(col, {
+          distance: 1,
+          direction: 'down',
+          incoming: ['wild'],
+          duration: NUDGE_DURATION,
+        }),
+      ),
+    );
+
+    // 3. Spotlight the new win line. `spotlight.show` re-parents the
+    //    winning symbols above the reel mask, dims the rest of the
+    //    viewport, and runs each symbol's `playWin()` animation. Resolves
+    //    once the animation chain completes — at which point `hide()`
+    //    returns the symbols to their reels.
+    const winners = NUDGE_COLS.map((col) => ({ reelIndex: col, row: WIN_ROW }));
+    await reelSet.spotlight.show(winners, {
+      dimAmount: 0.6,
+      playWinAnimation: true,
+    });
+    reelSet.spotlight.hide();
+  },
+};
+```
+
+### nudge-stagger
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-stagger/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   WILD_CARD, app
+
+// STAGGER NUDGE pattern.
+//
+// Promise.all with per-call `startDelay` produces a wave effect: every
+// reel runs its own tween concurrently, but each starts at a different
+// time. Cleaner than a sequential loop (each reel doesn't have to wait
+// for the previous to fully land), more visible than parallel (reels
+// kick off in sequence so the eye can follow the wave).
+
+const SYMBOLS = [...CARD_DECK, WILD_CARD];
+const FILLER = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER[Math.floor(Math.random() * FILLER.length)];
+const col3 = () => [filler(), filler(), filler()];
+
+const NUDGE_COLS = [0, 1, 2, 3, 4];
+const NUDGE_DURATION = 520;
+const STAGGER_MS = 90;
+
+const reelSet = new ReelSetBuilder()
+  .reels(5)
+  .visibleSymbols(3)
+  .symbolSize(72, 72)
+  .symbolGap(4, 4)
+  .symbols((r) => {
+    for (const sym of SYMBOLS) {
+      r.register(sym.id, CardSymbol, {
+        color: sym.color,
+        label: sym.label,
+        textColor: sym.textColor,
+      });
+    }
+  })
+  .speed('normal', SpeedPresets.NORMAL)
+  .ticker(app.ticker)
+  .build();
+
+return {
+  reelSet,
+  onSpin: async () => {
+    const p = reelSet.spin();
+    await new Promise((resolve) => setTimeout(resolve, 220));
+    reelSet.setResult([col3(), col3(), col3(), col3(), col3()]);
+    await p;
+    await new Promise((resolve) => setTimeout(resolve, 320));
+
+    // All five reels dispatch synchronously inside Promise.all; each one's
+    // tween is deferred by `startDelay`. Total wall time:
+    //   startDelay of last reel + duration = 4*90 + 520 = 880ms.
+    // (Versus 5 * 520 = 2600ms for sequential or 520ms for fully parallel.)
+    await Promise.all(
+      NUDGE_COLS.map((col, i) =>
+        reelSet.nudge(col, {
+          distance: 1,
+          direction: 'down',
+          incoming: ['wild'],
+          duration: NUDGE_DURATION,
+          startDelay: i * STAGGER_MS,
+        }),
+      ),
+    );
+  },
+};
+```
+
+### nudge-tail-reveal
+URL: https://pixi-reels.schmooky.dev/recipes/nudge-tail-reveal/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK, app
+
+// TAIL-REVEAL pattern.
+//
+// Big symbol lands fully visible. We nudge it UP by 1 so the anchor
+// crosses into bufferAbove — only the bottom cell of the block
+// remains in the visible window ("tail visible"). The engine's
+// `_finalizeFrame` sizes the anchor to span the whole block even
+// though it lives above visible, so the visible portion renders as
+// the bottom of the sprite, masked at the top edge.
+//
+// A beat later we nudge DOWN by 1 to bring the full block back into
+// view. The classic "the player sees the tail of the wild peeking in,
+// then nudges to reveal it fully" UX.
+
+const MEGA = { id: 'mega', color: 0xff8c42, label: 'MEGA', textColor: 0x4a1d00, w: 1, h: 2 };
+const REELS = 5;
+const ROWS = 3;
+const SIZE = 80;
+const GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS)
+  .visibleSymbols(ROWS)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .symbols((registry) => {
+    for (const card of CARD_DECK) {
+      registry.register(card.id, CardSymbol, {
+        color: card.color, label: card.label, textColor: card.textColor,
+      });
+    }
+    registry.register(MEGA.id, CardSymbol, {
+      color: MEGA.color, label: MEGA.label, textColor: MEGA.textColor,
+    });
+  })
+  .weights(Object.fromEntries(CARD_DECK.map((c, i) => [c.id, 12 - i])))
+  .symbolData({ [MEGA.id]: { weight: 0, zIndex: 5, size: { w: MEGA.w, h: MEGA.h } } })
+  .speed('normal', { ...SpeedPresets.NORMAL, bounceDistance: 0, bounceDuration: 0 })
+  .ticker(app.ticker)
+  .build();
+
+const FILLER_IDS = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER_IDS[Math.floor(Math.random() * FILLER_IDS.length)];
+const col3 = () => [filler(), filler(), filler()];
+
+return {
+  reelSet,
+  onSpin: async () => {
+    // 1. Land 1x2 MEGA anchored at column 2, row 0. Block fills rows 0+1.
+    const grid = [col3(), col3(), [MEGA.id, MEGA.id, filler()], col3(), col3()];
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 220));
+    reelSet.setResult(grid);
+    await p;
+    await new Promise((r) => setTimeout(r, 500));
+
+    // 2. Nudge UP by 1. anchor at strip[1] → strip[0] (bufferAbove).
+    //    Stub follows: strip[2] → strip[1] (visible row 0).
+    //    Block is now "tail visible": top in bufferAbove (clipped), bottom
+    //    showing at row 0. `_finalizeFrame` sizes the anchor sprite to the
+    //    full block height; the mask clips the half above visible.
+    await reelSet.nudge(2, {
+      distance: 1,
+      direction: 'up',
+      incoming: [filler()],
+      duration: 540,
+    });
+    await new Promise((r) => setTimeout(r, 800));
+
+    // 3. Nudge DOWN by 1 to fully reveal the block at rows 0+1 again.
+    //    The classic "nudge to reveal the wild" beat.
+    await reelSet.nudge(2, {
+      distance: 1,
+      direction: 'down',
+      incoming: [filler()],
+      duration: 540,
+    });
+  },
+};
+```
+
+### nudge
+URL: https://pixi-reels.schmooky.dev/recipes/nudge/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   WILD_CARD, app
+
+// Classic UK fruit-machine nudge demo. After every spin lands, the engine
+// fires two nudges in sequence:
+//   1. Reel 1 down by 1 — a wild slides in from the top.
+//   2. Reel 3 up by 1   — a wild slides in from the bottom.
+// One press shows both directions in one beat.
+
+const SYMBOLS = [...CARD_DECK, WILD_CARD];
+
+const FILLER = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER[Math.floor(Math.random() * FILLER.length)];
+const col3 = () => [filler(), filler(), filler()];
+
+const reelSet = new ReelSetBuilder()
+  .reels(5)
+  .visibleSymbols(3)
+  .symbolSize(90, 90)
+  .symbolGap(4, 4)
+  .symbols((r) => {
+    for (const sym of SYMBOLS) {
+      r.register(sym.id, CardSymbol, {
+        color: sym.color,
+        label: sym.label,
+        textColor: sym.textColor,
+      });
+    }
+  })
+  .speed('normal', SpeedPresets.NORMAL)
+  .speed('turbo', SpeedPresets.TURBO)
+  .ticker(app.ticker)
+  .build();
+
+// Log every nudge to the recipe console — useful for observing the
+// `nudge:start` / `nudge:complete` pair.
+reelSet.events.on('nudge:start', (info) => {
+  console.log('[nudge:start]', info);
+});
+reelSet.events.on('nudge:complete', (info) => {
+  console.log('[nudge:complete]', info);
+});
+
+return {
+  reelSet,
+  onSpin: async () => {
+    // Land on a flat near-miss — no wilds visible anywhere.
+    const p = reelSet.spin();
+    await new Promise((resolve) => setTimeout(resolve, 220));
+    reelSet.setResult([col3(), col3(), col3(), col3(), col3()]);
+    await p;
+
+    // Give the eye a beat to register the landed board.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // 1. Nudge reel 1 DOWN by 1 — `wild` enters from the top.
+    await reelSet.nudge(1, {
+      distance: 1,
+      direction: 'down',
+      incoming: ['wild'],
+      duration: 420,
+    });
+
+    // 2. Nudge reel 3 UP by 1 — `wild` enters from the bottom.
+    await reelSet.nudge(3, {
+      distance: 1,
+      direction: 'up',
+      incoming: ['wild'],
+      duration: 420,
+    });
   },
 };
 ```

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -6,7 +6,7 @@ Site: https://pixi-reels.schmooky.dev
 Repo: https://github.com/schmooky/pixi-reels
 Package: https://www.npmjs.com/package/pixi-reels
 
-Generated: 2026-05-22T05:33:17.000Z
+Generated: 2026-05-22T05:40:50.592Z
 
 ## Quick start
 
@@ -266,6 +266,16 @@ Steps:
   - Pin landed coins with { turns 'permanent', payload: { value } }
   - On collector land, sum neighbor pin payloads and unpin absorbed coins
   - Pin the collector with the total in its own payload
+
+### EmptySymbol — render nothing for a registered id
+URL: https://pixi-reels.schmooky.dev/recipes/empty-symbol/
+Register an EmptySymbol against an id like 'empty' to reserve a grid slot that produces no visual output. Useful for hold-and-win mechanics, miss cells, and any board where blank is the intended visual.
+Tags: symbols, empty, hold-and-win
+APIs: ReelSymbol, SymbolRegistry.register, ReelSetBuilder.symbols, ReelSetBuilder.weights
+Steps:
+  - Register the empty id with EmptySymbol — `r.register('empty', EmptySymbol, {})`
+  - Weight empty heavily so most cells land blank; weight real symbols lightly so they pop
+  - The reel renders empty cells as zero pixels — no sprite, no graphic, no animation
 
 ### Expanding wild (sticky)
 URL: https://pixi-reels.schmooky.dev/recipes/expanding-wild-pin/
@@ -2011,6 +2021,68 @@ return {
     }
   },
 };
+```
+
+### empty-symbol
+URL: https://pixi-reels.schmooky.dev/recipes/empty-symbol/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, WILD_CARD,
+//                   PIXI, app, EmptySymbol
+
+// EMPTY SYMBOL pattern.
+//
+// `EmptySymbol` is a {@link ReelSymbol} subclass that renders nothing
+// and never animates. Register it against an id (here `'empty'`) to
+// reserve a slot in the grid that produces NO visual output.
+//
+// Why this is useful (and why hold-and-win mechanics need it):
+//   - Hold & Win bonuses spawn 1×1 "coin" pins on a grid that's
+//     otherwise blank between respins. Real symbols would compete for
+//     the player's attention with the pinned coins; an empty symbol
+//     gets out of the way.
+//   - Weighting an EMPTY id heavily (and a real symbol lightly) makes
+//     valuable symbols feel rare and exciting — every coin landing on
+//     an otherwise-blank board reads as a hit.
+//   - Random fill still needs SOME id to put in each cell. EmptySymbol
+//     is that id when "no symbol" is the desired visual.
+//
+// What this recipe runs:
+//   - 3 reels, 3 visible rows. Symbol set is `{ coin, empty }`.
+//   - Weights `{ coin: 1, empty: 6 }` — most cells land blank; coins
+//     scatter sparsely (~1 in 7 by weight).
+//   - Hit Spin to spin all three reels. Coins land in a sea of nothing.
+
+const COIN = 'coin';
+const EMPTY = 'empty';
+
+const REELS = 3;
+const ROWS = 3;
+const CELL = 88;
+const GAP = 6;
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS)
+  .visibleSymbols(ROWS)
+  .symbolSize(CELL, CELL)
+  .symbolGap(GAP, GAP)
+  .symbols((registry) => {
+    // Real symbol: a wild-card-styled "coin".
+    registry.register(COIN, CardSymbol, {
+      color: WILD_CARD.color,
+      label: WILD_CARD.label,
+      textColor: WILD_CARD.textColor,
+    });
+    // The empty cell: rendered as absolutely nothing.
+    registry.register(EMPTY, EmptySymbol, {});
+  })
+  // Coins are rare; the strip is mostly blank.
+  .weights({ [COIN]: 1, [EMPTY]: 6 })
+  .speed('normal', SpeedPresets.NORMAL)
+  .ticker(app.ticker)
+  .build();
+
+return { reelSet };
 ```
 
 ### expanding-wild-pin

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -6,7 +6,7 @@ Site: https://pixi-reels.schmooky.dev
 Repo: https://github.com/schmooky/pixi-reels
 Package: https://www.npmjs.com/package/pixi-reels
 
-Generated: 2026-05-22T06:12:01.669Z
+Generated: 2026-05-22T06:22:38.324Z
 
 ## Quick start
 
@@ -161,6 +161,17 @@ Steps:
   - Call setAnticipation([...reels]) to slow specific reels before they land
   - Set result[col][-1] = HIGH_VALUE on those same reels to pin a symbol just above the visible area
   - During the anticipation decelerate, the symbol is visible at the top edge of the reel
+
+### Big symbol falls into view through a cascade
+URL: https://pixi-reels.schmooky.dev/recipes/big-symbol-cascade-fall/
+A tall wild lands with its tail peeking in from bufferAbove. The cells below the tail form a winning cluster, clear in the cascade, and the wild's anchor falls down through the strip into full visibility.
+Tags: big-symbols, buffer, cascade, tumble, recent
+APIs: ReelSet.runCascade, ReelSet.setResult, ColumnTarget.bufferAbove, SymbolData.size, ReelSetBuilder.tumble
+Steps:
+  - Land a 1xH wild with its anchor in `bufferAbove` — tail visible at row 0
+  - Plant a winning cluster on a row below the tail so detectWinners returns those cells
+  - In `nextGrid`, return a refill grid that places the wild's anchor at a more visible row — bufferAbove or visible
+  - The cascade refill animates each strip cell, including the moved anchor sprite, into its new position
 
 ### Nudge a big symbol in, then hold it across a respin
 URL: https://pixi-reels.schmooky.dev/recipes/big-symbol-held-respin/
@@ -822,6 +833,130 @@ return {
     reelSet.setAnticipation([3, 4]);
     reelSet.setResult(result);
     await p;
+  },
+};
+```
+
+### big-symbol-cascade-fall
+URL: https://pixi-reels.schmooky.dev/recipes/big-symbol-cascade-fall/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   PIXI, app
+
+// CASCADE-FALL pattern.
+//
+// A tall 1x3 wild lands with its anchor in bufferAbove — tail visible
+// at row 0. The other reels land a 3-of-a-kind cluster on a row BELOW
+// the wild's tail. The cluster wins, the cells clear, and the cascade
+// refill drops the wild downward into full visibility.
+//
+// This is the "big symbol falls when supporting cells are cleared"
+// beat — common in cluster / tumble slots where high-value symbols
+// reveal themselves over multiple cascade chains.
+//
+// What this proves:
+//   - `runCascade`'s `nextGrid` callback can return a grid that
+//     repositions a big-symbol anchor — moving it from bufferAbove[1]
+//     (row -2) to visible[0] (row 0) in one cascade step.
+//   - `_coordinateBigSymbols` runs on the refill grid the same as on
+//     a setResult grid — buffer-row anchors are accepted, OCCUPIED
+//     stubs painted across the moved block's new position.
+//   - The visual block "falls" because the refill animation drops
+//     each strip cell, including the anchor sprite, into its new slot.
+
+const TALL = { id: 'tall', color: 0xff8c42, label: 'TALL', textColor: 0x4a1d00, w: 1, h: 3 };
+const MATCH = { id: 'match', color: 0x4ade80, label: 'MATCH', textColor: 0x0a4a1d };
+const REELS = 3;
+const ROWS = 4;
+const SIZE = 76;
+const GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS)
+  .visibleSymbols(ROWS)
+  // Anchor at bufferAbove[1] (row -2) needs bufferAbove >= 2.
+  .bufferSymbols(2)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .symbols((registry) => {
+    for (const card of CARD_DECK) {
+      registry.register(card.id, CardSymbol, {
+        color: card.color, label: card.label, textColor: card.textColor,
+      });
+    }
+    registry.register(TALL.id, CardSymbol, {
+      color: TALL.color, label: TALL.label, textColor: TALL.textColor,
+    });
+    registry.register(MATCH.id, CardSymbol, {
+      color: MATCH.color, label: MATCH.label, textColor: MATCH.textColor,
+    });
+  })
+  .weights(Object.fromEntries(CARD_DECK.map((c, i) => [c.id, 12 - i])))
+  .symbolData({ [TALL.id]: { weight: 0, zIndex: 5, size: { w: TALL.w, h: TALL.h } } })
+  .speed('normal', { ...SpeedPresets.NORMAL, bounceDistance: 0, bounceDuration: 0 })
+  .tumble({
+    fall:   { duration: 320, ease: 'power3.in',  rowStagger: 60 },
+    dropIn: { duration: 480, ease: 'power3.out', rowStagger: 60, distance: 'perHole' },
+  })
+  .ticker(app.ticker)
+  .build();
+
+const FILLER_IDS = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER_IDS[Math.floor(Math.random() * FILLER_IDS.length)];
+
+return {
+  reelSet,
+  onSpin: async () => {
+    // ── 1. Initial spin: tall wild on reel 0 with tail at row 0; ─────
+    //      plant a MATCH cluster across all 3 reels at row 1.
+    const initialGrid = [
+      // Reel 0: anchor at bufferAbove[1] = row -2. Block spans rows
+      // -2, -1, 0. Tail at visible[0]. Plant MATCH at row 1; fillers
+      // at rows 2, 3.
+      {
+        visible: [filler(), MATCH.id, filler(), filler()],
+        bufferAbove: [undefined, TALL.id],
+      },
+      // Reel 1: MATCH at row 1.
+      { visible: [filler(), MATCH.id, filler(), filler()] },
+      // Reel 2: MATCH at row 1.
+      { visible: [filler(), MATCH.id, filler(), filler()] },
+    ];
+    const spinDone = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 240));
+    reelSet.setResult(initialGrid);
+    await spinDone;
+    await new Promise((r) => setTimeout(r, 900));
+
+    // ── 2. Cascade: MATCH row clears, wild falls. ─────────────────────
+    //
+    // `runCascade` runs `detectWinners` → `destroySymbols` → `nextGrid`
+    // → refill, repeating until detectWinners returns []. We script a
+    // single round here: row 1 across all 3 reels is the winning
+    // cluster, and nextGrid moves the wild block to visible[0..2].
+    let chained = false;
+    reelSet.setDropOrder('all');
+    await reelSet.runCascade({
+      detectWinners: () => {
+        if (chained) return [];
+        chained = true;
+        return [0, 1, 2].map((reel) => ({ reel, row: 1 }));
+      },
+      nextGrid: () => [
+        // Reel 0: block now at rows 0, 1, 2 (fully visible). New top
+        // cell in bufferAbove[0]; the coordinator paints OCCUPIED at
+        // visible[1] and [2] so 'tall' here is the anchor only.
+        {
+          visible: [TALL.id, filler(), filler(), filler()],
+          bufferAbove: [filler()],
+        },
+        // Reels 1, 2: fresh random fillers.
+        { visible: [filler(), filler(), filler(), filler()] },
+        { visible: [filler(), filler(), filler(), filler()] },
+      ],
+      pauseAfterDestroyMs: 280,
+    });
   },
 };
 ```

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -6,7 +6,7 @@ Site: https://pixi-reels.schmooky.dev
 Repo: https://github.com/schmooky/pixi-reels
 Package: https://www.npmjs.com/package/pixi-reels
 
-Generated: 2026-05-22T05:40:50.592Z
+Generated: 2026-05-22T06:12:01.669Z
 
 ## Quick start
 

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -6,7 +6,7 @@ Site: https://pixi-reels.schmooky.dev
 Repo: https://github.com/schmooky/pixi-reels
 Package: https://www.npmjs.com/package/pixi-reels
 
-Generated: 2026-05-21T21:45:33.313Z
+Generated: 2026-05-22T05:33:17.000Z
 
 ## Quick start
 
@@ -162,16 +162,16 @@ Steps:
   - Set result[col][-1] = HIGH_VALUE on those same reels to pin a symbol just above the visible area
   - During the anticipation decelerate, the symbol is visible at the top edge of the reel
 
-### Hold a buffer-anchored big symbol across a respin
+### Nudge a big symbol in, then hold it across a respin
 URL: https://pixi-reels.schmooky.dev/recipes/big-symbol-held-respin/
-A tall wild lands with its anchor in bufferAbove (tail visible at row 0). Hold that reel via spin holdReels, respin the others, then nudge to drag the wild into full view. The held reel preserves the block end-to-end across the no-op spin.
+A tall wild lands with its anchor in bufferAbove (tail visible at row 0). Nudge the trigger reel to drag the full block into view, then call spin with holdReels so the now-revealed wild survives a respin of the other reels.
 Tags: big-symbols, buffer, hold-reels, respin, nudge
 APIs: ReelSet.spin, SpinOptions.holdReels, ReelSet.setResult, ColumnTarget.bufferAbove, ReelSet.nudge
 Steps:
   - Land a 1xH wild with its anchor in bufferAbove on the trigger reel — only the bottom cell of the block shows at row 0
+  - Nudge the trigger reel down to drag the full block into visibility
   - Call reelSet.spin with holdReels including the trigger reel to skip START/SPIN/STOP on that column
-  - Pass a full-width grid to setResult — the held column entry is ignored
-  - Nudge the held reel after the respin to drag the full block into visibility
+  - Pass a full-width grid to setResult — the held column entry is ignored; the revealed block stays put
 
 ### Land a big symbol partially in buffer
 URL: https://pixi-reels.schmooky.dev/recipes/big-symbol-partial-land/
@@ -823,30 +823,34 @@ URL: https://pixi-reels.schmooky.dev/recipes/big-symbol-held-respin/
 // Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
 //                   PIXI, app
 
-// HELD-REEL RESPIN with a buffer-anchored big symbol.
+// NUDGE-IN, THEN HOLD a buffer-anchored big symbol across a respin.
 //
 // Classic UK fruit-machine bonus: reel 3 lands with a tall wild whose
 // anchor sits in bufferAbove (only the tail of the block shows at row 0
-// — "the wild is peeking in from the top"). The player gets a re-spin of
-// the OTHER reels; reel 3 is held. The held reel preserves the block
-// across spins because `SpinOptions.holdReels` skips START/SPIN/STOP on
+// — "the wild is peeking in from the top"). The player nudges to drag
+// the wild into full view, then gets a re-spin of the OTHER reels while
+// reel 3 is held. The held reel preserves the now-revealed block across
+// the respin because `SpinOptions.holdReels` skips START/SPIN/STOP on
 // the held column — the strip array, the anchor's size, and the
 // occupancy map all carry through.
 //
 // Sequence:
 //   1. Spin all reels; land tail-visible 1x3 wild on reel 2 (column index 2).
-//   2. Respin reels 0, 1, 3, 4 with `holdReels: [2]`. Reel 2 stays put
-//      (block intact, tail visible).
-//   3. Player nudges reel 2 down by 2 to drag the block into full view.
+//   2. Player nudges reel 2 down by 2 to drag the block into full view.
+//   3. Respin reels 0, 1, 3, 4 with `holdReels: [2]`. Reel 2 stays put
+//      (now-revealed block intact, fully visible).
 //
 // What this proves:
-//   - `holdReels` + buffer-anchored block: the held reel's `_finalizeFrame`
-//     state is preserved (occupancy + anchor size).
+//   - `setResult` accepts a big-symbol anchor in `bufferAbove`; the
+//     coordinator paints OCCUPIED stubs across the strip.
+//   - `nudge()` slides the block as a unit from its buffer-anchored
+//     landing into fully-visible state (strip rotates by `distance`).
+//   - `holdReels` + a big-symbol block: the held reel's strip array,
+//     occupancy map, and resized anchor sprite all survive the no-op
+//     spin. The block stays exactly where the nudge left it.
 //   - `_coordinateBigSymbols` runs on the result grid passed by the
 //     player for the non-held reels; the held column's placeholder entry
 //     is ignored.
-//   - A nudge AFTER the respin still moves the held block intact —
-//     proving the strip layout survived the no-op spin.
 
 const TALL = { id: 'tall', color: 0xff8c42, label: 'TALL', textColor: 0x4a1d00, w: 1, h: 3 };
 const REELS = 5;
@@ -900,7 +904,19 @@ return {
     await spin1;
     await new Promise((r) => setTimeout(r, 900));
 
-    // ── 2. Respin everything EXCEPT reel 2. ─────────────────────────
+    // ── 2. Nudge the held reel DOWN by 2 to reveal the full block. ──
+    //
+    // Survival check (down): anchor strip index (0) + h - 1 + distance =
+    // 0 + 3 - 1 + 2 = 4 < total 7 ✓. The block moves as a unit from
+    // strip[0..2] to strip[2..4]. Visible[0..2] = ['tall', 'tall', 'tall'].
+    await reelSet.nudge(HELD_REEL, {
+      distance: 2,
+      direction: 'down',
+      incoming: [filler(), filler()],
+      duration: 620,
+    });
+
+    // ── 3. Respin everything EXCEPT reel 2. ─────────────────────────
     //
     // `holdReels: [HELD_REEL]` tells the engine to skip START/SPIN/STOP
     // on reel 2 entirely. The grid we pass below MUST include all 5
@@ -927,18 +943,6 @@ return {
     reelSet.setResult(respinGrid);
     await spin2;
     await new Promise((r) => setTimeout(r, 900));
-
-    // ── 3. Nudge the held reel DOWN by 2 to reveal the full block. ──
-    //
-    // Survival check (down): anchor strip index (0) + h - 1 + distance =
-    // 0 + 3 - 1 + 2 = 4 < total 7 ✓. The block moves as a unit from
-    // strip[0..2] to strip[2..4]. Visible[0..2] = ['tall', 'tall', 'tall'].
-    await reelSet.nudge(HELD_REEL, {
-      distance: 2,
-      direction: 'down',
-      incoming: [filler(), filler()],
-      duration: 620,
-    });
   },
 };
 ```

--- a/apps/site/src/components/RecipeRunner.tsx
+++ b/apps/site/src/components/RecipeRunner.tsx
@@ -14,6 +14,7 @@ import {
 import { SpineReelSymbol } from 'pixi-reels/spine';
 import { BlurSpriteSymbol } from '../../../../examples/shared/BlurSpriteSymbol.ts';
 import { CardSymbol, CARD_DECK, WILD_CARD } from '../../../../examples/shared/CardSymbol.ts';
+import { EmptySymbol } from '../../../../examples/shared/EmptySymbol.ts';
 import { loadPrototypeSymbols } from '../../../../examples/shared/prototypeSpriteLoader.ts';
 import {
   loadGeneratedSpines,
@@ -39,14 +40,6 @@ function pickWeighted(weights: Record<string, number>): string {
     if (r <= 0) return id;
   }
   return Object.keys(weights)[0];
-}
-
-class EmptySymbol extends ReelSymbol {
-  protected onActivate(_symbolId: string): void {}
-  protected onDeactivate(): void {}
-  async playWin(): Promise<void> {}
-  stopAnimation(): void {}
-  resize(_w: number, _h: number): void {}
 }
 
 interface RunResult {

--- a/apps/site/src/components/ShareViewer.tsx
+++ b/apps/site/src/components/ShareViewer.tsx
@@ -22,6 +22,7 @@ import {
 import { SpineReelSymbol } from 'pixi-reels/spine';
 import { BlurSpriteSymbol } from '../../../../examples/shared/BlurSpriteSymbol.ts';
 import { CardSymbol, CARD_DECK, WILD_CARD } from '../../../../examples/shared/CardSymbol.ts';
+import { EmptySymbol } from '../../../../examples/shared/EmptySymbol.ts';
 import { loadPrototypeSymbols } from '../../../../examples/shared/prototypeSpriteLoader.ts';
 import {
   loadGeneratedSpines,
@@ -29,13 +30,6 @@ import {
 } from '../../../../examples/shared/generatedSpineLoader.ts';
 import { transform as sucraseTransform } from 'sucrase';
 
-class EmptySymbol extends ReelSymbol {
-  protected onActivate(_symbolId: string): void {}
-  protected onDeactivate(): void {}
-  async playWin(): Promise<void> {}
-  stopAnimation(): void {}
-  resize(_w: number, _h: number): void {}
-}
 import { getShare, ShareApiError } from '@/lib/studio/share/api.js';
 import { openEnvelope } from '@/lib/studio/share/crypto.js';
 import { decodePayload, verifyPayloadHashes } from '@/lib/studio/share/payload.js';

--- a/apps/site/src/components/Studio.tsx
+++ b/apps/site/src/components/Studio.tsx
@@ -42,6 +42,7 @@ import {
 import { SpineReelSymbol } from 'pixi-reels/spine';
 import { BlurSpriteSymbol } from '../../../../examples/shared/BlurSpriteSymbol.ts';
 import { CardSymbol, CARD_DECK, WILD_CARD } from '../../../../examples/shared/CardSymbol.ts';
+import { EmptySymbol } from '../../../../examples/shared/EmptySymbol.ts';
 import { loadPrototypeSymbols } from '../../../../examples/shared/prototypeSpriteLoader.ts';
 import {
   loadGeneratedSpines,
@@ -60,13 +61,6 @@ import {
 } from '@/lib/studio/applyConfig.js';
 import type { StudioConfig } from '@/lib/studio/types.js';
 
-class EmptySymbol extends ReelSymbol {
-  protected onActivate(_symbolId: string): void {}
-  protected onDeactivate(): void {}
-  async playWin(): Promise<void> {}
-  stopAnimation(): void {}
-  resize(_w: number, _h: number): void {}
-}
 
 const DEFAULT_CODE = `// @ts-nocheck
 // ─── pixi-reels studio ─────────────────────────────────────────────────

--- a/apps/site/src/components/recipes/HoldAndWinStarterRecipe.tsx
+++ b/apps/site/src/components/recipes/HoldAndWinStarterRecipe.tsx
@@ -3,24 +3,15 @@ import { useEffect, useRef, useState } from 'react';
 import { Application, Container, Graphics, Sprite } from 'pixi.js';
 import type { Texture } from 'pixi.js';
 import { gsap } from 'gsap';
-import { ReelSetBuilder, ReelSymbol, SpeedPresets, type ReelSet } from 'pixi-reels';
+import { ReelSetBuilder, SpeedPresets, type ReelSet } from 'pixi-reels';
 import { Play, RotateCcw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { BlurSpriteSymbol } from '../../../../../examples/shared/BlurSpriteSymbol.ts';
+import { EmptySymbol } from '../../../../../examples/shared/EmptySymbol.ts';
 import { loadPrototypeSymbols } from '../../../../../examples/shared/prototypeSpriteLoader.ts';
 
 const COIN = 'feature/feature_1';
 const EMPTY = 'empty';
-
-/** Renders nothing — gives the reel strip blank slots between coins so
- *  misses land on a visually empty cell (hit-or-miss feel). */
-class EmptySymbol extends ReelSymbol {
-  protected onActivate(): void {}
-  protected onDeactivate(): void {}
-  async playWin(): Promise<void> {}
-  stopAnimation(): void {}
-  resize(_w: number, _h: number): void {}
-}
 
 const COLS = 5;
 const ROWS = 3;

--- a/apps/site/src/content/recipes.ts
+++ b/apps/site/src/content/recipes.ts
@@ -174,13 +174,13 @@ export const RECIPES: RecipeMeta[] = [
   {
     slug: 'big-symbol-held-respin',
     group: 'big-symbols',
-    title: 'Hold a buffer-anchored big symbol across a respin',
-    oneLiner: 'A tall wild lands with its anchor in bufferAbove (tail-visible at row 0). Hold that reel via `spin({ holdReels: [...] })`, respin the others; the block stays intact because the held strip is never touched. Then nudge the held reel to reveal the full block.',
+    title: 'Nudge a big symbol in, then hold it across a respin',
+    oneLiner: 'A tall wild lands with its anchor in bufferAbove (tail-visible at row 0). Nudge the trigger reel to drag the full block into view, then call `spin({ holdReels: [...] })` so the revealed wild survives a respin of the other reels — the held strip is never touched.',
     steps: [
       'Land a 1xH wild with its anchor in `bufferAbove` on the trigger reel (only the bottom cell shows at row 0)',
+      'Nudge the trigger reel down to drag the full block into visibility',
       'Call `reelSet.spin({ holdReels: [triggerReel] })` to skip START/SPIN/STOP on that column',
-      'Pass a full-width grid to `setResult` — the held column entry is ignored',
-      'Nudge the held reel after the respin to drag the full block into visibility',
+      'Pass a full-width grid to `setResult` — the held column entry is ignored; the revealed block stays put',
     ],
     apis: ['ReelSet.spin', 'SpinOptions.holdReels', 'ReelSet.setResult', 'ColumnTarget.bufferAbove', 'ReelSet.nudge'],
     tags: ['big-symbols', 'buffer', 'hold-reels', 'respin', 'nudge', 'recent'],

--- a/apps/site/src/content/recipes.ts
+++ b/apps/site/src/content/recipes.ts
@@ -172,6 +172,20 @@ export const RECIPES: RecipeMeta[] = [
     tags: ['big-symbols', 'buffer', 'nudge', 'recent'],
   },
   {
+    slug: 'big-symbol-held-respin',
+    group: 'big-symbols',
+    title: 'Hold a buffer-anchored big symbol across a respin',
+    oneLiner: 'A tall wild lands with its anchor in bufferAbove (tail-visible at row 0). Hold that reel via `spin({ holdReels: [...] })`, respin the others; the block stays intact because the held strip is never touched. Then nudge the held reel to reveal the full block.',
+    steps: [
+      'Land a 1xH wild with its anchor in `bufferAbove` on the trigger reel (only the bottom cell shows at row 0)',
+      'Call `reelSet.spin({ holdReels: [triggerReel] })` to skip START/SPIN/STOP on that column',
+      'Pass a full-width grid to `setResult` — the held column entry is ignored',
+      'Nudge the held reel after the respin to drag the full block into visibility',
+    ],
+    apis: ['ReelSet.spin', 'SpinOptions.holdReels', 'ReelSet.setResult', 'ColumnTarget.bufferAbove', 'ReelSet.nudge'],
+    tags: ['big-symbols', 'buffer', 'hold-reels', 'respin', 'nudge', 'recent'],
+  },
+  {
     slug: 'get-block-bounds',
     group: 'big-symbols',
     title: 'getBlockBounds — outline a big symbol',

--- a/apps/site/src/content/recipes.ts
+++ b/apps/site/src/content/recipes.ts
@@ -158,6 +158,20 @@ export const RECIPES: RecipeMeta[] = [
     tags: ['big-symbols', 'layout', 'sizing'],
   },
   {
+    slug: 'big-symbol-partial-land',
+    group: 'big-symbols',
+    title: 'Land a big symbol partially in buffer',
+    oneLiner: 'A tall 1xH block lands with its anchor in bufferAbove — only the bottom cell shows at row 0. Nudge to drag the rest into view. Works end-to-end through setResult, refill, nudge, and the cross-reel resolver.',
+    steps: [
+      'Pass an anchor at `bufferAbove[i]` via the explicit `ColumnTarget` form (or row -i-1 via legacy negative-index)',
+      "Coordinator paints OCCUPIED at the rest of the block's cells (negative rows, visible rows, or bufferBelow as needed)",
+      '`_finalizeFrame` sizes the anchor sprite to span the whole block; the mask clips the off-screen portion',
+      '`getVisibleSymbols` resolves visible cells to the anchor id via a NEGATIVE `anchorRow` in `_occupancy`',
+    ],
+    apis: ['ReelSet.setResult', 'ColumnTarget.bufferAbove', 'ColumnTarget.bufferBelow', 'ReelSet.getSymbolFootprint'],
+    tags: ['big-symbols', 'buffer', 'nudge', 'recent'],
+  },
+  {
     slug: 'get-block-bounds',
     group: 'big-symbols',
     title: 'getBlockBounds — outline a big symbol',

--- a/apps/site/src/content/recipes.ts
+++ b/apps/site/src/content/recipes.ts
@@ -212,6 +212,20 @@ export const RECIPES: RecipeMeta[] = [
     tags: ['debug', 'prototyping', 'custom-symbol', 'graphics'],
   },
   {
+    slug: 'empty-symbol',
+    group: 'starters',
+    title: 'EmptySymbol — render nothing for a registered id',
+    oneLiner: 'Register an EmptySymbol against an id like `empty` to reserve a grid slot that produces no visual output. The canonical background for hold-and-win bonus boards, miss cells, and any pattern where "blank" is the intended visual.',
+    steps: [
+      "Import EmptySymbol from `examples/shared/EmptySymbol.ts`",
+      "Register the empty id — `r.register('empty', EmptySymbol, {})`",
+      'Weight empty heavily so most cells land blank; weight real symbols lightly so they pop',
+      'The cell still occupies a strip slot, but renders zero pixels',
+    ],
+    apis: ['ReelSymbol', 'SymbolRegistry.register', 'ReelSetBuilder.symbols', 'ReelSetBuilder.weights'],
+    tags: ['symbols', 'empty', 'hold-and-win', 'recent'],
+  },
+  {
     slug: 'multiways-cascade',
     group: 'multiways',
     title: 'MultiWays cascade',

--- a/apps/site/src/content/recipes.ts
+++ b/apps/site/src/content/recipes.ts
@@ -186,6 +186,20 @@ export const RECIPES: RecipeMeta[] = [
     tags: ['big-symbols', 'buffer', 'hold-reels', 'respin', 'nudge', 'recent'],
   },
   {
+    slug: 'big-symbol-cascade-fall',
+    group: 'big-symbols',
+    title: 'Big symbol falls into view through a cascade',
+    oneLiner: "A tall wild lands with its tail peeking in from bufferAbove. The cells below the tail form a winning cluster, clear in the cascade, and the wild's anchor falls down through the strip into full visibility.",
+    steps: [
+      'Land a 1xH wild with its anchor in `bufferAbove` — tail visible at row 0',
+      'Plant a winning cluster on a row below the tail so `detectWinners` returns those cells',
+      "In `nextGrid`, return a refill grid that places the wild's anchor at a more visible row",
+      'The cascade refill animates each strip cell, including the moved anchor sprite, into its new position',
+    ],
+    apis: ['ReelSet.runCascade', 'ReelSet.setResult', 'ColumnTarget.bufferAbove', 'SymbolData.size', 'ReelSetBuilder.tumble'],
+    tags: ['big-symbols', 'buffer', 'cascade', 'tumble', 'recent'],
+  },
+  {
     slug: 'get-block-bounds',
     group: 'big-symbols',
     title: 'getBlockBounds — outline a big symbol',

--- a/apps/site/src/pages/guides/big-symbols.mdx
+++ b/apps/site/src/pages/guides/big-symbols.mdx
@@ -147,6 +147,7 @@ Pin overlays render at zIndex `10000` (an internal `ReelSet` constant — not pa
 - [Guide: MultiWays](/guides/multiways/) — mutually exclusive with big symbols
 - [`big-symbols-mxn`](/recipes/big-symbols-mxn/) recipe — every shape: 1×3, 2×2, 3×3, 2×4
 - [`big-symbol-partial-land`](/recipes/big-symbol-partial-land/) recipe — tail-visible landings via `bufferAbove`
+- [`big-symbol-held-respin`](/recipes/big-symbol-held-respin/) recipe — nudge to reveal, then hold across a respin
 - [`nudge-big-symbol`](/recipes/nudge-big-symbol/) recipe — nudge a block through visible + buffer
 - [`card-symbol-debug`](/recipes/card-symbol-debug/) recipe — the debug `CardSymbol` used in these recipes
 - [`cell-bounds`](/recipes/cell-bounds/) recipe — pixel rects for any cell

--- a/apps/site/src/pages/guides/big-symbols.mdx
+++ b/apps/site/src/pages/guides/big-symbols.mdx
@@ -72,11 +72,30 @@ Pass any cell of a block — anchor or non-anchor — both APIs return the same 
 The engine throws fail-fast at `setResult()` if a block doesn't fit:
 
 - `"big symbol 'giant' (3x3) at (col=4, row=2) exceeds reel count 6."`
-- `"big symbol 'tallBar' (1x3) at (col=0, row=3) exceeds reel 0 height 5."`
+- `"big symbol 'tallBar' (1x3) at (col=0, row=3) extends past the bottom of the strip on reel 0 (anchor row + h = 6 > visibleRows + bufferBelow = 4)."`
+
+The vertical check is against the **full strip** (visible + bufferBelow), not just visible — anchors are allowed to land partially, with the block extending into bufferAbove or bufferBelow.
 
 Pinning the **non-anchor** cell of a big symbol throws — pin the anchor instead, which covers the block visually because the anchor's view spans it.
 
 The **build-time** check refuses big symbols with non-zero weight (`big symbol 'bonus' (2x2) must have weight 0 — ...`). Random fill can't place blocks in v1, so non-zero weight would silently never be picked.
+
+## Partial-visibility landings (buffer-row anchors)
+
+Big-symbol anchors are NOT restricted to visible rows. A 1×H block can land with its anchor in `bufferAbove` so only the bottom of the block ("the tail") shows at the top of the visible window — the classic UK fruit-machine setup where the player sees a sliver of a tall wild and nudges to reveal it. Equivalently, a block can anchor at the last visible row with its lower cells spilling into `bufferBelow` ("head visible").
+
+Use the explicit `ColumnTarget` form to target buffer slots:
+
+```ts
+// 1x3 wild lands with its tail at visible row 0; anchor + two stubs are
+// off-screen in bufferAbove. Requires bufferSymbols(2) or more.
+reelSet.setResult([
+  { visible: [...], bufferAbove: [undefined, 'tallWild'] },
+  // ...
+]);
+```
+
+`ReelSet.getSymbolFootprint(col, 0)` for the visible cell returns `anchor.row = -2` (negative) — `ReelSet.getBlockBounds(col, 0)` returns the full block's pixel rect including the off-screen portion (the mask clips the rendered output to the visible window). See [Land a big symbol partially in buffer](/recipes/big-symbol-partial-land/) for the runnable demo.
 
 ## Mask interaction (`SharedRectMaskStrategy`)
 
@@ -126,7 +145,8 @@ Pin overlays render at zIndex `10000` (an internal `ReelSet` constant — not pa
 
 - [Guide: Per-reel geometry](/guides/per-reel-geometry/) — overview + constraint matrix + mask strategy
 - [Guide: MultiWays](/guides/multiways/) — mutually exclusive with big symbols
-- [`big-symbols`](/recipes/big-symbols/) recipe — single 2×2 bonus
 - [`big-symbols-mxn`](/recipes/big-symbols-mxn/) recipe — every shape: 1×3, 2×2, 3×3, 2×4
+- [`big-symbol-partial-land`](/recipes/big-symbol-partial-land/) recipe — tail-visible landings via `bufferAbove`
+- [`nudge-big-symbol`](/recipes/nudge-big-symbol/) recipe — nudge a block through visible + buffer
 - [`card-symbol-debug`](/recipes/card-symbol-debug/) recipe — the debug `CardSymbol` used in these recipes
 - [`cell-bounds`](/recipes/cell-bounds/) recipe — pixel rects for any cell

--- a/apps/site/src/pages/guides/buffer-indexing.mdx
+++ b/apps/site/src/pages/guides/buffer-indexing.mdx
@@ -99,7 +99,12 @@ Reach for the **explicit `ColumnTarget` form** when:
 - You want stronger TypeScript narrowing on which slots are set
 - A reviewer would be more confused than helped by `arr[-1] = 'X'`
 
+## Buffer rows + big symbols
+
+A big-symbol anchor (`SymbolData.size.h > 1`) can sit in `bufferAbove[i]` or at a visible row whose stubs spill into `bufferBelow`. The coordinator paints `OCCUPIED` across the rest of the block automatically — passing the anchor alone is enough. See the [`big-symbols` guide](/guides/big-symbols/#partial-visibility-landings-buffer-row-anchors) for the runnable demo. The validation rule is `anchorRow + h <= visibleRows + bufferBelow` — the block must fit on the strip end-to-end, but not necessarily inside the visible window.
+
 ## Recipes
 
 - [Peek symbol from buffer-above](/recipes/peek-from-above/) — the minimum runnable demo
 - [Anticipation teaser](/recipes/anticipation-teaser/) — pair buffer-above with `setAnticipation` for tense reveals
+- [Land a big symbol partially in buffer](/recipes/big-symbol-partial-land/) — tail-visible 1×H wild via `bufferAbove`

--- a/apps/site/src/pages/guides/nudge.mdx
+++ b/apps/site/src/pages/guides/nudge.mdx
@@ -263,3 +263,6 @@ unrelated reels, and other reels' symbols all carry through.
 - [Land a big symbol partially in buffer](/recipes/big-symbol-partial-land/) —
   the dual entry point: land in tail-visible state via `setResult`'s
   `bufferAbove`, nudge to reveal.
+- [Nudge a big symbol in, then hold it across a respin](/recipes/big-symbol-held-respin/) —
+  the classic fruit-machine bonus beat: reveal a buffer-anchored wild,
+  then hold the reel through a respin of the others.

--- a/apps/site/src/pages/guides/nudge.mdx
+++ b/apps/site/src/pages/guides/nudge.mdx
@@ -258,3 +258,8 @@ unrelated reels, and other reels' symbols all carry through.
 - [Fruit-machine nudge](/recipes/nudge/) — the minimum runnable demo.
 - [Spotlight after a nudge](/recipes/nudge-spotlight/) — nudge into a
   win line, then run `WinPresenter` on the new cells.
+- [Nudge through a big symbol](/recipes/nudge-big-symbol/) — block
+  survival math + tail-reveal canvas.
+- [Land a big symbol partially in buffer](/recipes/big-symbol-partial-land/) —
+  the dual entry point: land in tail-visible state via `setResult`'s
+  `bufferAbove`, nudge to reveal.

--- a/apps/site/src/pages/recipes/big-symbol-cascade-fall.mdx
+++ b/apps/site/src/pages/recipes/big-symbol-cascade-fall.mdx
@@ -1,0 +1,105 @@
+---
+layout: ../../layouts/Recipe.astro
+title: Big symbol falls into view through a cascade
+description: A tall wild lands with its tail peeking in from bufferAbove. The cells below the tail form a winning cluster, clear in the cascade, and the wild's anchor falls down through the strip into full visibility.
+tags: [big-symbols, buffer, cascade, tumble, recent]
+steps:
+  - "Land a 1xH wild with its anchor in `bufferAbove` — tail visible at row 0"
+  - "Plant a winning cluster on a row below the tail so detectWinners returns those cells"
+  - "In `nextGrid`, return a refill grid that places the wild's anchor at a more visible row — bufferAbove or visible"
+  - "The cascade refill animates each strip cell, including the moved anchor sprite, into its new position"
+apis:
+  - ReelSet.runCascade
+  - ReelSet.setResult
+  - ColumnTarget.bufferAbove
+  - SymbolData.size
+  - ReelSetBuilder.tumble
+---
+
+import code from '../../recipes/big-symbol-cascade-fall.recipe.ts?raw';
+import { RecipeRunner } from '../../components/RecipeRunner.tsx';
+
+<RecipeRunner code={code} client:only="react" />
+
+A tall 1×3 wild lands with most of its body hidden above the visible
+window — only the **tail** shows at row 0. The other reels plant a
+3-of-a-kind MATCH cluster on row 1. The cluster wins, the cells clear,
+and the cascade refill drops the wild's anchor down through the strip
+into full visibility.
+
+This is the "big symbol falls when supporting cells are cleared" beat
+common in cluster / tumble slots — the high-value symbol reveals
+itself across multiple cascade chains as the cells below it
+disappear.
+
+## Why this works
+
+`runCascade` doesn't have any opinion about big symbols. It just calls
+`detectWinners` and `nextGrid` and feeds the result back through
+`refill()`. The refill path runs the same `_coordinateBigSymbols`
+coordinator as `setResult`, so:
+
+- The refill grid can contain a big-symbol anchor at **any** strip
+  slot — visible, bufferAbove, or bufferBelow.
+- The coordinator paints OCCUPIED stubs across the rest of the block
+  in the new position.
+- The visible anchor sprite re-sizes via `_finalizeFrame` after the
+  refill snap.
+- The drop animation tweens each strip cell into its new slot — for a
+  block, this is the anchor sprite (sized to span the whole block)
+  dropping as a unit.
+
+## What this recipe scripts
+
+```ts
+// 1. Initial spin: tall at bufferAbove[1], MATCH cluster at row 1.
+const initialGrid = [
+  {
+    visible: [filler(), 'match', filler(), filler()],
+    bufferAbove: [undefined, 'tall'], // anchor at row -2
+  },
+  { visible: [filler(), 'match', filler(), filler()] },
+  { visible: [filler(), 'match', filler(), filler()] },
+];
+await reelSet.setResult(initialGrid);
+
+// 2. Cascade: row-1 cluster wins, wild falls to visible[0..2].
+await reelSet.runCascade({
+  detectWinners: () => [0, 1, 2].map((reel) => ({ reel, row: 1 })),
+  nextGrid: () => [
+    {
+      visible: ['tall', filler(), filler(), filler()],
+      bufferAbove: [filler()],
+    },
+    { visible: [filler(), filler(), filler(), filler()] },
+    { visible: [filler(), filler(), filler(), filler()] },
+  ],
+});
+```
+
+The `nextGrid` here scripts a one-shot reveal — anchor moves from
+`row -2` to `row 0` in a single cascade step. Real games might stage
+this across multiple chains (anchor moves down one row per cascade
+until fully visible), which is just a matter of returning different
+grids on each call.
+
+## What still throws
+
+- **Big-symbol anchors cannot land at a row that would push the block
+  past the strip end.** Same validator as `setResult` — see
+  [Big symbols guide](/guides/big-symbols/#validation).
+- **MultiWays + big symbols** is rejected at build, regardless of
+  cascade mode.
+- **Cross-reel (`w > 1`) blocks cannot be moved via cascade** if the
+  fall would require relocating the block to a different left-edge
+  column. Reposition w=1 blocks freely; for wider blocks, keep the
+  anchor column constant across refills.
+
+## Related
+
+- [Land a big symbol partially in buffer](/recipes/big-symbol-partial-land/) —
+  the static landing without a cascade follow-up.
+- [Nudge a big symbol in, then hold it across a respin](/recipes/big-symbol-held-respin/) —
+  player-driven reveal via nudge instead of cascade.
+- [Cascade 6×5](/recipes/cascade-6x5/) — the cascade orchestration
+  pattern without big-symbol involvement.

--- a/apps/site/src/pages/recipes/big-symbol-held-respin.mdx
+++ b/apps/site/src/pages/recipes/big-symbol-held-respin.mdx
@@ -1,13 +1,13 @@
 ---
 layout: ../../layouts/Recipe.astro
-title: Hold a buffer-anchored big symbol across a respin
-description: A tall wild lands with its anchor in bufferAbove (tail visible at row 0). Hold that reel via spin holdReels, respin the others, then nudge to drag the wild into full view. The held reel preserves the block end-to-end across the no-op spin.
+title: Nudge a big symbol in, then hold it across a respin
+description: A tall wild lands with its anchor in bufferAbove (tail visible at row 0). Nudge the trigger reel to drag the full block into view, then call spin with holdReels so the now-revealed wild survives a respin of the other reels.
 tags: [big-symbols, buffer, hold-reels, respin, nudge]
 steps:
   - "Land a 1xH wild with its anchor in bufferAbove on the trigger reel — only the bottom cell of the block shows at row 0"
+  - "Nudge the trigger reel down to drag the full block into visibility"
   - "Call reelSet.spin with holdReels including the trigger reel to skip START/SPIN/STOP on that column"
-  - "Pass a full-width grid to setResult — the held column entry is ignored"
-  - "Nudge the held reel after the respin to drag the full block into visibility"
+  - "Pass a full-width grid to setResult — the held column entry is ignored; the revealed block stays put"
 apis:
   - ReelSet.spin
   - SpinOptions.holdReels
@@ -23,9 +23,9 @@ import { RecipeRunner } from '../../components/RecipeRunner.tsx';
 
 The classic UK fruit-machine bonus: a tall wild lands with most of its
 body hidden above the visible window — only the **tail** (the bottom
-cell) shows at row 0. The player gets a respin of the OTHER reels with
-the wild reel held; the tail keeps peeking in. After the respin, a nudge
-drags the whole wild into view. This recipe wires the full sequence.
+cell) shows at row 0. The player nudges to drag the whole wild into
+view, then gets a respin of the OTHER reels with the wild reel held —
+the revealed block stays put. This recipe wires the full sequence.
 
 ## Why this works end-to-end
 
@@ -39,19 +39,20 @@ buffer-row anchor feature:
    validation rule is the full strip (`anchorRow + h <= visibleRows +
    bufferBelow`), not just visible.
 
-2. **`spin({ holdReels: [...] })` skips the held reels entirely.**
-   START / SPIN / STOP never fire on the held column. The strip
-   array, the anchor sprite's resized dimensions, and the
-   `_occupancy` map all carry through unchanged. Big-symbol blocks
-   that crossed into bufferAbove or bufferBelow at the previous land
-   stay exactly where they were.
+2. **`nudge()` slides the block as a unit from buffer-anchored to
+   fully visible.** The survival check
+   (`anchor + h - 1 + distance < total`) applies; for a 1×3 wild at
+   `strip[0]` and a `distance=2` down nudge, `0 + 3 - 1 + 2 = 4 < 7`
+   (where total is `bufferAbove(2) + visibleRows(3) + bufferBelow(2)`).
+   The wrap pipeline never splits the anchor from its stubs. Post-nudge
+   the anchor sits at `strip[2] = visible[0]`; the block fills all
+   three visible rows.
 
-3. **`nudge()` on the held reel moves the block as a unit.** The same
-   survival check (`anchor + h - 1 + distance < total`) applies; for
-   a 1×3 wild at `strip[0]` and a `distance=2` down nudge, `0 + 3 - 1
-   + 2 = 4 < 7` (where total is `bufferAbove(2) + visibleRows(3) +
-   bufferBelow(2)`). The wrap pipeline never splits the anchor from
-   its stubs.
+3. **`spin({ holdReels: [...] })` skips the held reels entirely.**
+   START / SPIN / STOP never fire on the held column. The strip
+   array, the resized anchor sprite, and the `_occupancy` map all
+   carry through unchanged. The block sits exactly where the nudge
+   left it — no jitter, no re-land.
 
 ## What the recipe runs
 
@@ -67,7 +68,14 @@ const spin1 = reelSet.spin();
 reelSet.setResult(initialGrid);
 await spin1;
 
-// 2. Respin reels 0, 1, 3, 4 — reel 2 held, block preserved.
+// 2. Nudge the held reel down by 2 — block slides into full view.
+await reelSet.nudge(2, {
+  distance: 2,
+  direction: 'down',
+  incoming: [filler(), filler()],
+});
+
+// 3. Respin reels 0, 1, 3, 4 — reel 2 held, revealed block preserved.
 const spin2 = reelSet.spin({ holdReels: [2] });
 reelSet.setResult([
   ct(), ct(),
@@ -75,13 +83,6 @@ reelSet.setResult([
   ct(), ct(),
 ]);
 await spin2;
-
-// 3. Nudge the held reel to reveal the block.
-await reelSet.nudge(2, {
-  distance: 2,
-  direction: 'down',
-  incoming: [filler(), filler()],
-});
 ```
 
 ## Required configuration
@@ -120,7 +121,7 @@ await reelSet.nudge(2, {
 
 - [Land a big symbol partially in buffer](/recipes/big-symbol-partial-land/) —
   same buffer-anchor entry, but with both nudge directions instead of a
-  hold-then-respin.
+  nudge-then-hold-respin.
 - [Hold & Win pin](/recipes/hold-and-win/) — the spiritual cousin: hold
   CHIP symbols as 1×1 pins across respins (no big-symbol layout).
 - [Nudge through a big symbol](/recipes/nudge-big-symbol/) — the survival

--- a/apps/site/src/pages/recipes/big-symbol-held-respin.mdx
+++ b/apps/site/src/pages/recipes/big-symbol-held-respin.mdx
@@ -1,0 +1,127 @@
+---
+layout: ../../layouts/Recipe.astro
+title: Hold a buffer-anchored big symbol across a respin
+description: A tall wild lands with its anchor in bufferAbove (tail visible at row 0). Hold that reel via spin holdReels, respin the others, then nudge to drag the wild into full view. The held reel preserves the block end-to-end across the no-op spin.
+tags: [big-symbols, buffer, hold-reels, respin, nudge]
+steps:
+  - "Land a 1xH wild with its anchor in bufferAbove on the trigger reel — only the bottom cell of the block shows at row 0"
+  - "Call reelSet.spin with holdReels including the trigger reel to skip START/SPIN/STOP on that column"
+  - "Pass a full-width grid to setResult — the held column entry is ignored"
+  - "Nudge the held reel after the respin to drag the full block into visibility"
+apis:
+  - ReelSet.spin
+  - SpinOptions.holdReels
+  - ReelSet.setResult
+  - ColumnTarget.bufferAbove
+  - ReelSet.nudge
+---
+
+import code from '../../recipes/big-symbol-held-respin.recipe.ts?raw';
+import { RecipeRunner } from '../../components/RecipeRunner.tsx';
+
+<RecipeRunner code={code} client:only="react" />
+
+The classic UK fruit-machine bonus: a tall wild lands with most of its
+body hidden above the visible window — only the **tail** (the bottom
+cell) shows at row 0. The player gets a respin of the OTHER reels with
+the wild reel held; the tail keeps peeking in. After the respin, a nudge
+drags the whole wild into view. This recipe wires the full sequence.
+
+## Why this works end-to-end
+
+Three pieces have to cooperate, and they do — the audit case for the
+buffer-row anchor feature:
+
+1. **`setResult` accepts an anchor in `bufferAbove`.** Pass the anchor
+   id at `bufferAbove[i]` (or `frame[col][-i-1]` via legacy negative
+   indexing) and `_coordinateBigSymbols` paints `OCCUPIED` across the
+   rest of the block — even when stubs fall in visible rows. The
+   validation rule is the full strip (`anchorRow + h <= visibleRows +
+   bufferBelow`), not just visible.
+
+2. **`spin({ holdReels: [...] })` skips the held reels entirely.**
+   START / SPIN / STOP never fire on the held column. The strip
+   array, the anchor sprite's resized dimensions, and the
+   `_occupancy` map all carry through unchanged. Big-symbol blocks
+   that crossed into bufferAbove or bufferBelow at the previous land
+   stay exactly where they were.
+
+3. **`nudge()` on the held reel moves the block as a unit.** The same
+   survival check (`anchor + h - 1 + distance < total`) applies; for
+   a 1×3 wild at `strip[0]` and a `distance=2` down nudge, `0 + 3 - 1
+   + 2 = 4 < 7` (where total is `bufferAbove(2) + visibleRows(3) +
+   bufferBelow(2)`). The wrap pipeline never splits the anchor from
+   its stubs.
+
+## What the recipe runs
+
+```ts
+// 1. Land the tail-visible wild.
+const initialGrid = [
+  ct(), ct(),
+  // Anchor at bufferAbove[1] = row -2. Block spans rows -2, -1, 0.
+  { visible: [filler(), filler(), filler()], bufferAbove: [undefined, 'tall'] },
+  ct(), ct(),
+];
+const spin1 = reelSet.spin();
+reelSet.setResult(initialGrid);
+await spin1;
+
+// 2. Respin reels 0, 1, 3, 4 — reel 2 held, block preserved.
+const spin2 = reelSet.spin({ holdReels: [2] });
+reelSet.setResult([
+  ct(), ct(),
+  ct(), // ignored — reel 2 is held
+  ct(), ct(),
+]);
+await spin2;
+
+// 3. Nudge the held reel to reveal the block.
+await reelSet.nudge(2, {
+  distance: 2,
+  direction: 'down',
+  incoming: [filler(), filler()],
+});
+```
+
+## Required configuration
+
+- **`bufferSymbols(n)` where `n` >= the largest off-screen extension.**
+  For a 1×3 wild with its tail at row 0, the anchor sits at row -2 —
+  needs `bufferAbove >= 2`. The builder sets both buffers to the same
+  value, so `bufferSymbols(2)` works.
+
+- **The big-symbol id needs `weight: 0`.** Random fill can't place
+  blocks; non-zero weight throws at build.
+
+- **Bounce should be 0 for big symbols.**
+  `bounceDistance: 0, bounceDuration: 0` in the speed profile — the
+  default landing bounce doesn't account for stubs and produces a
+  visual jitter on big anchors.
+
+## What still throws
+
+- **Cross-reel (`w > 1`) blocks held across a respin work, but you
+  can't nudge them** — nudging shifts only the one held reel, and the
+  block's right-side cells live on other reels.
+
+- **Mixing `string[]` and `ColumnTarget` columns inside one `setResult`
+  call.** `toLegacyTargetGrid` rejects mixed shapes — pick one form for
+  the whole grid. The recipe uses `ColumnTarget` everywhere, including
+  the held reel's placeholder, because the wild reel needs the
+  `bufferAbove` field.
+
+- **An anchor in `bufferAbove` whose h pushes the block past
+  `bufferBelow`.** `_coordinateBigSymbols` validates against the full
+  strip; an over-tall anchor throws with `extends past the bottom of
+  the strip`.
+
+## Related
+
+- [Land a big symbol partially in buffer](/recipes/big-symbol-partial-land/) —
+  same buffer-anchor entry, but with both nudge directions instead of a
+  hold-then-respin.
+- [Hold & Win pin](/recipes/hold-and-win/) — the spiritual cousin: hold
+  CHIP symbols as 1×1 pins across respins (no big-symbol layout).
+- [Nudge through a big symbol](/recipes/nudge-big-symbol/) — the survival
+  rules for nudging blocks through the strip.

--- a/apps/site/src/pages/recipes/big-symbol-partial-land.mdx
+++ b/apps/site/src/pages/recipes/big-symbol-partial-land.mdx
@@ -1,0 +1,134 @@
+---
+layout: ../../layouts/Recipe.astro
+title: Land a big symbol partially in buffer
+description: A tall 1xH block lands with its anchor in bufferAbove — only the bottom cell shows at the top of the visible window. Nudge to drag the rest into view. Works end-to-end through setResult, refill, nudge, and the cross-reel resolver.
+tags: [big-symbols, buffer, nudge, recent]
+steps:
+  - "Pass an anchor at `bufferAbove[i]` via the explicit `ColumnTarget` form (or row `-i-1` via legacy negative-index)"
+  - "Coordinator paints OCCUPIED at the rest of the block's cells (negative rows, visible rows, or bufferBelow as needed)"
+  - "`_finalizeFrame` sizes the anchor sprite to span the whole block; the mask clips the off-screen portion"
+  - "`getVisibleSymbols` resolves visible cells to the anchor id via a NEGATIVE `anchorRow` in `_occupancy`"
+apis:
+  - ReelSet.setResult
+  - SymbolData.size
+  - ColumnTarget.bufferAbove
+  - ColumnTarget.bufferBelow
+  - ReelSet.getSymbolFootprint
+---
+
+import code from '../../recipes/big-symbol-partial-land.recipe.ts?raw';
+import { RecipeRunner } from '../../components/RecipeRunner.tsx';
+
+<RecipeRunner code={code} client:only="react" />
+
+Before this change `_coordinateBigSymbols` only iterated visible rows;
+trying to set a big-symbol anchor at `bufferAbove[i]` or
+`bufferBelow[i]` either threw (`exceeds reel height`) or silently
+failed to paint OCCUPIED stubs. Now the coordinator scans the full
+strip range — anchor + h must stay on the strip, but it doesn't have
+to stay in the visible window.
+
+The recipe above lands a `1x3` TALL block with its anchor at row -2
+(`bufferAbove[1]`), so two of the block's cells are clipped off the
+top of the visible window and only the **tail** shows at row 0. A nudge
+DOWN by 2 drags the whole block into view; a nudge UP by 2 pushes it
+back out.
+
+## The contract
+
+`ColumnTarget` already exposes `bufferAbove` and `bufferBelow`. Put a
+big-symbol id at any strip slot and the coordinator handles the rest:
+
+```ts
+reelSet.setResult([
+  // Anchor at row -2 (bufferAbove[1]) for a 1x3 block.
+  // The engine paints OCCUPIED at row -1 and row 0 automatically.
+  {
+    visible: [filler(), filler(), filler()],
+    bufferAbove: [undefined, 'TALL'],
+  },
+  // ...other columns
+]);
+```
+
+Equivalent legacy form (negative-index string properties on the column
+array — note this DOES NOT survive `structuredClone`/JSON/postMessage,
+so prefer the `ColumnTarget` form for any grid that crosses a worker /
+network / serializer boundary):
+
+```ts
+const col: string[] = [filler(), filler(), filler()];
+(col as Record<number, string>)[-2] = 'TALL';
+reelSet.setResult([col, /* ... */]);
+```
+
+## Where the block can live
+
+For a `1xH` block on a strip with `bufferAbove + visibleRows + bufferBelow`
+cells, the anchor's strip index must be in `[0, total - h]`:
+
+| Anchor at row | Block occupies (row coords) | Visible portion |
+| --- | --- | --- |
+| `-h + 1` | `[-h+1, 0]` | Just the bottom cell at row 0 (the "tail") |
+| `-1` | `[-1, h-2]` | All but the topmost cell |
+| `0` | `[0, h-1]` | Entirely in visible if `h <= visibleRows` |
+| `visibleRows - h` | `[visibleRows - h, visibleRows - 1]` | Bottom-aligned, all visible |
+| `visibleRows - 1` | `[visibleRows - 1, visibleRows + h - 2]` | Just the top cell at the last visible row (the "head") |
+
+Anchors past these bounds throw with a precise message naming the
+violated rule (`extends past the bottom of the strip` or
+`exceeds reel count` for cross-reel overflows).
+
+## How it works end-to-end
+
+1. **`setResult` / `refill`** — both call `_coordinateBigSymbols(grid)`
+   which now iterates the full strip range. For every big-symbol
+   anchor it finds (in buffer or visible), it paints OCCUPIED at the
+   block's non-anchor cells. The legacy negative-index pattern is
+   preserved via `cloneTargetGrid`.
+
+2. **`FrameBuilder.TargetPlacementMiddleware`** — places target symbols
+   into the strip's symbol array, mapping row coordinates to strip
+   indices via `bufferAbove + row`. Already handles negative rows.
+
+3. **`StopSequencer` / `placeSymbols`** — consume the frame and place
+   real `ReelSymbol`s or `OccupiedStub`s at each strip slot.
+
+4. **`Reel._finalizeFrame`** — after every snap, two passes:
+   - Scan 1: visible-row anchors (the common case).
+   - Scan 2: bufferAbove anchors whose blocks extend into visible. For
+     these, `_occupancy[visibleRow].anchorRow` is set to a NEGATIVE
+     value (offset from `bufferAbove`).
+
+5. **`getVisibleSymbols` / `getSymbolAt`** — index back to the anchor
+   via `this.symbols[bufferAbove + anchorRow]`, which works whether
+   `anchorRow` is positive or negative.
+
+6. **`getSymbolFootprint`** — returns `anchor.row` (possibly negative)
+   so external consumers can locate the anchor cell.
+
+7. **`getBlockBounds`** — handles negative `anchor.row` by computing
+   pixel coordinates directly from the row offset rather than
+   delegating to `getCellBounds` (which still rejects negative rows by
+   design).
+
+## What still throws
+
+- **MultiWays + big symbols** — already rejected at build (existing
+  constraint, unchanged).
+- **Cross-reel blocks via nudge** — `w > 1` blocks throw inside
+  `reelSet.nudge(col, ...)`. Buffer-row anchors don't change this:
+  nudging a single reel can't shift a block whose other-reel cells
+  stay put.
+- **Random-fill big symbols** — big symbols must still have `weight: 0`
+  so the random provider never picks one (random fill of a 1x1 slot
+  can't paint a multi-cell block coherently).
+
+## Related
+
+- [Big symbols MxN](/recipes/big-symbols-mxn/) — every shape variant.
+- [Nudge through a big symbol](/recipes/nudge-big-symbol/) — full-block
+  nudges + the tail-reveal canvas (the in-window mirror of this
+  recipe).
+- [Peek symbol from buffer-above](/recipes/peek-from-above/) — the 1x1
+  analogue: tease a single symbol above the visible window.

--- a/apps/site/src/pages/recipes/empty-symbol.mdx
+++ b/apps/site/src/pages/recipes/empty-symbol.mdx
@@ -1,0 +1,83 @@
+---
+layout: ../../layouts/Recipe.astro
+title: EmptySymbol — render nothing for a registered id
+description: Register an EmptySymbol against an id like 'empty' to reserve a grid slot that produces no visual output. Useful for hold-and-win mechanics, miss cells, and any board where blank is the intended visual.
+tags: [symbols, empty, hold-and-win]
+steps:
+  - "Register the empty id with EmptySymbol — `r.register('empty', EmptySymbol, {})`"
+  - "Weight empty heavily so most cells land blank; weight real symbols lightly so they pop"
+  - "The reel renders empty cells as zero pixels — no sprite, no graphic, no animation"
+apis:
+  - ReelSymbol
+  - SymbolRegistry.register
+  - ReelSetBuilder.symbols
+  - ReelSetBuilder.weights
+---
+
+import code from '../../recipes/empty-symbol.recipe.ts?raw';
+import { RecipeRunner } from '../../components/RecipeRunner.tsx';
+
+<RecipeRunner code={code} client:only="react" />
+
+`EmptySymbol` is a tiny `ReelSymbol` subclass that does the minimum
+required to be a registered symbol — all of its lifecycle hooks are
+no-ops:
+
+```ts
+export class EmptySymbol extends ReelSymbol {
+  protected onActivate(_symbolId: string): void {}
+  protected onDeactivate(): void {}
+  async playWin(): Promise<void> {}
+  stopAnimation(): void {}
+  resize(_w: number, _h: number): void {}
+}
+```
+
+It still occupies a strip slot — the reel needs SOMETHING in every
+cell — but the cell renders as nothing. This is what you reach for
+when "blank" is the intended visual.
+
+## When to use it
+
+The canonical use is **Hold & Win**. A 5x3 bonus board fills with
+pinned coins between respins, but the cells _without_ coins need a
+neutral background — not the base-game symbol set. Register an empty
+id, weight it heavily on the bonus reels, and the board reads as
+"coins on a blank field" instead of "coins between cherry/lemon/seven".
+
+Other patterns where it fits:
+
+- **Miss cells in cluster / scatter games.** The board only shows
+  symbols where wins exist; everywhere else is blank.
+- **Random-fill placeholders for protected slots.** Cells that get
+  pinned later still need an id to land between spins; empty is the
+  least visually intrusive choice.
+- **Debugging.** Drop an empty id into the registry to confirm a
+  cell is being targeted but rendering nothing — fast bisection when
+  a symbol won't show up.
+
+## What this recipe shows
+
+Three reels, three rows, two registered symbols: `coin` and `empty`.
+Weights `{ coin: 1, empty: 6 }` give coins a ~14% per-cell hit rate,
+so most cells land blank. Hitting Spin a few times shows coins
+scattering through a sea of nothing — exactly the visual hold-and-win
+mechanics build on.
+
+## What EmptySymbol is not
+
+- **Not a way to skip a cell entirely.** The cell is still there; it
+  still occupies a strip slot; spin motion still rotates through it.
+  It just doesn't render. If you need a cell to physically not exist,
+  use per-reel geometry (different `visibleRows` per column) instead.
+- **Not the same as `OCCUPIED_SENTINEL`.** That's the engine's
+  internal big-symbol stub. EmptySymbol is a regular symbol you
+  register; OCCUPIED is the painted-by-coordinator marker.
+
+## Related
+
+- [Hold & Win respin](/recipes/hold-and-win/) — the canonical
+  consumer; empty cells form the board between pinned coins.
+- [Value coin pin](/recipes/value-coin-pin/) and
+  [Collector pin](/recipes/collector-symbol-pin/) — both register
+  `EmptySymbol` as the non-pin background.

--- a/apps/site/src/pages/recipes/hold-and-win.mdx
+++ b/apps/site/src/pages/recipes/hold-and-win.mdx
@@ -90,6 +90,7 @@ When to pick which:
 
 ## Related recipes
 
+- [`EmptySymbol`](/recipes/empty-symbol/) — the blank-cell symbol class this recipe registers as the bonus-board background
 - [Near-miss](/recipes/near-miss/) — tease a coin just off the board
 - [Anticipate a reel](/recipes/anticipate-a-reel/) — slow the final reel when close to a jackpot
 - [Sticky wild (CellPin)](/recipes/sticky-wild-pin/) — the engine-blessed sticky-symbol path

--- a/apps/site/src/pages/recipes/nudge-big-symbol.mdx
+++ b/apps/site/src/pages/recipes/nudge-big-symbol.mdx
@@ -114,10 +114,6 @@ await reelSet.nudge(2, {
   Placing a new big symbol via a nudge would require the cross-reel
   OCCUPIED coordinator and a different API surface — use `setResult`
   or `placeSymbols` for that.
-- **Anchors in bufferAbove that should render partially.** Engine's
-  `_finalizeFrame` only resizes anchors at visible cells today; a
-  block whose anchor is above visible with its tail in view doesn't
-  render at the right size. Tracked as a follow-up.
 
 ## Error messages
 
@@ -137,6 +133,9 @@ cells would stay put and split the block.
 
 ## Related
 
+- [Land a big symbol partially in buffer](/recipes/big-symbol-partial-land/) —
+  the complementary entry: land directly into the tail-visible state via
+  `setResult`'s `bufferAbove` slot, then nudge to reveal.
 - [MxN big symbols](/recipes/big-symbols-mxn/) — placement, footprint,
   bounds.
 - [Nudge guide](/guides/nudge/) — full survival formula derivation.

--- a/apps/site/src/pages/recipes/value-coin-pin.mdx
+++ b/apps/site/src/pages/recipes/value-coin-pin.mdx
@@ -108,5 +108,6 @@ Each `unpin` fires `pin:expired` with reason `'explicit'`, clearing badges and z
 
 ## Related
 
+- [`EmptySymbol`](/recipes/empty-symbol/) — the blank-cell symbol class this recipe registers as the non-coin background
 - [Collector symbol](/recipes/collector-symbol-pin/) — same architecture + one collector that absorbs adjacent pin values
 - [Multiplier wild](/recipes/multiplier-wild-pin/) — payload pattern on a single full-grid ReelSet

--- a/apps/site/src/recipes/big-symbol-cascade-fall.recipe.ts
+++ b/apps/site/src/recipes/big-symbol-cascade-fall.recipe.ts
@@ -1,0 +1,119 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   PIXI, app
+
+// CASCADE-FALL pattern.
+//
+// A tall 1x3 wild lands with its anchor in bufferAbove — tail visible
+// at row 0. The other reels land a 3-of-a-kind cluster on a row BELOW
+// the wild's tail. The cluster wins, the cells clear, and the cascade
+// refill drops the wild downward into full visibility.
+//
+// This is the "big symbol falls when supporting cells are cleared"
+// beat — common in cluster / tumble slots where high-value symbols
+// reveal themselves over multiple cascade chains.
+//
+// What this proves:
+//   - `runCascade`'s `nextGrid` callback can return a grid that
+//     repositions a big-symbol anchor — moving it from bufferAbove[1]
+//     (row -2) to visible[0] (row 0) in one cascade step.
+//   - `_coordinateBigSymbols` runs on the refill grid the same as on
+//     a setResult grid — buffer-row anchors are accepted, OCCUPIED
+//     stubs painted across the moved block's new position.
+//   - The visual block "falls" because the refill animation drops
+//     each strip cell, including the anchor sprite, into its new slot.
+
+const TALL = { id: 'tall', color: 0xff8c42, label: 'TALL', textColor: 0x4a1d00, w: 1, h: 3 };
+const MATCH = { id: 'match', color: 0x4ade80, label: 'MATCH', textColor: 0x0a4a1d };
+const REELS = 3;
+const ROWS = 4;
+const SIZE = 76;
+const GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS)
+  .visibleSymbols(ROWS)
+  // Anchor at bufferAbove[1] (row -2) needs bufferAbove >= 2.
+  .bufferSymbols(2)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .symbols((registry) => {
+    for (const card of CARD_DECK) {
+      registry.register(card.id, CardSymbol, {
+        color: card.color, label: card.label, textColor: card.textColor,
+      });
+    }
+    registry.register(TALL.id, CardSymbol, {
+      color: TALL.color, label: TALL.label, textColor: TALL.textColor,
+    });
+    registry.register(MATCH.id, CardSymbol, {
+      color: MATCH.color, label: MATCH.label, textColor: MATCH.textColor,
+    });
+  })
+  .weights(Object.fromEntries(CARD_DECK.map((c, i) => [c.id, 12 - i])))
+  .symbolData({ [TALL.id]: { weight: 0, zIndex: 5, size: { w: TALL.w, h: TALL.h } } })
+  .speed('normal', { ...SpeedPresets.NORMAL, bounceDistance: 0, bounceDuration: 0 })
+  .tumble({
+    fall:   { duration: 320, ease: 'power3.in',  rowStagger: 60 },
+    dropIn: { duration: 480, ease: 'power3.out', rowStagger: 60, distance: 'perHole' },
+  })
+  .ticker(app.ticker)
+  .build();
+
+const FILLER_IDS = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER_IDS[Math.floor(Math.random() * FILLER_IDS.length)];
+
+return {
+  reelSet,
+  onSpin: async () => {
+    // ── 1. Initial spin: tall wild on reel 0 with tail at row 0; ─────
+    //      plant a MATCH cluster across all 3 reels at row 1.
+    const initialGrid = [
+      // Reel 0: anchor at bufferAbove[1] = row -2. Block spans rows
+      // -2, -1, 0. Tail at visible[0]. Plant MATCH at row 1; fillers
+      // at rows 2, 3.
+      {
+        visible: [filler(), MATCH.id, filler(), filler()],
+        bufferAbove: [undefined, TALL.id],
+      },
+      // Reel 1: MATCH at row 1.
+      { visible: [filler(), MATCH.id, filler(), filler()] },
+      // Reel 2: MATCH at row 1.
+      { visible: [filler(), MATCH.id, filler(), filler()] },
+    ];
+    const spinDone = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 240));
+    reelSet.setResult(initialGrid);
+    await spinDone;
+    await new Promise((r) => setTimeout(r, 900));
+
+    // ── 2. Cascade: MATCH row clears, wild falls. ─────────────────────
+    //
+    // `runCascade` runs `detectWinners` → `destroySymbols` → `nextGrid`
+    // → refill, repeating until detectWinners returns []. We script a
+    // single round here: row 1 across all 3 reels is the winning
+    // cluster, and nextGrid moves the wild block to visible[0..2].
+    let chained = false;
+    reelSet.setDropOrder('all');
+    await reelSet.runCascade({
+      detectWinners: () => {
+        if (chained) return [];
+        chained = true;
+        return [0, 1, 2].map((reel) => ({ reel, row: 1 }));
+      },
+      nextGrid: () => [
+        // Reel 0: block now at rows 0, 1, 2 (fully visible). New top
+        // cell in bufferAbove[0]; the coordinator paints OCCUPIED at
+        // visible[1] and [2] so 'tall' here is the anchor only.
+        {
+          visible: [TALL.id, filler(), filler(), filler()],
+          bufferAbove: [filler()],
+        },
+        // Reels 1, 2: fresh random fillers.
+        { visible: [filler(), filler(), filler(), filler()] },
+        { visible: [filler(), filler(), filler(), filler()] },
+      ],
+      pauseAfterDestroyMs: 280,
+    });
+  },
+};

--- a/apps/site/src/recipes/big-symbol-held-respin.recipe.ts
+++ b/apps/site/src/recipes/big-symbol-held-respin.recipe.ts
@@ -79,7 +79,19 @@ return {
     await spin1;
     await new Promise((r) => setTimeout(r, 900));
 
-    // ── 2. Respin everything EXCEPT reel 2. ─────────────────────────
+    // ── 2. Nudge the held reel DOWN by 2 to reveal the full block. ──
+    //
+    // Survival check (down): anchor strip index (0) + h - 1 + distance =
+    // 0 + 3 - 1 + 2 = 4 < total 7 ✓. The block moves as a unit from
+    // strip[0..2] to strip[2..4]. Visible[0..2] = ['tall', 'tall', 'tall'].
+    await reelSet.nudge(HELD_REEL, {
+      distance: 2,
+      direction: 'down',
+      incoming: [filler(), filler()],
+      duration: 620,
+    });
+
+    // ── 3. Respin everything EXCEPT reel 2. ─────────────────────────
     //
     // `holdReels: [HELD_REEL]` tells the engine to skip START/SPIN/STOP
     // on reel 2 entirely. The grid we pass below MUST include all 5
@@ -106,17 +118,5 @@ return {
     reelSet.setResult(respinGrid);
     await spin2;
     await new Promise((r) => setTimeout(r, 900));
-
-    // ── 3. Nudge the held reel DOWN by 2 to reveal the full block. ──
-    //
-    // Survival check (down): anchor strip index (0) + h - 1 + distance =
-    // 0 + 3 - 1 + 2 = 4 < total 7 ✓. The block moves as a unit from
-    // strip[0..2] to strip[2..4]. Visible[0..2] = ['tall', 'tall', 'tall'].
-    await reelSet.nudge(HELD_REEL, {
-      distance: 2,
-      direction: 'down',
-      incoming: [filler(), filler()],
-      duration: 620,
-    });
   },
 };

--- a/apps/site/src/recipes/big-symbol-held-respin.recipe.ts
+++ b/apps/site/src/recipes/big-symbol-held-respin.recipe.ts
@@ -1,0 +1,122 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   PIXI, app
+
+// HELD-REEL RESPIN with a buffer-anchored big symbol.
+//
+// Classic UK fruit-machine bonus: reel 3 lands with a tall wild whose
+// anchor sits in bufferAbove (only the tail of the block shows at row 0
+// — "the wild is peeking in from the top"). The player gets a re-spin of
+// the OTHER reels; reel 3 is held. The held reel preserves the block
+// across spins because `SpinOptions.holdReels` skips START/SPIN/STOP on
+// the held column — the strip array, the anchor's size, and the
+// occupancy map all carry through.
+//
+// Sequence:
+//   1. Spin all reels; land tail-visible 1x3 wild on reel 2 (column index 2).
+//   2. Respin reels 0, 1, 3, 4 with `holdReels: [2]`. Reel 2 stays put
+//      (block intact, tail visible).
+//   3. Player nudges reel 2 down by 2 to drag the block into full view.
+//
+// What this proves:
+//   - `holdReels` + buffer-anchored block: the held reel's `_finalizeFrame`
+//     state is preserved (occupancy + anchor size).
+//   - `_coordinateBigSymbols` runs on the result grid passed by the
+//     player for the non-held reels; the held column's placeholder entry
+//     is ignored.
+//   - A nudge AFTER the respin still moves the held block intact —
+//     proving the strip layout survived the no-op spin.
+
+const TALL = { id: 'tall', color: 0xff8c42, label: 'TALL', textColor: 0x4a1d00, w: 1, h: 3 };
+const REELS = 5;
+const HELD_REEL = 2;
+const ROWS = 3;
+const SIZE = 80;
+const GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS)
+  .visibleSymbols(ROWS)
+  // bufferAbove >= 2 lets the 1x3 anchor sit at row -2 (block extends
+  // through row 0 — tail visible).
+  .bufferSymbols(2)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .symbols((registry) => {
+    for (const card of CARD_DECK) {
+      registry.register(card.id, CardSymbol, {
+        color: card.color, label: card.label, textColor: card.textColor,
+      });
+    }
+    registry.register(TALL.id, CardSymbol, {
+      color: TALL.color, label: TALL.label, textColor: TALL.textColor,
+    });
+  })
+  .weights(Object.fromEntries(CARD_DECK.map((c, i) => [c.id, 12 - i])))
+  .symbolData({ [TALL.id]: { weight: 0, zIndex: 5, size: { w: TALL.w, h: TALL.h } } })
+  .speed('normal', { ...SpeedPresets.NORMAL, bounceDistance: 0, bounceDuration: 0 })
+  .ticker(app.ticker)
+  .build();
+
+const FILLER_IDS = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER_IDS[Math.floor(Math.random() * FILLER_IDS.length)];
+const ct = () => ({ visible: [filler(), filler(), filler()] });
+
+return {
+  reelSet,
+  onSpin: async () => {
+    // ── 1. Initial spin lands the tail-visible wild on reel 2. ──────
+    const initialGrid = [
+      ct(), ct(),
+      // Reel 2: anchor at bufferAbove[1] = row -2. Block spans rows
+      // -2, -1, 0. Only row 0 shows the block's bottom cell.
+      { visible: [filler(), filler(), filler()], bufferAbove: [undefined, TALL.id] },
+      ct(), ct(),
+    ];
+    const spin1 = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 240));
+    reelSet.setResult(initialGrid);
+    await spin1;
+    await new Promise((r) => setTimeout(r, 900));
+
+    // ── 2. Respin everything EXCEPT reel 2. ─────────────────────────
+    //
+    // `holdReels: [HELD_REEL]` tells the engine to skip START/SPIN/STOP
+    // on reel 2 entirely. The grid we pass below MUST include all 5
+    // columns (every shipped slot expects a full grid), but the entry at
+    // index 2 is ignored — the held reel keeps whatever it had.
+    //
+    // The block on reel 2 (anchor at strip[0], stubs at strip[1..2])
+    // survives because:
+    //   - no motion runs on reel 2 (strip array unchanged)
+    //   - `_finalizeFrame` doesn't re-run (occupancy unchanged)
+    //   - the anchor's sized sprite stays at its post-land dimensions
+    //
+    // We hand the held column a ColumnTarget so the input shape is
+    // homogeneous — `setResult` rejects mixed `string[] | ColumnTarget`
+    // grids. The held entry's contents are not validated against the
+    // current strip; they're simply dropped during frame building.
+    const respinGrid = [
+      ct(), ct(),
+      ct(), // ignored — reel 2 is held
+      ct(), ct(),
+    ];
+    const spin2 = reelSet.spin({ holdReels: [HELD_REEL] });
+    await new Promise((r) => setTimeout(r, 240));
+    reelSet.setResult(respinGrid);
+    await spin2;
+    await new Promise((r) => setTimeout(r, 900));
+
+    // ── 3. Nudge the held reel DOWN by 2 to reveal the full block. ──
+    //
+    // Survival check (down): anchor strip index (0) + h - 1 + distance =
+    // 0 + 3 - 1 + 2 = 4 < total 7 ✓. The block moves as a unit from
+    // strip[0..2] to strip[2..4]. Visible[0..2] = ['tall', 'tall', 'tall'].
+    await reelSet.nudge(HELD_REEL, {
+      distance: 2,
+      direction: 'down',
+      incoming: [filler(), filler()],
+      duration: 620,
+    });
+  },
+};

--- a/apps/site/src/recipes/big-symbol-held-respin.recipe.ts
+++ b/apps/site/src/recipes/big-symbol-held-respin.recipe.ts
@@ -2,30 +2,34 @@
 // Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
 //                   PIXI, app
 
-// HELD-REEL RESPIN with a buffer-anchored big symbol.
+// NUDGE-IN, THEN HOLD a buffer-anchored big symbol across a respin.
 //
 // Classic UK fruit-machine bonus: reel 3 lands with a tall wild whose
 // anchor sits in bufferAbove (only the tail of the block shows at row 0
-// — "the wild is peeking in from the top"). The player gets a re-spin of
-// the OTHER reels; reel 3 is held. The held reel preserves the block
-// across spins because `SpinOptions.holdReels` skips START/SPIN/STOP on
+// — "the wild is peeking in from the top"). The player nudges to drag
+// the wild into full view, then gets a re-spin of the OTHER reels while
+// reel 3 is held. The held reel preserves the now-revealed block across
+// the respin because `SpinOptions.holdReels` skips START/SPIN/STOP on
 // the held column — the strip array, the anchor's size, and the
 // occupancy map all carry through.
 //
 // Sequence:
 //   1. Spin all reels; land tail-visible 1x3 wild on reel 2 (column index 2).
-//   2. Respin reels 0, 1, 3, 4 with `holdReels: [2]`. Reel 2 stays put
-//      (block intact, tail visible).
-//   3. Player nudges reel 2 down by 2 to drag the block into full view.
+//   2. Player nudges reel 2 down by 2 to drag the block into full view.
+//   3. Respin reels 0, 1, 3, 4 with `holdReels: [2]`. Reel 2 stays put
+//      (now-revealed block intact, fully visible).
 //
 // What this proves:
-//   - `holdReels` + buffer-anchored block: the held reel's `_finalizeFrame`
-//     state is preserved (occupancy + anchor size).
+//   - `setResult` accepts a big-symbol anchor in `bufferAbove`; the
+//     coordinator paints OCCUPIED stubs across the strip.
+//   - `nudge()` slides the block as a unit from its buffer-anchored
+//     landing into fully-visible state (strip rotates by `distance`).
+//   - `holdReels` + a big-symbol block: the held reel's strip array,
+//     occupancy map, and resized anchor sprite all survive the no-op
+//     spin. The block stays exactly where the nudge left it.
 //   - `_coordinateBigSymbols` runs on the result grid passed by the
 //     player for the non-held reels; the held column's placeholder entry
 //     is ignored.
-//   - A nudge AFTER the respin still moves the held block intact —
-//     proving the strip layout survived the no-op spin.
 
 const TALL = { id: 'tall', color: 0xff8c42, label: 'TALL', textColor: 0x4a1d00, w: 1, h: 3 };
 const REELS = 5;

--- a/apps/site/src/recipes/big-symbol-partial-land.recipe.ts
+++ b/apps/site/src/recipes/big-symbol-partial-land.recipe.ts
@@ -85,14 +85,17 @@ return {
     // 2. Nudge DOWN by 2 — anchor moves from row -2 to row 0; block now
     //    fills visible rows 0, 1, 2. Fully visible.
     //
-    //    Survival check (down): anchor (-2 maps to strip index 0 with
-    //    bufferAbove=2) + h - 1 + distance = 0 + 3 - 1 + 2 = 4 < total 6 ✓.
+    //    Survival check (down): anchor strip index + h - 1 + distance < total
+    //    (0 + 3 - 1 + 2 = 4 < 7) — total = bufferAbove(2) + visibleRows(3) +
+    //    bufferBelow(2). The block stays on the strip end-to-end.
     //
-    //    `incoming` describes the new bufferAbove slot that becomes visible
-    //    above the block (none — the block fills visible). The 2 incoming
-    //    slots correspond to the rows that BECOME visible above the
-    //    surviving block; here they end up in bufferAbove (off-screen)
-    //    because the block occupies the whole visible window.
+    //    `incoming` is the new visible-area content arriving from the top.
+    //    Buffer slots and big-symbol cells (anchor / OCCUPIED stubs) are
+    //    protected during pre-placement, so any incoming entries that would
+    //    land on a protected slot are dropped. Here every visible row is
+    //    consumed by the block, so the incoming pair is consumed by the
+    //    wrap pipeline (queue → random buffer fill) rather than appearing
+    //    on screen. Pass real ids regardless; the engine ignores unused ones.
     await reelSet.nudge(2, {
       distance: 2,
       direction: 'down',
@@ -102,6 +105,7 @@ return {
     await new Promise((r) => setTimeout(r, 800));
 
     // 3. Nudge UP by 2 — anchor moves back from row 0 to row -2.
+    //    Survival check (up): anchor strip index - distance >= 0 (2 - 2 = 0).
     //    Block returns to tail-visible state.
     await reelSet.nudge(2, {
       distance: 2,

--- a/apps/site/src/recipes/big-symbol-partial-land.recipe.ts
+++ b/apps/site/src/recipes/big-symbol-partial-land.recipe.ts
@@ -1,0 +1,113 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   PIXI, app
+
+// PARTIAL-LAND pattern.
+//
+// A tall 1x3 wild lands with its ANCHOR in bufferAbove — most of the
+// block is hidden above the visible window, only its bottom cell shows
+// at row 0 ("tail visible"). The player nudges DOWN by 2 to drag the
+// whole block into view, then nudges UP by 2 to push it back into
+// hiding. The classic "the big symbol is peeking — nudge to reveal"
+// fruit-machine beat.
+//
+// This is enabled by:
+//   - `_coordinateBigSymbols` scans the full strip range (including
+//     bufferAbove and bufferBelow) for big-symbol anchors. The user
+//     supplies the anchor at `bufferAbove[1]`; the engine paints
+//     OCCUPIED at `bufferAbove[0]` and `visible[0]` automatically.
+//   - `_finalizeFrame` sizes anchors that sit in bufferAbove with the
+//     block's body extending into visible. The mask clips the off-screen
+//     portion; the visible portion of the sprite shows through.
+//   - `getVisibleSymbols` resolves visible row 0 to the anchor's id via
+//     a NEGATIVE `anchorRow` in `_occupancy`.
+
+const TALL = { id: 'tall', color: 0xff8c42, label: 'TALL', textColor: 0x4a1d00, w: 1, h: 3 };
+const REELS = 5;
+const ROWS = 3;
+const SIZE = 80;
+const GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS)
+  .visibleSymbols(ROWS)
+  // Need bufferAbove >= 2 so the 1x3 block's anchor can sit at row -2
+  // with the block extending through row 0.
+  .bufferSymbols(2)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .symbols((registry) => {
+    for (const card of CARD_DECK) {
+      registry.register(card.id, CardSymbol, {
+        color: card.color, label: card.label, textColor: card.textColor,
+      });
+    }
+    registry.register(TALL.id, CardSymbol, {
+      color: TALL.color, label: TALL.label, textColor: TALL.textColor,
+    });
+  })
+  .weights(Object.fromEntries(CARD_DECK.map((c, i) => [c.id, 12 - i])))
+  .symbolData({ [TALL.id]: { weight: 0, zIndex: 5, size: { w: TALL.w, h: TALL.h } } })
+  // Big symbols don't tolerate the default landing bounce — zero it.
+  .speed('normal', { ...SpeedPresets.NORMAL, bounceDistance: 0, bounceDuration: 0 })
+  .ticker(app.ticker)
+  .build();
+
+const FILLER_IDS = ['7', '8', '9', '10', 'J'];
+const filler = () => FILLER_IDS[Math.floor(Math.random() * FILLER_IDS.length)];
+const ct = () => ({ visible: [filler(), filler(), filler()] });
+
+return {
+  reelSet,
+  onSpin: async () => {
+    // 1. Land the 1x3 TALL with anchor at `bufferAbove[1]` (= row -2).
+    //    Block spans rows -2, -1, 0. Only visible row 0 shows the block's
+    //    bottom cell; rows 1 and 2 are random fillers.
+    //
+    //    The engine paints OCCUPIED at row -1 and row 0 automatically;
+    //    we leave `bufferAbove[0]` undefined and `visible[0]` as filler
+    //    (both get overwritten by the coordinator).
+    //
+    //    NOTE: `setResult` requires every column to use the same input
+    //    shape (string[] OR ColumnTarget — never mixed). The other reels
+    //    are also ColumnTargets even though they don't need buffer entries.
+    const grid = [
+      ct(), ct(),
+      { visible: [filler(), filler(), filler()], bufferAbove: [undefined, TALL.id] },
+      ct(), ct(),
+    ];
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 220));
+    reelSet.setResult(grid);
+    await p;
+    await new Promise((r) => setTimeout(r, 700));
+
+    // 2. Nudge DOWN by 2 — anchor moves from row -2 to row 0; block now
+    //    fills visible rows 0, 1, 2. Fully visible.
+    //
+    //    Survival check (down): anchor (-2 maps to strip index 0 with
+    //    bufferAbove=2) + h - 1 + distance = 0 + 3 - 1 + 2 = 4 < total 6 ✓.
+    //
+    //    `incoming` describes the new bufferAbove slot that becomes visible
+    //    above the block (none — the block fills visible). The 2 incoming
+    //    slots correspond to the rows that BECOME visible above the
+    //    surviving block; here they end up in bufferAbove (off-screen)
+    //    because the block occupies the whole visible window.
+    await reelSet.nudge(2, {
+      distance: 2,
+      direction: 'down',
+      incoming: [filler(), filler()],
+      duration: 640,
+    });
+    await new Promise((r) => setTimeout(r, 800));
+
+    // 3. Nudge UP by 2 — anchor moves back from row 0 to row -2.
+    //    Block returns to tail-visible state.
+    await reelSet.nudge(2, {
+      distance: 2,
+      direction: 'up',
+      incoming: [filler(), filler()],
+      duration: 540,
+    });
+  },
+};

--- a/apps/site/src/recipes/empty-symbol.recipe.ts
+++ b/apps/site/src/recipes/empty-symbol.recipe.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, WILD_CARD,
+//                   PIXI, app, EmptySymbol
+
+// EMPTY SYMBOL pattern.
+//
+// `EmptySymbol` is a {@link ReelSymbol} subclass that renders nothing
+// and never animates. Register it against an id (here `'empty'`) to
+// reserve a slot in the grid that produces NO visual output.
+//
+// Why this is useful (and why hold-and-win mechanics need it):
+//   - Hold & Win bonuses spawn 1×1 "coin" pins on a grid that's
+//     otherwise blank between respins. Real symbols would compete for
+//     the player's attention with the pinned coins; an empty symbol
+//     gets out of the way.
+//   - Weighting an EMPTY id heavily (and a real symbol lightly) makes
+//     valuable symbols feel rare and exciting — every coin landing on
+//     an otherwise-blank board reads as a hit.
+//   - Random fill still needs SOME id to put in each cell. EmptySymbol
+//     is that id when "no symbol" is the desired visual.
+//
+// What this recipe runs:
+//   - 3 reels, 3 visible rows. Symbol set is `{ coin, empty }`.
+//   - Weights `{ coin: 1, empty: 6 }` — most cells land blank; coins
+//     scatter sparsely (~1 in 7 by weight).
+//   - Hit Spin to spin all three reels. Coins land in a sea of nothing.
+
+const COIN = 'coin';
+const EMPTY = 'empty';
+
+const REELS = 3;
+const ROWS = 3;
+const CELL = 88;
+const GAP = 6;
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS)
+  .visibleSymbols(ROWS)
+  .symbolSize(CELL, CELL)
+  .symbolGap(GAP, GAP)
+  .symbols((registry) => {
+    // Real symbol: a wild-card-styled "coin".
+    registry.register(COIN, CardSymbol, {
+      color: WILD_CARD.color,
+      label: WILD_CARD.label,
+      textColor: WILD_CARD.textColor,
+    });
+    // The empty cell: rendered as absolutely nothing.
+    registry.register(EMPTY, EmptySymbol, {});
+  })
+  // Coins are rare; the strip is mostly blank.
+  .weights({ [COIN]: 1, [EMPTY]: 6 })
+  .speed('normal', SpeedPresets.NORMAL)
+  .ticker(app.ticker)
+  .build();
+
+return { reelSet };

--- a/examples/shared/EmptySymbol.ts
+++ b/examples/shared/EmptySymbol.ts
@@ -1,0 +1,17 @@
+import { ReelSymbol } from 'pixi-reels';
+
+/**
+ * No-op {@link ReelSymbol} subclass. Renders nothing, never animates.
+ *
+ * Injected into the recipe / Studio / shared-studio runtime as a placeholder
+ * symbol class — useful when a recipe wants to register a symbol id that
+ * occupies a slot in the grid without producing any visual output (cascade
+ * "hole" cells, debug fillers, dry-run symbol-set wiring).
+ */
+export class EmptySymbol extends ReelSymbol {
+  protected onActivate(_symbolId: string): void {}
+  protected onDeactivate(): void {}
+  async playWin(): Promise<void> {}
+  stopAnimation(): void {}
+  resize(_w: number, _h: number): void {}
+}

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -295,6 +295,7 @@ export class Reel implements Disposable {
       config.symbolGapY,
       config.bufferAbove,
       config.visibleRows,
+      config.bufferBelow,
       (symbol, row, direction) => this._onSymbolWrapped(symbol, row, direction),
     );
 
@@ -1031,7 +1032,7 @@ export class Reel implements Disposable {
     }
 
     // Update motion: new slot height + bounds.
-    this.motion.reshape(newSymbolHeight, this._symbolGapY, bufferAbove, newVisibleRows);
+    this.motion.reshape(newSymbolHeight, this._symbolGapY, bufferAbove, newVisibleRows, bufferBelow);
     this.motion.snapToGrid();
     this.refreshZIndex();
   }

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -1325,7 +1325,12 @@ export class Reel implements Disposable {
    * **Two scans:**
    *
    *  1. Visible anchors — sizes blocks whose anchor is in `[0, visibleRows)`.
-   *     This is the common case (most blocks land fully visible).
+   *     This is the common case (most blocks land fully visible). Blocks
+   *     whose stubs spill into bufferBelow are handled here: the anchor is
+   *     in visible, the sprite is sized to span `h * cellH`, and the mask
+   *     clips the off-screen tail. No occupancy entry is written for the
+   *     bufferBelow stubs because `_occupancy` is keyed by visible rows
+   *     only — consumers can't query a non-visible cell anyway.
    *  2. BufferAbove anchors — sizes blocks whose anchor sits above visible
    *     but whose body extends into the visible window. This is the "tail
    *     visible" partial-visibility case: a 1xH block whose top is clipped
@@ -1333,6 +1338,14 @@ export class Reel implements Disposable {
    *     window. Without this scan, the anchor sprite would stay at the
    *     default 1x1 size and the block wouldn't render its visible portion
    *     correctly.
+   *
+   * **No Scan 3 for bufferBelow-only anchors.** A block whose anchor is at
+   * `row >= visibleRows` would lie entirely off-screen (the strip ends at
+   * `visibleRows + bufferBelow - 1` and `h >= 1`, so no visible cell is
+   * covered). The cross-reel coordinator already accepts such anchors as a
+   * legal-but-invisible placement; there's nothing to size and nothing for
+   * the consumer-facing query API to return. If you ever add a scenario
+   * where bufferBelow-only anchors need rendering, add Scan 3 here.
    *
    * For bufferAbove anchors, `_occupancy[visibleRow].anchorRow` is set to
    * a NEGATIVE value — the offset from `bufferAbove`. So

--- a/packages/pixi-reels/src/core/ReelMotion.ts
+++ b/packages/pixi-reels/src/core/ReelMotion.ts
@@ -28,12 +28,20 @@ export class ReelMotion {
     symbolGapY: number,
     private _bufferAbove: number,
     visibleRows: number,
+    bufferBelow: number,
     private _onSymbolWrapped: (symbol: ReelSymbol, arrayIndex: number, direction: 'up' | 'down') => void,
   ) {
     this._symbolHeight = symbolHeight;
     this._symbolGapY = symbolGapY;
     this._slotHeight = symbolHeight + symbolGapY;
-    this._maxY = (visibleRows + 1) * this._slotHeight;
+    // Wrap thresholds sit one slot beyond the strip on each side. The last
+    // strip cell rests at y = (visibleRows + bufferBelow - 1) * slotH, so
+    // maxY = (visibleRows + bufferBelow) * slotH keeps it strictly below
+    // the wrap boundary at rest. Symmetric with minY's `bufferAbove + 1`.
+    // Pre-fix the formula was `(visibleRows + 1) * slotH`, which collapsed
+    // to maxY === strip[last].y for bufferBelow >= 2 and fired a phantom
+    // wrap on the first nudge displacement (anchor moved one slot too far).
+    this._maxY = (visibleRows + bufferBelow) * this._slotHeight;
     this._minY = -(this._bufferAbove + 1) * this._slotHeight;
   }
 
@@ -85,12 +93,12 @@ export class ReelMotion {
    * `Reel.reshape()` directly via the same array reference, so this method
    * doesn't take a new array.
    */
-  reshape(symbolHeight: number, symbolGapY: number, bufferAbove: number, visibleRows: number): void {
+  reshape(symbolHeight: number, symbolGapY: number, bufferAbove: number, visibleRows: number, bufferBelow: number): void {
     this._symbolHeight = symbolHeight;
     this._symbolGapY = symbolGapY;
     this._slotHeight = symbolHeight + symbolGapY;
     this._bufferAbove = bufferAbove;
-    this._maxY = (visibleRows + 1) * this._slotHeight;
+    this._maxY = (visibleRows + bufferBelow) * this._slotHeight;
     this._minY = -(this._bufferAbove + 1) * this._slotHeight;
   }
 

--- a/packages/pixi-reels/src/core/ReelSet.ts
+++ b/packages/pixi-reels/src/core/ReelSet.ts
@@ -19,7 +19,7 @@ import { pinKey } from '../pins/CellPin.js';
 import { getGsap } from '../utils/gsapRef.js';
 import type { FrameMiddleware } from '../frame/FrameBuilder.js';
 import type { ColumnTarget } from '../frame/ColumnTarget.js';
-import { cloneTargetGrid, toLegacyTargetGrid } from '../frame/ColumnTarget.js';
+import { assertBufferCountsInRange, cloneTargetGrid, toLegacyTargetGrid } from '../frame/ColumnTarget.js';
 import type { Cell } from '../cascade/tumbleAlgorithm.js';
 
 export interface ReelSetParams {
@@ -505,6 +505,12 @@ export class ReelSet extends Container implements Disposable {
    * always land on the pin's `symbolId` regardless of what the server sent.
    */
   setResult(symbols: string[][] | ColumnTarget[]): void {
+    assertBufferCountsInRange(
+      symbols,
+      this._reels.map((r) => r.bufferAbove),
+      this._reels.map((r) => r.bufferBelow),
+      'setResult',
+    );
     const grid = toLegacyTargetGrid(symbols);
     const withPins = this._applyPinsToGrid(grid);
     this._resultSetForCurrentSpin = true;

--- a/packages/pixi-reels/src/core/ReelSetBuilder.ts
+++ b/packages/pixi-reels/src/core/ReelSetBuilder.ts
@@ -26,7 +26,7 @@ import type { SpinningMode } from '../spin/modes/SpinningMode.js';
 import { StandardMode } from '../spin/modes/StandardMode.js';
 import type { FrameMiddleware } from '../frame/FrameBuilder.js';
 import type { ColumnTarget } from '../frame/ColumnTarget.js';
-import { toLegacyTargetGrid } from '../frame/ColumnTarget.js';
+import { assertBufferCountsInRange, toLegacyTargetGrid } from '../frame/ColumnTarget.js';
 import type { TumbleConfig, ResolvedTumbleConfig } from '../cascade/TumbleConfig.js';
 import { resolveTumbleConfig } from '../cascade/TumbleConfig.js';
 import { CascadeFallPhase } from '../spin/phases/CascadeFallPhase.js';
@@ -80,7 +80,7 @@ export class ReelSetBuilder {
   private _spinningMode: SpinningMode = new StandardMode();
   private _phaseFactory = new PhaseFactory();
   private _middlewares: FrameMiddleware[] = [];
-  private _initialFrame?: string[][];
+  private _initialFrame?: string[][] | ColumnTarget[];
   private _symbolDataOverrides: Record<string, Partial<SymbolData>> = {};
   private _tumbleConfig?: ResolvedTumbleConfig;
   private _defaultSpinMode: 'standard' | 'cascade' = 'standard';
@@ -446,7 +446,12 @@ export class ReelSetBuilder {
    *      explicit form does.
    */
   initialFrame(frame: string[][] | ColumnTarget[]): this {
-    this._initialFrame = toLegacyTargetGrid(frame);
+    // Stored un-materialized so `build()` can validate it against the
+    // final bufferSymbols config (which may not be set yet when
+    // `initialFrame()` is called — builder methods are order-free) and
+    // produce form-faithful error messages (explicit `bufferAbove[]`
+    // vs legacy `frame[col][-k]`).
+    this._initialFrame = frame;
     return this;
   }
 
@@ -647,6 +652,23 @@ export class ReelSetBuilder {
       this._offset,
     );
 
+    // Validate + materialize the initial frame now that buffer counts are
+    // fully resolved. `initialFrame()` stores the raw input so the
+    // validator sees the original form and can produce form-faithful
+    // error messages (explicit `bufferAbove[]` vs legacy `frame[col][-k]`).
+    let materializedInitialFrame: string[][] | undefined;
+    if (this._initialFrame) {
+      const bufferAboveArr = new Array(reelCount).fill(bufferAbove);
+      const bufferBelowArr = new Array(reelCount).fill(bufferBelow);
+      assertBufferCountsInRange(
+        this._initialFrame,
+        bufferAboveArr,
+        bufferBelowArr,
+        'initialFrame',
+      );
+      materializedInitialFrame = toLegacyTargetGrid(this._initialFrame);
+    }
+
     // Create reels with per-reel geometry.
     const reels: Reel[] = [];
     const maskRects: ReelMaskRect[] = [];
@@ -655,8 +677,8 @@ export class ReelSetBuilder {
       const initialCellH = initialSymbolHeight[reelIndex];
 
       // Per-reel initial frame at its own visibleRows count.
-      const initialFrame = this._initialFrame
-        ? frameBuilder.build(reelIndex, rows, bufferAbove, bufferBelow, this._initialFrame[reelIndex])
+      const initialFrame = materializedInitialFrame
+        ? frameBuilder.build(reelIndex, rows, bufferAbove, bufferBelow, materializedInitialFrame[reelIndex])
         : frameBuilder.build(reelIndex, rows, bufferAbove, bufferBelow);
 
       const reelConfig: ReelConfig = {

--- a/packages/pixi-reels/src/frame/ColumnTarget.ts
+++ b/packages/pixi-reels/src/frame/ColumnTarget.ts
@@ -110,6 +110,91 @@ export function columnTargetToArray(target: ColumnTarget): string[] {
 }
 
 /**
+ * Validate that a target grid does not carry more buffer-above / buffer-below
+ * entries than the engine can consume. Throws a `RangeError` with a
+ * column-pointing message if it does; otherwise a no-op.
+ *
+ * Background — without this check the failure is silent. `columnTargetToArray`
+ * materializes `bufferAbove[k]` as `arr[-1-k]` and `bufferBelow[k]` as
+ * `arr[visible.length + k]`, but downstream the pipeline only reads the first
+ * `bufferAbove` negative-index slots (see `cloneColumn` — its loop runs
+ * `1..bufferAbove` only) and the first `bufferBelow` post-visible slots.
+ * Extra entries land in the array, are dropped at the next clone, and never
+ * reach the reel. Failing here at the entry point is far cheaper than a
+ * "why didn't my target land" debugging session.
+ *
+ * Validates both input forms:
+ *   - Explicit `ColumnTarget`: checks `bufferAbove.length` and
+ *     `bufferBelow.length` directly against the engine's configured counts.
+ *     This is the form most likely to be misused — its lengths survive
+ *     `structuredClone`, so an off-by-one overflow can ride along
+ *     unnoticed across worker / network boundaries.
+ *   - Legacy `string[]`: scans own-property names for negative-index keys
+ *     beyond `-bufferAbove`. We do NOT validate the array length against
+ *     `visibleRows + bufferBelow` for this form: in MultiWays the per-reel
+ *     `visibleRows` changes after `setShape()` but before `setResult()`,
+ *     so any visibleRows-based check fires false positives on legitimate
+ *     post-reshape calls. The negative-index check is safe because
+ *     `bufferAbove` is stable across reshape (see Reel.reshape — only
+ *     `_visibleRows` mutates; `_bufferAbove` is reassigned to the same
+ *     value). Callers using the legacy form for `bufferBelow` overflow
+ *     should switch to the explicit form, which has no such limitation.
+ *
+ * Mixed-shape grids are NOT validated here — `toLegacyTargetGrid` already
+ * throws on those with a more specific message, and the validator inspects
+ * each column on its own merits so mixing won't crash this pass.
+ *
+ * `callerLabel` shows up in the thrown message so the caller knows which
+ * public API surfaced the error.
+ */
+export function assertBufferCountsInRange(
+  grid: string[][] | ColumnTarget[],
+  bufferAbovePerReel: ReadonlyArray<number>,
+  bufferBelowPerReel: ReadonlyArray<number>,
+  callerLabel: string,
+): void {
+  for (let c = 0; c < grid.length; c++) {
+    const maxAbove = bufferAbovePerReel[c] ?? 0;
+    const maxBelow = bufferBelowPerReel[c] ?? 0;
+    const item = grid[c];
+
+    if (Array.isArray(item)) {
+      let mostNegative = 0;
+      for (const key of Object.getOwnPropertyNames(item)) {
+        if (key[0] !== '-') continue;
+        const n = Number(key);
+        if (Number.isInteger(n) && n < 0 && n < mostNegative) mostNegative = n;
+      }
+      if (-mostNegative > maxAbove) {
+        throw new RangeError(
+          `${callerLabel} column ${c}: frame[${c}][${mostNegative}] is set ` +
+          `but engine bufferSymbols=${maxAbove} — only frame[${c}][-1..-${maxAbove}] is consumed; ` +
+          `extra entries would be silently dropped. ` +
+          `Increase bufferSymbols(...) on the builder or remove the extra entries.`,
+        );
+      }
+    } else {
+      const aboveLen = item.bufferAbove?.length ?? 0;
+      const belowLen = item.bufferBelow?.length ?? 0;
+      if (aboveLen > maxAbove) {
+        throw new RangeError(
+          `${callerLabel} column ${c}: bufferAbove has ${aboveLen} entries ` +
+          `but engine bufferSymbols=${maxAbove} — extra entries would be silently dropped. ` +
+          `Increase bufferSymbols(...) on the builder or remove the extra entries.`,
+        );
+      }
+      if (belowLen > maxBelow) {
+        throw new RangeError(
+          `${callerLabel} column ${c}: bufferBelow has ${belowLen} entries ` +
+          `but engine bufferSymbols=${maxBelow} — extra entries would be silently dropped. ` +
+          `Increase bufferSymbols(...) on the builder or remove the extra entries.`,
+        );
+      }
+    }
+  }
+}
+
+/**
  * Normalize either input form into the legacy `string[][]` shape the
  * pipeline runs on. Cheap when the input is already `string[][]` — returns
  * it unchanged. Otherwise materializes one `string[]` per column.

--- a/packages/pixi-reels/src/frame/ColumnTarget.ts
+++ b/packages/pixi-reels/src/frame/ColumnTarget.ts
@@ -14,12 +14,26 @@ export interface ColumnTarget {
    * Buffer-above target symbols. `bufferAbove[0]` is the slot closest to the
    * visible top row; `bufferAbove[bufferAboveCount-1]` is the furthest above.
    * Equivalent to legacy `frame[col][-1] … frame[col][-bufferAboveCount]`.
+   *
+   * **Big-symbol anchors may sit here.** Place a multi-cell symbol id (one
+   * whose `SymbolData.size.h > 1`) at any `bufferAbove[i]` and the
+   * coordinator paints OCCUPIED stubs across the rest of the block —
+   * including any cells that fall in visible. The block must fit on the
+   * strip end-to-end (`anchor.row + h <= visibleRows + bufferBelow`); the
+   * portion above visible is clipped by the reel mask. This is the
+   * "tail-visible" partial-landing pattern.
    */
   bufferAbove?: (string | undefined)[];
   /**
    * Buffer-below target symbols. `bufferBelow[0]` is the slot closest to the
    * visible bottom row; later indices go further below.
    * Equivalent to legacy `frame[col][visibleRows] … frame[col][visibleRows + n - 1]`.
+   *
+   * **Big-symbol stubs may sit here.** A block anchored at the last visible
+   * row with `h > 1` will have its non-anchor cells spill into `bufferBelow`
+   * automatically — you don't need to place stubs by hand. You can also
+   * place an anchor here, but the block then lies entirely off-screen
+   * (legal but invisible — the engine accepts the placement).
    */
   bufferBelow?: (string | undefined)[];
 }

--- a/packages/pixi-reels/src/spin/SpinController.ts
+++ b/packages/pixi-reels/src/spin/SpinController.ts
@@ -1238,14 +1238,19 @@ export class SpinController implements Disposable {
     grid: string[][],
     visibleRowsForReel: (i: number) => number,
   ): string[][] {
-    const bufferAbove0 = this._reels[0]?.bufferAbove ?? 0;
-    const out = cloneTargetGrid(grid, bufferAbove0);
+    const bufferAbove = this._reels[0]?.bufferAbove ?? 0;
+    const bufferBelow = this._reels[0]?.bufferBelow ?? 0;
+    const out = cloneTargetGrid(grid, bufferAbove);
     const symData = this._hooks.symbolsData;
 
-    // Buffer geometry is uniform across reels in every shipped slot
-    // (set by the builder); we assume that here.
-    const bufferAbove = bufferAbove0;
-    const bufferBelow = this._reels[0]?.bufferBelow ?? 0;
+    // Buffer geometry is read from reel[0] and treated as uniform across
+    // all reels. This holds today because `ReelSetBuilder.bufferSymbols(n)`
+    // is the only buffer-setting API and applies a single global value;
+    // there is no per-reel buffer API. If you ever add one (e.g. a
+    // `bufferSymbolsPerReel([...])` builder method), propagate per-reel
+    // values into the validator loop below — the `targetRows` lookup
+    // already supports per-reel geometry; only the buffers are still
+    // global here.
 
     // Read a per-reel target slot for any row in `[-bufferAbove, rows + bufferBelow)`.
     // Negative rows live as string properties (`out[col][-1]`); positive rows

--- a/packages/pixi-reels/src/spin/SpinController.ts
+++ b/packages/pixi-reels/src/spin/SpinController.ts
@@ -1238,24 +1238,55 @@ export class SpinController implements Disposable {
     grid: string[][],
     visibleRowsForReel: (i: number) => number,
   ): string[][] {
-    const out = cloneTargetGrid(grid, this._reels[0]?.bufferAbove ?? 0);
+    const bufferAbove0 = this._reels[0]?.bufferAbove ?? 0;
+    const out = cloneTargetGrid(grid, bufferAbove0);
     const symData = this._hooks.symbolsData;
+
+    // Buffer geometry is uniform across reels in every shipped slot
+    // (set by the builder); we assume that here.
+    const bufferAbove = bufferAbove0;
+    const bufferBelow = this._reels[0]?.bufferBelow ?? 0;
+
+    // Read a per-reel target slot for any row in `[-bufferAbove, rows + bufferBelow)`.
+    // Negative rows live as string properties (`out[col][-1]`); positive rows
+    // are normal array indices. We tolerate both forms because the legacy
+    // `string[][]` input passes through unchanged and the `ColumnTarget`
+    // form has already been materialized into the same shape by
+    // `toLegacyTargetGrid`.
+    const readSlot = (col: number, row: number): string | undefined => {
+      const arr = out[col] as string[] & Record<number, string | undefined>;
+      return arr[row];
+    };
+    const writeSlot = (col: number, row: number, value: string): void => {
+      const arr = out[col] as string[] & Record<number, string>;
+      arr[row] = value;
+    };
 
     for (let col = 0; col < out.length; col++) {
       const rows = visibleRowsForReel(col);
-      for (let row = 0; row < rows && row < out[col].length; row++) {
-        const id = out[col][row];
+      // Iterate the FULL strip range, not just visible. A big-symbol anchor
+      // may sit in bufferAbove (partial-visibility from the top — only the
+      // block's tail shows in row 0) or in bufferBelow (the head shows at
+      // the last visible row, the rest is clipped below the mask).
+      // `_finalizeFrame` sizes anchors anywhere on the strip, so the engine
+      // renders both cases correctly.
+      for (let row = -bufferAbove; row < rows + bufferBelow; row++) {
+        const id = readSlot(col, row);
+        if (id === undefined) continue;
         const meta = symData[id];
         if (!meta?.size) continue;
         const w = meta.size.w;
         const h = meta.size.h;
         if (w === 1 && h === 1) continue;
 
-        // Validate block fit on this reel and across columns to the right.
-        if (row + h > rows) {
+        // Validate block fit on this reel: anchor + h must stay on the
+        // strip. The strip ends at `rows + bufferBelow - 1` (last bufferBelow
+        // slot) and starts at `-bufferAbove` (first bufferAbove slot).
+        if (row + h > rows + bufferBelow) {
           throw new Error(
             `big symbol '${id}' (${w}x${h}) at (col=${col}, row=${row}) ` +
-            `exceeds reel ${col} height ${rows}.`,
+            `extends past the bottom of the strip on reel ${col} ` +
+            `(anchor row + h = ${row + h} > visibleRows + bufferBelow = ${rows + bufferBelow}).`,
           );
         }
         if (col + w > out.length) {
@@ -1267,19 +1298,22 @@ export class SpinController implements Disposable {
         for (let dx = 0; dx < w; dx++) {
           const targetReel = col + dx;
           const targetRows = visibleRowsForReel(targetReel);
-          if (row + h > targetRows) {
+          if (row + h > targetRows + bufferBelow) {
             throw new Error(
               `big symbol '${id}' (${w}x${h}) at (col=${col}, row=${row}) ` +
-              `exceeds reel ${targetReel} height ${targetRows}.`,
+              `extends past the bottom of the strip on reel ${targetReel} ` +
+              `(anchor row + h = ${row + h} > visibleRows + bufferBelow = ${targetRows + bufferBelow}).`,
             );
           }
         }
 
         // Paint OCCUPIED across the block (skip the anchor itself at dx=0,dy=0).
+        // Stub cells may land in bufferAbove (negative row), visible, or
+        // bufferBelow (row >= visibleRows). `writeSlot` handles all three.
         for (let dy = 0; dy < h; dy++) {
           for (let dx = 0; dx < w; dx++) {
             if (dx === 0 && dy === 0) continue;
-            out[col + dx][row + dy] = OCCUPIED_SENTINEL;
+            writeSlot(col + dx, row + dy, OCCUPIED_SENTINEL);
           }
         }
       }

--- a/packages/pixi-reels/tests/integration/bufferOverflow.test.ts
+++ b/packages/pixi-reels/tests/integration/bufferOverflow.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Buffer-overflow fail-fast tests for the two public entry points that
+ * accept `ColumnTarget[]` / legacy `string[][]` grids: `ReelSet.setResult`
+ * and `ReelSetBuilder.initialFrame`.
+ *
+ * The bug being defended against: extra `bufferAbove` / `bufferBelow`
+ * entries (more than the engine's configured `bufferSymbols`) used to be
+ * written into the materialized array but silently dropped by the next
+ * clone — no error, no warning, target never lands. The assertion is now
+ * at the entry point so the caller sees the misuse immediately.
+ */
+import { describe, it, expect } from 'vitest';
+import { createTestReelSet } from '../../src/testing/index.js';
+import { ReelSetBuilder } from '../../src/core/ReelSetBuilder.js';
+import { FakeTicker } from '../../src/testing/FakeTicker.js';
+import { HeadlessSymbol } from '../../src/testing/HeadlessSymbol.js';
+import type { Ticker } from 'pixi.js';
+
+const SYMBOLS = ['a', 'b', 'c', 'X', 'Y'];
+
+describe('setResult — buffer overflow throws', () => {
+  it('throws when ColumnTarget.bufferAbove has more entries than bufferSymbols', () => {
+    const h = createTestReelSet({ reels: 3, visibleRows: 3, symbolIds: SYMBOLS, bufferSymbols: 1 });
+    try {
+      expect(() =>
+        h.reelSet.setResult([
+          { visible: ['a', 'b', 'c'] },
+          { visible: ['a', 'b', 'c'], bufferAbove: ['X', 'Y'] }, // 2 > 1
+          { visible: ['a', 'b', 'c'] },
+        ]),
+      ).toThrowError(/setResult column 1: bufferAbove has 2 entries but engine bufferSymbols=1/);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('throws when ColumnTarget.bufferBelow has more entries than bufferSymbols', () => {
+    const h = createTestReelSet({ reels: 3, visibleRows: 3, symbolIds: SYMBOLS, bufferSymbols: 1 });
+    try {
+      expect(() =>
+        h.reelSet.setResult([
+          { visible: ['a', 'b', 'c'] },
+          { visible: ['a', 'b', 'c'], bufferBelow: ['X', 'Y'] }, // 2 > 1
+          { visible: ['a', 'b', 'c'] },
+        ]),
+      ).toThrowError(/setResult column 1: bufferBelow has 2 entries but engine bufferSymbols=1/);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('throws for legacy form negative-index keys beyond bufferAbove', () => {
+    const h = createTestReelSet({ reels: 3, visibleRows: 3, symbolIds: SYMBOLS, bufferSymbols: 1 });
+    try {
+      const col: string[] = ['a', 'b', 'c'];
+      (col as Record<number, string>)[-1] = 'X';
+      (col as Record<number, string>)[-2] = 'Y'; // out of range
+      expect(() =>
+        h.reelSet.setResult([['a', 'b', 'c'], col, ['a', 'b', 'c']]),
+      ).toThrowError(/setResult column 1: frame\[1\]\[-2\] is set but engine bufferSymbols=1/);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('accepts ColumnTarget within bounds (regression — assertion is non-disruptive)', async () => {
+    const h = createTestReelSet({ reels: 3, visibleRows: 3, symbolIds: SYMBOLS, bufferSymbols: 1 });
+    try {
+      await h.spinAndLand([
+        { visible: ['a', 'b', 'c'] },
+        { visible: ['a', 'b', 'c'], bufferAbove: ['X'] },
+        { visible: ['a', 'b', 'c'], bufferBelow: ['Y'] },
+      ] as unknown as string[][]);
+      expect(h.reelSet.reels[1].symbols[0].symbolId).toBe('X');
+      expect(
+        h.reelSet.reels[2].symbols[h.reelSet.reels[2].symbols.length - 1].symbolId,
+      ).toBe('Y');
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('accepts bufferSymbols(2) when the caller supplies two entries', async () => {
+    const h = createTestReelSet({ reels: 3, visibleRows: 3, symbolIds: SYMBOLS, bufferSymbols: 2 });
+    try {
+      await h.spinAndLand([
+        { visible: ['a', 'b', 'c'] },
+        { visible: ['a', 'b', 'c'], bufferAbove: ['X', 'Y'] },
+        { visible: ['a', 'b', 'c'] },
+      ] as unknown as string[][]);
+      // bufferAbove=2: bufferAbove[0]='X' closest to visible → arr[-1] → reel.symbols[1];
+      // bufferAbove[1]='Y' furthest above → arr[-2] → reel.symbols[0].
+      expect(h.reelSet.reels[1].symbols[0].symbolId).toBe('Y');
+      expect(h.reelSet.reels[1].symbols[1].symbolId).toBe('X');
+    } finally {
+      h.destroy();
+    }
+  });
+});
+
+describe('initialFrame — buffer overflow throws', () => {
+  function makeBuilder() {
+    return new ReelSetBuilder()
+      .reels(3)
+      .visibleRows(3)
+      .symbolSize(100, 100)
+      .ticker(new FakeTicker() as unknown as Ticker)
+      .symbols((r) => {
+        for (const id of SYMBOLS) r.register(id, HeadlessSymbol, {});
+      });
+  }
+
+  it('throws on build() when ColumnTarget.bufferAbove exceeds bufferSymbols', () => {
+    const builder = makeBuilder()
+      .bufferSymbols(1)
+      .initialFrame([
+        { visible: ['a', 'b', 'c'] },
+        { visible: ['a', 'b', 'c'], bufferAbove: ['X', 'Y'] }, // 2 > 1
+        { visible: ['a', 'b', 'c'] },
+      ]);
+    expect(() => builder.build()).toThrowError(
+      /initialFrame column 1: bufferAbove has 2 entries but engine bufferSymbols=1/,
+    );
+  });
+
+  it('throws on build() when ColumnTarget.bufferBelow exceeds bufferSymbols', () => {
+    const builder = makeBuilder()
+      .bufferSymbols(1)
+      .initialFrame([
+        { visible: ['a', 'b', 'c'] },
+        { visible: ['a', 'b', 'c'], bufferBelow: ['X', 'Y'] }, // 2 > 1
+        { visible: ['a', 'b', 'c'] },
+      ]);
+    expect(() => builder.build()).toThrowError(
+      /initialFrame column 1: bufferBelow has 2 entries but engine bufferSymbols=1/,
+    );
+  });
+
+  it('throws on build() for legacy form negative-index keys beyond bufferAbove', () => {
+    const col: string[] = ['a', 'b', 'c'];
+    (col as Record<number, string>)[-1] = 'X';
+    (col as Record<number, string>)[-2] = 'Y';
+    const builder = makeBuilder()
+      .bufferSymbols(1)
+      .initialFrame([['a', 'b', 'c'], col, ['a', 'b', 'c']]);
+    expect(() => builder.build()).toThrowError(
+      /initialFrame column 1: frame\[1\]\[-2\] is set but engine bufferSymbols=1/,
+    );
+  });
+
+  it('order of builder calls does not matter — overflow throws regardless', () => {
+    // initialFrame() called BEFORE bufferSymbols(). The previous behavior
+    // was to materialize immediately with whatever defaults were set; the
+    // current behavior defers materialization to build() so configuration
+    // is final by the time we check.
+    const builder = makeBuilder()
+      .initialFrame([
+        { visible: ['a', 'b', 'c'] },
+        { visible: ['a', 'b', 'c'], bufferAbove: ['X', 'Y'] }, // 2 entries
+        { visible: ['a', 'b', 'c'] },
+      ])
+      .bufferSymbols(1); // set AFTER initialFrame; 2 > 1 still throws
+    expect(() => builder.build()).toThrowError(/bufferAbove has 2 entries/);
+  });
+
+  it('accepts initialFrame within bounds (regression)', () => {
+    const builder = makeBuilder()
+      .bufferSymbols(1)
+      .initialFrame([
+        { visible: ['a', 'b', 'c'] },
+        { visible: ['a', 'b', 'c'], bufferAbove: ['X'] },
+        { visible: ['a', 'b', 'c'], bufferBelow: ['Y'] },
+      ]);
+    const reelSet = builder.build();
+    try {
+      expect(reelSet.reels[1].symbols[0].symbolId).toBe('X');
+      expect(reelSet.reels[2].symbols[reelSet.reels[2].symbols.length - 1].symbolId).toBe('Y');
+    } finally {
+      reelSet.destroy();
+    }
+  });
+});
+
+// ─── MultiWays compatibility regression ──────────────────────────────────
+//
+// MultiWays varies visible row counts per spin: `setShape([5,2,6])` records
+// the target shape, then `setResult` passes a grid sized to that target,
+// then AdjustPhase reshapes the reels DURING the spin. At the moment
+// `setResult` runs the validator, `reel.visibleRows` still holds the
+// PREVIOUS spin's shape — so a check that compared `grid[i].length` to
+// `visibleRows + bufferBelow` would fire false positives on every
+// legitimate MultiWays spin that resizes.
+//
+// The validator's design decision is to OMIT the length-based bufferBelow
+// check for the legacy `string[]` form (using the explicit form is the
+// recommended path for full overflow protection). This test pins that
+// decision so a future contributor can't silently reintroduce the check
+// without breaking MultiWays.
+describe('setResult — MultiWays compatibility', () => {
+  it('does NOT throw when legacy-form column length > current visibleRows (MultiWays reshape pending)', async () => {
+    const ticker = new FakeTicker();
+    const reelSet = new ReelSetBuilder()
+      .reels(3)
+      .multiways({ minRows: 2, maxRows: 6, reelPixelHeight: 600 })
+      .symbolSize(100, 100)
+      .tumble()
+      .ticker(ticker as unknown as Ticker)
+      .symbols((r) => {
+        for (const id of SYMBOLS) r.register(id, HeadlessSymbol, {});
+      })
+      .build();
+
+    try {
+      // Spin 1: shape [3,4,2] — reels resize from default (maxRows=6) to
+      // these values during AdjustPhase.
+      let promise = reelSet.spin({ mode: 'cascade' });
+      reelSet.setShape([3, 4, 2]);
+      reelSet.setResult([
+        ['a', 'b', 'c'],
+        ['a', 'b', 'c', 'a'],
+        ['a', 'b'],
+      ]);
+      reelSet.slamStop();
+      await promise;
+      expect(reelSet.reels.map((r) => r.visibleRows)).toEqual([3, 4, 2]);
+
+      // Spin 2: shape [5,2,6]. At setResult time, reels are still at
+      // [3,4,2] from spin 1 — `reel.visibleRows[0]` = 3, but the caller
+      // legitimately passes a length-5 column. The validator must NOT
+      // throw here (this was the v1 regression).
+      promise = reelSet.spin({ mode: 'cascade' });
+      reelSet.setShape([5, 2, 6]);
+      expect(() => {
+        reelSet.setResult([
+          ['a', 'b', 'c', 'a', 'b'],
+          ['a', 'b'],
+          ['a', 'b', 'c', 'a', 'b', 'c'],
+        ]);
+      }).not.toThrow();
+      reelSet.slamStop();
+      await promise;
+      expect(reelSet.reels.map((r) => r.visibleRows)).toEqual([5, 2, 6]);
+    } finally {
+      reelSet.destroy();
+      ticker.destroy();
+    }
+  });
+
+  it('still throws on legacy-form NEGATIVE-index overflow during MultiWays — bufferAbove is stable across reshape', async () => {
+    const ticker = new FakeTicker();
+    const reelSet = new ReelSetBuilder()
+      .reels(3)
+      .multiways({ minRows: 2, maxRows: 6, reelPixelHeight: 600 })
+      .bufferSymbols(1)
+      .symbolSize(100, 100)
+      .tumble()
+      .ticker(ticker as unknown as Ticker)
+      .symbols((r) => {
+        for (const id of SYMBOLS) r.register(id, HeadlessSymbol, {});
+      })
+      .build();
+
+    try {
+      reelSet.spin({ mode: 'cascade' }).catch(() => {});
+      reelSet.setShape([3, 3, 3]);
+
+      const col: string[] = ['a', 'b', 'c'];
+      (col as Record<number, string>)[-1] = 'X';
+      (col as Record<number, string>)[-2] = 'Y'; // overflow
+
+      expect(() => {
+        reelSet.setResult([['a', 'b', 'c'], col, ['a', 'b', 'c']]);
+      }).toThrowError(/setResult column 1: frame\[1\]\[-2\] is set but engine bufferSymbols=1/);
+
+      reelSet.slamStop();
+    } finally {
+      reelSet.destroy();
+      ticker.destroy();
+    }
+  });
+});

--- a/packages/pixi-reels/tests/integration/cascade-bigSymbol-fall.test.ts
+++ b/packages/pixi-reels/tests/integration/cascade-bigSymbol-fall.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Cascade refill with a buffer-anchored big symbol.
+ *
+ * A 1×3 wild lands with its anchor in bufferAbove (tail visible at row 0).
+ * A win-bearing row below the tail clears, and the `refill()` grid moves
+ * the anchor to a fully-visible row. Asserts that `_coordinateBigSymbols`
+ * runs on the refill path the same as on `setResult`, and that the moved
+ * block's strip layout is correct post-refill.
+ *
+ * This is the recipe in /apps/site/src/recipes/big-symbol-cascade-fall.recipe.ts,
+ * boiled down to a headless deterministic test.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Ticker } from 'pixi.js';
+import { ReelSetBuilder } from '../../src/core/ReelSetBuilder.js';
+import { HeadlessSymbol } from '../../src/testing/HeadlessSymbol.js';
+import { FakeTicker } from '../../src/testing/FakeTicker.js';
+import { OCCUPIED_SENTINEL } from '../../src/core/Reel.js';
+
+// Headless tumble harness with the big-symbol-friendly setup. Builder
+// `initialFrame` doesn't run `_coordinateBigSymbols`, so we land the
+// initial state through a spin → setResult → slamStop pipeline (the
+// same path `createTestReelSet.spinAndLand` uses, just inlined here
+// because the shared harness doesn't expose tumble config).
+function buildTumbleHarnessWithBigSymbol() {
+  const ticker = new FakeTicker();
+  const reelSet = new ReelSetBuilder()
+    .reels(3)
+    .visibleSymbols(4)
+    .bufferSymbols(2)
+    .symbolSize(50, 50)
+    .symbols((r) => {
+      for (const id of ['a', 'b', 'tall', 'match']) r.register(id, HeadlessSymbol, {});
+    })
+    .weights({ a: 1, b: 1, match: 1 })
+    .symbolData({ tall: { weight: 0, size: { w: 1, h: 3 } } })
+    .tumble({
+      fall:   { duration: 0, ease: 'none', rowStagger: 0 },
+      dropIn: { duration: 0, ease: 'none', rowStagger: 0, distance: 'perHole' },
+    })
+    .ticker(ticker as unknown as Ticker)
+    .build();
+  return {
+    reelSet,
+    ticker,
+    destroy: () => { reelSet.destroy(); ticker.destroy(); },
+  };
+}
+
+describe('cascade refill — buffer-anchored big symbol', () => {
+  it('moves a 1x3 anchor from bufferAbove[1] to visible[0] via a one-step cascade refill', async () => {
+    const { reelSet, destroy } = buildTumbleHarnessWithBigSymbol();
+    try {
+      // Land the initial state through the spin pipeline so
+      // _coordinateBigSymbols paints OCCUPIED stubs.
+      const spinDone = reelSet.spin();
+      reelSet.setResult([
+        // Reel 0: anchor at bufferAbove[1] = row -2. Block at rows -2, -1, 0.
+        // Tail visible at row 0. Plant MATCH at row 1.
+        { visible: ['a', 'match', 'a', 'a'], bufferAbove: [undefined, 'tall'] },
+        { visible: ['b', 'match', 'b', 'b'] },
+        { visible: ['b', 'match', 'b', 'b'] },
+      ]);
+      reelSet.slamStop();
+      await spinDone;
+
+      // Sanity: initial state has the tall block tail-visible.
+      const beforeGrid = reelSet.getVisibleGrid();
+      expect(beforeGrid[0]).toEqual(['tall', 'match', 'a', 'a']);
+      // Strip layout: anchor at strip[0], stubs at strip[1..2].
+      expect(reelSet.reels[0].symbols[0].symbolId).toBe('tall');
+      expect(reelSet.reels[0].symbols[1].symbolId).toBe(OCCUPIED_SENTINEL);
+      expect(reelSet.reels[0].symbols[2].symbolId).toBe(OCCUPIED_SENTINEL);
+
+      // Cascade refill: row-1 cluster wins, wild falls to visible[0..2].
+      await reelSet.refill({
+        winners: [
+          { reel: 0, row: 1 },
+          { reel: 1, row: 1 },
+          { reel: 2, row: 1 },
+        ],
+        grid: [
+          // Reel 0: anchor now at row 0 (fully visible). The coordinator
+          // paints OCCUPIED at visible[1] and visible[2] from the
+          // size.h = 3 metadata; the 'a' placeholders at those rows are
+          // overwritten.
+          { visible: ['tall', 'a', 'a', 'a'], bufferAbove: ['a'] },
+          // Reels 1, 2: fresh fillers.
+          { visible: ['b', 'b', 'b', 'b'] },
+          { visible: ['b', 'b', 'b', 'b'] },
+        ],
+      });
+
+      // Block now fully visible on reel 0.
+      const afterGrid = reelSet.getVisibleGrid();
+      expect(afterGrid[0]).toEqual(['tall', 'tall', 'tall', 'a']);
+
+      // Strip layout post-refill:
+      // bufferAbove(2) | visible(4) | bufferBelow(2) — 8 cells.
+      //   strip[0,1]   |  [2..5]    |  [6,7]
+      // Anchor moved to strip[2] (visible[0]); stubs at strip[3..4].
+      const reel0 = reelSet.reels[0];
+      expect(reel0.symbols[2].symbolId).toBe('tall');
+      expect(reel0.symbols[3].symbolId).toBe(OCCUPIED_SENTINEL);
+      expect(reel0.symbols[4].symbolId).toBe(OCCUPIED_SENTINEL);
+      // bufferBelow must NOT carry any block cell — the block stopped
+      // at strip[4].
+      expect(reel0.symbols[5].symbolId).not.toBe(OCCUPIED_SENTINEL);
+      expect(reel0.symbols[5].symbolId).not.toBe('tall');
+
+      // Footprint reports the anchor at its new visible row.
+      const fp = reelSet.getSymbolFootprint(0, 0);
+      expect(fp.anchor).toEqual({ col: 0, row: 0 });
+      expect(fp.size).toEqual({ w: 1, h: 3 });
+    } finally {
+      destroy();
+    }
+  });
+
+});

--- a/packages/pixi-reels/tests/unit/ColumnTarget.test.ts
+++ b/packages/pixi-reels/tests/unit/ColumnTarget.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  assertBufferCountsInRange,
   cloneColumn,
   cloneTargetGrid,
   columnTargetToArray,
@@ -136,6 +137,95 @@ describe('ColumnTarget helpers', () => {
 
     it('handles empty array without throwing', () => {
       expect(toLegacyTargetGrid([])).toEqual([]);
+    });
+  });
+
+  describe('assertBufferCountsInRange', () => {
+    const aboveOne = [1, 1, 1];
+    const belowOne = [1, 1, 1];
+
+    it('passes when all columns are within bounds (explicit form)', () => {
+      const grid: ColumnTarget[] = [
+        { visible: ['a', 'b', 'c'] },
+        { visible: ['a', 'b', 'c'], bufferAbove: ['X'] },
+        { visible: ['a', 'b', 'c'], bufferBelow: ['Y'] },
+      ];
+      expect(() =>
+        assertBufferCountsInRange(grid, aboveOne, belowOne, 'setResult'),
+      ).not.toThrow();
+    });
+
+    it('passes when legacy negative-index keys are within bufferAbove', () => {
+      const col: string[] = ['a', 'b', 'c'];
+      (col as Record<number, string>)[-1] = 'X';
+      const grid: string[][] = [['a', 'b', 'c'], col, ['a', 'b', 'c']];
+      expect(() =>
+        assertBufferCountsInRange(grid, aboveOne, belowOne, 'setResult'),
+      ).not.toThrow();
+    });
+
+    it('throws when explicit bufferAbove length exceeds engine count', () => {
+      const grid: ColumnTarget[] = [
+        { visible: ['a', 'b', 'c'] },
+        { visible: ['a', 'b', 'c'], bufferAbove: ['X', 'Y'] }, // 2 > 1
+        { visible: ['a', 'b', 'c'] },
+      ];
+      expect(() =>
+        assertBufferCountsInRange(grid, aboveOne, belowOne, 'setResult'),
+      ).toThrowError(/setResult column 1: bufferAbove has 2 entries but engine bufferSymbols=1/);
+    });
+
+    it('throws when explicit bufferBelow length exceeds engine count', () => {
+      const grid: ColumnTarget[] = [
+        { visible: ['a', 'b', 'c'] },
+        { visible: ['a', 'b', 'c'], bufferBelow: ['X', 'Y'] }, // 2 > 1
+        { visible: ['a', 'b', 'c'] },
+      ];
+      expect(() =>
+        assertBufferCountsInRange(grid, aboveOne, belowOne, 'setResult'),
+      ).toThrowError(/setResult column 1: bufferBelow has 2 entries but engine bufferSymbols=1/);
+    });
+
+    it('throws when legacy frame[col][-k] exceeds engine bufferAbove', () => {
+      const col: string[] = ['a', 'b', 'c'];
+      (col as Record<number, string>)[-1] = 'X';
+      (col as Record<number, string>)[-2] = 'Y'; // out of range with above=1
+      const grid: string[][] = [['a', 'b', 'c'], col, ['a', 'b', 'c']];
+      expect(() =>
+        assertBufferCountsInRange(grid, aboveOne, belowOne, 'setResult'),
+      ).toThrowError(/setResult column 1: frame\[1\]\[-2\] is set but engine bufferSymbols=1/);
+    });
+
+    it('does not validate legacy form length (visibleRows is unreliable in MultiWays)', () => {
+      // A long column array used to trip the validator; we deliberately
+      // skip this check now so MultiWays setShape→setResult flows are not
+      // broken. See assertBufferCountsInRange JSDoc for the full rationale.
+      const grid: string[][] = [['a', 'b', 'c'], ['a', 'b', 'c', 'X', 'Y'], ['a', 'b', 'c']];
+      expect(() =>
+        assertBufferCountsInRange(grid, aboveOne, belowOne, 'setResult'),
+      ).not.toThrow();
+    });
+
+    it('uses the supplied callerLabel in the message', () => {
+      const grid: ColumnTarget[] = [{ visible: ['a'], bufferAbove: ['X', 'Y'] }];
+      expect(() =>
+        assertBufferCountsInRange(grid, [1], [1], 'initialFrame'),
+      ).toThrowError(/^initialFrame column 0: bufferAbove/);
+    });
+
+    it('handles per-reel buffer counts that vary by index', () => {
+      // reel 0: above=2, reel 1: above=1
+      const grid: ColumnTarget[] = [
+        { visible: ['a', 'b', 'c'], bufferAbove: ['X', 'Y'] }, // OK (above=2)
+        { visible: ['a', 'b', 'c'], bufferAbove: ['X', 'Y'] }, // throws (above=1)
+      ];
+      expect(() =>
+        assertBufferCountsInRange(grid, [2, 1], [1, 1], 'setResult'),
+      ).toThrowError(/setResult column 1: bufferAbove has 2 entries but engine bufferSymbols=1/);
+    });
+
+    it('no-op for empty grid', () => {
+      expect(() => assertBufferCountsInRange([], [], [], 'setResult')).not.toThrow();
     });
   });
 });

--- a/packages/pixi-reels/tests/unit/bigSymbols.test.ts
+++ b/packages/pixi-reels/tests/unit/bigSymbols.test.ts
@@ -335,6 +335,49 @@ describe('big symbols', () => {
     }
   });
 
+  // ReelMotion wrap thresholds depended on the assumption bufferBelow === 1
+  // — `_maxY` was hard-coded to `(visibleRows + 1) * slotH`, which collapses
+  // to `strip[last].y` exactly for bufferBelow=2 and triggers a phantom wrap
+  // on the first displace tick. With the fix, maxY scales with bufferBelow
+  // and nudge counts wraps exactly `distance` times.
+  it('nudge DOWN preserves block position when bufferBelow >= 2 (pre-fix: off-by-one)', async () => {
+    const { reelSet, spinAndLand, destroy } = createTestReelSet({
+      reels: 1,
+      visibleRows: 3,
+      bufferSymbols: 2, // bufferAbove=2 AND bufferBelow=2 — total strip = 7.
+      symbolIds: ['a', 'tall'],
+      symbolData: { tall: { weight: 0, size: { w: 1, h: 3 } } },
+    });
+    try {
+      // 1x3 anchor at bufferAbove[1] = row -2 → block at rows -2, -1, 0.
+      // Tail visible: visible[0] = stub→'tall', visible[1..2] = 'a'.
+      await spinAndLand([
+        { visible: ['a', 'a', 'a'], bufferAbove: [undefined, 'tall'] },
+      ]);
+      expect(reelSet.getVisibleGrid()[0]).toEqual(['tall', 'a', 'a']);
+
+      // DOWN by 2: anchor moves from strip[0] (row -2) to strip[2] (row 0).
+      // Block fills all three visible rows. Pre-fix this landed at strip[3]
+      // because the wrap fired one tick too early.
+      const result = await reelSet.nudge(0, {
+        distance: 2,
+        direction: 'down',
+        incoming: ['a', 'a'],
+      });
+      expect(result.symbols).toEqual(['tall', 'tall', 'tall']);
+
+      // UP by 2 returns to tail-visible.
+      const result2 = await reelSet.nudge(0, {
+        distance: 2,
+        direction: 'up',
+        incoming: ['a', 'a'],
+      });
+      expect(result2.symbols).toEqual(['tall', 'a', 'a']);
+    } finally {
+      destroy();
+    }
+  });
+
   it('throws if the buffer-anchored block extends past the bottom of the strip', async () => {
     const { reelSet, destroy } = createTestReelSet({
       reels: 1,

--- a/packages/pixi-reels/tests/unit/bigSymbols.test.ts
+++ b/packages/pixi-reels/tests/unit/bigSymbols.test.ts
@@ -515,6 +515,53 @@ describe('big symbols', () => {
     }
   });
 
+  // Cross-reel block at the LAST visible row with stubs spilling into
+  // bufferBelow on both columns. Mirror of the cross-reel buffer-above
+  // test above, but for the bottom of the strip. Exercises
+  // `_coordinateBigSymbols` painting OCCUPIED into bufferBelow positions
+  // (`row >= visibleRows`) across multiple reels, and the per-Reel
+  // `placeSymbols` path consuming those positions during the slamStop
+  // skip-path landing.
+  it('cross-reel 2x2 anchored at last visible row — stubs spill into bufferBelow on both columns', async () => {
+    const { reelSet, spinAndLand, destroy } = createTestReelSet({
+      reels: 2,
+      visibleRows: 3,
+      bufferSymbols: 1,
+      symbolIds: ['a', 'big'],
+      symbolData: { big: { weight: 0, size: { w: 2, h: 2 } } },
+    });
+    try {
+      // Anchor at (col=0, row=2). Block covers (0,2)(anchor), (1,2)(stub),
+      // (0,3)(stub in bufferBelow[0]), (1,3)(stub in bufferBelow[0]).
+      await spinAndLand([
+        { visible: ['a', 'a', 'big'] },
+        { visible: ['a', 'a', 'a'] },
+      ]);
+
+      const grid = reelSet.getVisibleGrid();
+      expect(grid[0][2]).toBe('big');
+      expect(grid[1][2]).toBe('big'); // cross-reel resolver
+
+      const OCC = '__pixi_reels_occupied__';
+      // bufferBelow[0] lives at strip index `bufferAbove + visibleRows` = 1+3 = 4.
+      const reel0BufferBelow = reelSet.reels[0].symbols[4].symbolId;
+      const reel1BufferBelow = reelSet.reels[1].symbols[4].symbolId;
+      // Both bufferBelow slots got painted OCCUPIED by the coordinator
+      // and survived the skip-path placeSymbols.
+      expect(reel0BufferBelow).toBe(OCC);
+      expect(reel1BufferBelow).toBe(OCC);
+
+      // Footprint from either visible-row cell points to the same anchor.
+      const fpLeft = reelSet.getSymbolFootprint(0, 2);
+      const fpRight = reelSet.getSymbolFootprint(1, 2);
+      expect(fpLeft.anchor).toEqual({ col: 0, row: 2 });
+      expect(fpRight.anchor).toEqual({ col: 0, row: 2 });
+      expect(fpLeft.size).toEqual({ w: 2, h: 2 });
+    } finally {
+      destroy();
+    }
+  });
+
   it('throws if the buffer-anchored block extends past the bottom of the strip', async () => {
     const { reelSet, destroy } = createTestReelSet({
       reels: 1,

--- a/packages/pixi-reels/tests/unit/bigSymbols.test.ts
+++ b/packages/pixi-reels/tests/unit/bigSymbols.test.ts
@@ -63,12 +63,15 @@ describe('big symbols', () => {
     }
   });
 
-  it('throws when block exceeds reel height', async () => {
+  it('throws when block extends past the bottom of the strip', async () => {
     const { reelSet, destroy } = createTestReelSet({
       reels: 3,
       visibleRows: 3,
+      // total strip = bufferAbove(1) + visibleRows(3) + bufferBelow(1) = 5.
+      // 1x6 block at row 0 needs rows 0..5 — last row (5) is one past
+      // the strip end.
       symbolIds: ['a', 'giant'],
-      symbolData: { giant: { weight: 0, size: { w: 1, h: 4 } } },
+      symbolData: { giant: { weight: 0, size: { w: 1, h: 6 } } },
     });
     try {
       const promise = reelSet.spin();
@@ -78,7 +81,7 @@ describe('big symbols', () => {
           ['a', 'a', 'a'],
           ['a', 'a', 'a'],
         ]);
-      }).toThrow(/exceeds reel/);
+      }).toThrow(/extends past the bottom of the strip/);
       reelSet.slamStop();
       await promise.catch(() => {});
     } finally {
@@ -161,5 +164,199 @@ describe('big symbols', () => {
         symbolData: { bonus: { weight: 5, size: { w: 2, h: 2 } } },
       }),
     ).toThrow(/big symbol .* must have weight 0/);
+  });
+
+  // ─── Buffer-row anchors (partial visibility) ────────────────────────
+  // A 1xH block can land with its anchor in bufferAbove (tail visible at
+  // the top of the window) or with stubs spilling into bufferBelow (head
+  // visible at the bottom). The coordinator scans the full strip range,
+  // `_finalizeFrame` sizes anchors anywhere on the strip, and
+  // `getVisibleSymbols` / `getSymbolFootprint` / `getBlockBounds` all
+  // resolve consistently — including via a negative `anchor.row` for
+  // buffer-above anchors.
+
+  it('lands a 1x3 with anchor in bufferAbove — visible row 0 reads the anchor id', async () => {
+    const { reelSet, spinAndLand, destroy } = createTestReelSet({
+      reels: 1,
+      visibleRows: 3,
+      bufferSymbols: 2,
+      symbolIds: ['a', 'b', 'tall'],
+      symbolData: { tall: { weight: 0, size: { w: 1, h: 3 } } },
+    });
+    try {
+      // ColumnTarget form. Anchor at bufferAbove[1] = row -2. Block
+      // spans rows -2, -1, 0 — only the bottom cell shows in visible
+      // row 0. The coordinator paints OCCUPIED at row -1 and row 0
+      // automatically; the user's `visible[0]` is overwritten.
+      await spinAndLand([
+        { visible: ['a', 'a', 'a'], bufferAbove: [undefined, 'tall'] },
+      ]);
+
+      // Visible row 0 resolves to the anchor via the negative-row
+      // occupancy added by `_finalizeFrame`'s bufferAbove scan.
+      const grid = reelSet.getVisibleGrid();
+      expect(grid[0][0]).toBe('tall');
+      expect(grid[0][1]).toBe('a');
+      expect(grid[0][2]).toBe('a');
+    } finally {
+      destroy();
+    }
+  });
+
+  it('lands a 1x2 with anchor in bufferAbove[0] — top two rows of the block are off-screen, bottom shows at row 0+1', async () => {
+    const { reelSet, spinAndLand, destroy } = createTestReelSet({
+      reels: 1,
+      visibleRows: 3,
+      bufferSymbols: 1,
+      symbolIds: ['a', 'tall'],
+      symbolData: { tall: { weight: 0, size: { w: 1, h: 2 } } },
+    });
+    try {
+      // Anchor at bufferAbove[0] = row -1. Block spans rows -1, 0.
+      // Only row 0 is visible; row 1 and row 2 are the user's `a` fillers.
+      await spinAndLand([
+        { visible: ['x', 'a', 'a'], bufferAbove: ['tall'] },
+      ]);
+      const grid = reelSet.getVisibleGrid();
+      expect(grid[0][0]).toBe('tall');
+      expect(grid[0][1]).toBe('a');
+      expect(grid[0][2]).toBe('a');
+    } finally {
+      destroy();
+    }
+  });
+
+  it('lands a 1x2 with anchor at last visible row — stub spills into bufferBelow', async () => {
+    const { reelSet, spinAndLand, destroy } = createTestReelSet({
+      reels: 1,
+      visibleRows: 3,
+      bufferSymbols: 1,
+      symbolIds: ['a', 'tall'],
+      symbolData: { tall: { weight: 0, size: { w: 1, h: 2 } } },
+    });
+    try {
+      // Anchor at visible row 2 (last). Block spans rows 2, 3 — row 3
+      // is bufferBelow[0]. Pre-feature this threw (`row + h > rows`);
+      // now it's a legal partial-visibility placement.
+      await spinAndLand([
+        { visible: ['a', 'a', 'tall'] },
+      ]);
+      const grid = reelSet.getVisibleGrid();
+      expect(grid[0]).toEqual(['a', 'a', 'tall']);
+      // Footprint reports the anchor at its actual visible row.
+      const fp = reelSet.getSymbolFootprint(0, 2);
+      expect(fp.anchor.row).toBe(2);
+      expect(fp.size).toEqual({ w: 1, h: 2 });
+    } finally {
+      destroy();
+    }
+  });
+
+  it('getSymbolFootprint returns a NEGATIVE anchor.row for blocks anchored in bufferAbove', async () => {
+    const { reelSet, spinAndLand, destroy } = createTestReelSet({
+      reels: 1,
+      visibleRows: 3,
+      bufferSymbols: 2,
+      symbolIds: ['a', 'tall'],
+      symbolData: { tall: { weight: 0, size: { w: 1, h: 3 } } },
+    });
+    try {
+      // Anchor at bufferAbove[1] = row -2.
+      await spinAndLand([
+        { visible: ['a', 'a', 'a'], bufferAbove: [undefined, 'tall'] },
+      ]);
+      const fp = reelSet.getSymbolFootprint(0, 0);
+      expect(fp.anchor.row).toBe(-2);
+      expect(fp.size).toEqual({ w: 1, h: 3 });
+      // getBlockBounds handles the negative row — returns the full
+      // block's pixel rect (the off-screen portion is clipped by mask).
+      const r = reelSet.getBlockBounds(0, 0);
+      expect(r.height).toBeGreaterThan(0);
+      expect(r.width).toBeGreaterThan(0);
+    } finally {
+      destroy();
+    }
+  });
+
+  it('partial-visibility block + nudge = fully reveals the block', async () => {
+    const { reelSet, spinAndLand, destroy } = createTestReelSet({
+      reels: 1,
+      visibleRows: 3,
+      bufferSymbols: 1,
+      symbolIds: ['a', 'b', 'tall'],
+      symbolData: { tall: { weight: 0, size: { w: 1, h: 2 } } },
+    });
+    try {
+      // 1x2 anchor at bufferAbove[0]: block spans rows -1 and 0.
+      // Visible reads ['tall' (via occupancy), 'a', 'a'].
+      await spinAndLand([
+        { visible: ['x', 'a', 'a'], bufferAbove: ['tall'] },
+      ]);
+      expect(reelSet.getVisibleGrid()[0]).toEqual(['tall', 'a', 'a']);
+      // Nudge down by 1 — the anchor slides into visible row 0, stub
+      // moves to row 1. Block fully visible.
+      const result = await reelSet.nudge(0, {
+        distance: 1,
+        direction: 'down',
+        incoming: ['b'],
+      });
+      expect(result.symbols[0]).toBe('tall');
+      expect(result.symbols[1]).toBe('tall');
+      expect(result.symbols[2]).toBe('a');
+    } finally {
+      destroy();
+    }
+  });
+
+  it('strip-spin landing: 1x2 block at last visible row + stub in bufferBelow lands cleanly', async () => {
+    const { reelSet, spinAndLand, destroy } = createTestReelSet({
+      reels: 3,
+      visibleRows: 3,
+      bufferSymbols: 1,
+      symbolIds: ['a', 'b', 'tall'],
+      symbolData: { tall: { weight: 0, size: { w: 1, h: 2 } } },
+    });
+    try {
+      // setResult goes through `_coordinateBigSymbols`, so a 1x2 anchor
+      // at row 2 (stub spilling into bufferBelow) should be legal.
+      await spinAndLand([
+        ['a', 'a', 'tall'],
+        ['a', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ]);
+      const grid = reelSet.getVisibleGrid();
+      expect(grid[0]).toEqual(['a', 'a', 'tall']);
+      // And the anchor's footprint reports correctly.
+      const fp = reelSet.getSymbolFootprint(0, 2);
+      expect(fp.anchor).toEqual({ col: 0, row: 2 });
+      expect(fp.size).toEqual({ w: 1, h: 2 });
+    } finally {
+      destroy();
+    }
+  });
+
+  it('throws if the buffer-anchored block extends past the bottom of the strip', async () => {
+    const { reelSet, destroy } = createTestReelSet({
+      reels: 1,
+      visibleRows: 3,
+      bufferSymbols: 1,
+      // total = 5. 1x4 anchor at row -1 needs rows -1..2 (4 cells) → fits.
+      // 1x4 anchor at row 1 needs rows 1..4 → fits exactly (1+4 = 5 = visible+below).
+      // 1x4 anchor at row 2 needs rows 2..5 → 5 > 4 → throws.
+      symbolIds: ['a', 'tall'],
+      symbolData: { tall: { weight: 0, size: { w: 1, h: 4 } } },
+    });
+    try {
+      const promise = reelSet.spin();
+      expect(() => {
+        reelSet.setResult([
+          { visible: ['a', 'a', 'tall'] }, // anchor at row 2, h=4 → past strip
+        ]);
+      }).toThrow(/extends past the bottom of the strip/);
+      reelSet.slamStop();
+      await promise.catch(() => {});
+    } finally {
+      destroy();
+    }
   });
 });

--- a/packages/pixi-reels/tests/unit/bigSymbols.test.ts
+++ b/packages/pixi-reels/tests/unit/bigSymbols.test.ts
@@ -340,6 +340,13 @@ describe('big symbols', () => {
   // to `strip[last].y` exactly for bufferBelow=2 and triggers a phantom wrap
   // on the first displace tick. With the fix, maxY scales with bufferBelow
   // and nudge counts wraps exactly `distance` times.
+  //
+  // We assert the EXACT strip layout (anchor at strip[2], stubs at strip[3..4])
+  // and not just visibleSymbols. Pre-fix the visible symbols read
+  // `['?', 'tall', 'tall']` because the block landed at strip[3..5] with the
+  // tail spilling into bufferBelow — exactly the "tail in lower buffer"
+  // regression. Asserting strip-by-index catches that even if a future bug
+  // happens to also produce the right `visibleSymbols` accidentally.
   it('nudge DOWN preserves block position when bufferBelow >= 2 (pre-fix: off-by-one)', async () => {
     const { reelSet, spinAndLand, destroy } = createTestReelSet({
       reels: 1,
@@ -356,15 +363,34 @@ describe('big symbols', () => {
       ]);
       expect(reelSet.getVisibleGrid()[0]).toEqual(['tall', 'a', 'a']);
 
+      const reel = reelSet.reels[0];
+      const OCC = '__pixi_reels_occupied__';
+
+      // Pre-nudge: anchor at strip[0], stubs at strip[1..2].
+      const preStrip = reel.symbols.map((s) => s.symbolId);
+      expect(preStrip[0]).toBe('tall');
+      expect(preStrip[1]).toBe(OCC);
+      expect(preStrip[2]).toBe(OCC);
+
       // DOWN by 2: anchor moves from strip[0] (row -2) to strip[2] (row 0).
       // Block fills all three visible rows. Pre-fix this landed at strip[3]
-      // because the wrap fired one tick too early.
+      // because the wrap fired one tick too early — the tail slipped into
+      // bufferBelow and only the top 2/3 of the block stayed visible.
       const result = await reelSet.nudge(0, {
         distance: 2,
         direction: 'down',
         incoming: ['a', 'a'],
       });
       expect(result.symbols).toEqual(['tall', 'tall', 'tall']);
+
+      const postStrip = reel.symbols.map((s) => s.symbolId);
+      expect(postStrip[2]).toBe('tall'); // anchor at row 0
+      expect(postStrip[3]).toBe(OCC);
+      expect(postStrip[4]).toBe(OCC);
+      // Bufferbelow must NOT carry any block cell — that was the
+      // regression: tail ended up at strip[5] (= bufferBelow[0]).
+      expect(postStrip[5]).not.toBe(OCC);
+      expect(postStrip[5]).not.toBe('tall');
 
       // UP by 2 returns to tail-visible.
       const result2 = await reelSet.nudge(0, {
@@ -373,6 +399,52 @@ describe('big symbols', () => {
         incoming: ['a', 'a'],
       });
       expect(result2.symbols).toEqual(['tall', 'a', 'a']);
+
+      const finalStrip = reel.symbols.map((s) => s.symbolId);
+      expect(finalStrip[0]).toBe('tall');
+      expect(finalStrip[1]).toBe(OCC);
+      expect(finalStrip[2]).toBe(OCC);
+    } finally {
+      destroy();
+    }
+  });
+
+  // The user-reported regression: when the recipe runs DOWN only (no UP),
+  // pre-fix the block ended in a head-visible state with the tail in
+  // bufferBelow. Post-fix the block ends in fully-visible state (anchor at
+  // row 0). This test mirrors that exact scenario verbatim.
+  it('DOWN-only nudge from tail-visible lands the block fully visible, not head-visible', async () => {
+    const { reelSet, spinAndLand, destroy } = createTestReelSet({
+      reels: 1,
+      visibleRows: 3,
+      bufferSymbols: 2,
+      symbolIds: ['a', 'tall'],
+      symbolData: { tall: { weight: 0, size: { w: 1, h: 3 } } },
+    });
+    try {
+      await spinAndLand([
+        { visible: ['a', 'a', 'a'], bufferAbove: [undefined, 'tall'] },
+      ]);
+
+      const result = await reelSet.nudge(0, {
+        distance: 2,
+        direction: 'down',
+        incoming: ['a', 'a'],
+      });
+
+      // All three visible rows show the block.
+      expect(result.symbols).toEqual(['tall', 'tall', 'tall']);
+
+      // And specifically the block did NOT land in head-visible with the
+      // tail spilling into bufferBelow. Strip layout:
+      //   bufferAbove(2) | visible(3) | bufferBelow(2)
+      //   [0..1]         | [2..4]     | [5..6]
+      // Correct: anchor strip[2], stubs strip[3..4].
+      // Regression: anchor strip[3], stubs strip[4..5] (stub at bufferBelow[0]).
+      const OCC = '__pixi_reels_occupied__';
+      const ids = reelSet.reels[0].symbols.map((s) => s.symbolId);
+      expect(ids[2]).toBe('tall');
+      expect(ids[5]).not.toBe(OCC);
     } finally {
       destroy();
     }

--- a/packages/pixi-reels/tests/unit/bigSymbols.test.ts
+++ b/packages/pixi-reels/tests/unit/bigSymbols.test.ts
@@ -450,14 +450,84 @@ describe('big symbols', () => {
     }
   });
 
+  // Cross-reel buffer-above anchor: a 2x2 block whose anchor sits at
+  // bufferAbove[0] on the left reel. The block covers col 0 rows -1, 0 and
+  // col 1 rows -1, 0. On col 1, the visible[0] OccupiedStub must resolve
+  // back to the anchor on col 0 via the cross-reel resolver, even though
+  // the anchor lives at a NEGATIVE row.
+  //
+  // This exercises three branches together that no other test hits:
+  //   - `_coordinateBigSymbols` painting OCCUPIED at `(col=1, row=-1)`
+  //     AND `(col=1, row=0)` for a w>1 block anchored above visible.
+  //   - The cross-reel resolver's `symbols[bufferAbove + anchor.row]`
+  //     read with a negative `anchor.row`.
+  //   - `getSymbolFootprint` walking left from a cross-reel OCCUPIED cell
+  //     whose own `_getAnchorRow` returns the visible row (no per-reel
+  //     occupancy on col 1 because Scan 2 only sees its own anchor) and
+  //     finding the leftward big-symbol owner that covers it.
+  it('cross-reel 2x2 with anchor in bufferAbove — resolves visible cells and footprint correctly', async () => {
+    const { reelSet, spinAndLand, destroy } = createTestReelSet({
+      reels: 2,
+      visibleRows: 3,
+      bufferSymbols: 2,
+      symbolIds: ['a', 'big'],
+      symbolData: { big: { weight: 0, size: { w: 2, h: 2 } } },
+    });
+    try {
+      // Anchor at (col=0, bufferAbove[0]) = (col=0, row=-1). Block covers
+      // (0,-1)(anchor), (1,-1)(stub), (0,0)(stub), (1,0)(stub).
+      // Visible: row 0 across both cols shows the bottom of the block;
+      // rows 1, 2 are random fillers.
+      await spinAndLand([
+        { visible: ['a', 'a', 'a'], bufferAbove: ['big'] },
+        { visible: ['a', 'a', 'a'] },
+      ]);
+
+      // Visible row 0 on BOTH columns resolves to 'big':
+      //   - col 0: via local `_occupancy[0].anchorRow = -1` (Scan 2)
+      //   - col 1: via the cross-reel resolver walking left to col 0
+      const grid = reelSet.getVisibleGrid();
+      expect(grid[0][0]).toBe('big');
+      expect(grid[1][0]).toBe('big');
+      expect(grid[0][1]).toBe('a');
+      expect(grid[1][1]).toBe('a');
+
+      // Footprint from EITHER cell of the visible bottom row of the block
+      // points back to the same anchor at (0, -1).
+      const fpLeft = reelSet.getSymbolFootprint(0, 0);
+      expect(fpLeft.anchor).toEqual({ col: 0, row: -1 });
+      expect(fpLeft.size).toEqual({ w: 2, h: 2 });
+
+      const fpRight = reelSet.getSymbolFootprint(1, 0);
+      expect(fpRight.anchor).toEqual({ col: 0, row: -1 });
+      expect(fpRight.size).toEqual({ w: 2, h: 2 });
+
+      // Block bounds span both reels and reach above visible row 0.
+      const r = reelSet.getBlockBounds(1, 0);
+      expect(r.width).toBeGreaterThan(0);
+      expect(r.height).toBeGreaterThan(0);
+      // 1x1 cell bounds for comparison: block height must be ~2x.
+      const cell = reelSet.getCellBounds(0, 1);
+      expect(r.height).toBeGreaterThan(cell.height);
+      expect(r.width).toBeGreaterThan(cell.width);
+    } finally {
+      destroy();
+    }
+  });
+
   it('throws if the buffer-anchored block extends past the bottom of the strip', async () => {
     const { reelSet, destroy } = createTestReelSet({
       reels: 1,
       visibleRows: 3,
       bufferSymbols: 1,
-      // total = 5. 1x4 anchor at row -1 needs rows -1..2 (4 cells) → fits.
-      // 1x4 anchor at row 1 needs rows 1..4 → fits exactly (1+4 = 5 = visible+below).
-      // 1x4 anchor at row 2 needs rows 2..5 → 5 > 4 → throws.
+      // Strip layout: bufferAbove(1) | visible(3) | bufferBelow(1) — 5 cells.
+      // The check is `anchor.row + h > visibleRows + bufferBelow`, i.e.
+      // `row + 4 > 4`. So legal anchor rows for h=4 are {-1, 0}:
+      //   row=-1 → -1+4 = 3 → 3 > 4 ? no → fits (cells -1..2).
+      //   row= 0 →  0+4 = 4 → 4 > 4 ? no → fits exactly (cells 0..3,
+      //                                          last cell in bufferBelow).
+      //   row= 1 →  1+4 = 5 → 5 > 4 ? yes → throws.
+      //   row= 2 →  2+4 = 6 → 6 > 4 ? yes → throws (what this test uses).
       symbolIds: ['a', 'tall'],
       symbolData: { tall: { weight: 0, size: { w: 1, h: 4 } } },
     });


### PR DESCRIPTION
## Summary

Closes the "land a 1xH symbol partially in buffer" gap raised after the nudge PR. The classic UK fruit-machine UX — a tall wild lands with most of it hidden above the visible window and only its bottom cell ("the tail") shows at row 0 — now works end-to-end through `setResult`, `refill`, and `nudge`.

```ts
// 1x3 TALL with anchor in bufferAbove[1] (= row -2).
// Block spans rows -2, -1, 0 — only the bottom cell shows at row 0.
reelSet.setResult([
  { visible: [filler, filler, filler] },
  { visible: [filler, filler, filler] },
  { visible: [filler, filler, filler], bufferAbove: [undefined, 'TALL'] },
  // ...
]);
```

Live recipe at `/recipes/big-symbol-partial-land/`.

## Engine changes

### `_coordinateBigSymbols` (SpinController)
- Used to iterate only the visible rows `[0, rows)`, throwing on any big-symbol anchor whose block extended past `rows`. Now iterates the full strip range `[-bufferAbove, visibleRows + bufferBelow)` and validates against strip capacity instead.
- Anchors at any strip slot are accepted as long as the block fits end-to-end:
  - `anchor + h - 1 <= visibleRows + bufferBelow - 1`
  - `anchor >= -bufferAbove`
- OCCUPIED stubs are painted at the right strip indices regardless of whether each cell lands in bufferAbove (negative row coordinate), visible, or bufferBelow.
- Validation error message tightened: `exceeds reel height` → `extends past the bottom of the strip` with the exact computed values.

### Rest of the pipeline already supported it
- `FrameBuilder.TargetPlacementMiddleware` iterates from `-bufferAbove` and writes at `bufferAbove + row` — unchanged.
- `Reel.placeSymbols` already accepted negative-index symbol ids.
- `Reel._finalizeFrame` scans bufferAbove anchors (shipped with the nudge PR), sizes them to span the full block, marks visible-row occupancy with a negative `anchorRow`.
- `getSymbolFootprint` / `getBlockBounds` already handle negative `anchor.row`.

## Behaviour change

`_coordinateBigSymbols` is **more permissive** now. A 1×4 block on a 3-visible-row reel with 1 bufferBelow is **LEGAL** where it previously threw. Code that depended on the old "exceeds reel height" rejection should re-validate against the new strip-capacity rule.

`getSymbolFootprint` may now return a **negative** `anchor.row` for blocks anchored in bufferAbove. `getBlockBounds` handles this internally; external consumers that read `anchor.row` should accept negative values.

## Test coverage

**448 tests passing (was 441; +7 new):**
- Updated `throws when block exceeds reel height` to `throws when block extends past the bottom of the strip` (new semantics).
- 1x3 with anchor at `bufferAbove[1]` — visible row 0 reads the anchor id.
- 1x2 with anchor at `bufferAbove[0]` — top of block clipped, bottom at row 0.
- 1x2 with anchor at last visible row — stub spills into bufferBelow.
- `getSymbolFootprint` returns negative `anchor.row` for buffer-above anchors.
- Partial-visibility + nudge — land tail-visible, nudge to reveal, verify final visible reads the full block.
- Strip-spin landing path (no slam) — verifies the full coordinator → frame builder → stop sequencer pipeline lands the buffer-row anchor cleanly.

## Recipe + docs

- **`/recipes/big-symbol-partial-land/`** — new live `RecipeRunner`. Lands a 1×3 TALL at `bufferAbove[1]` (only tail at row 0), nudges DOWN by 2 to reveal the whole block, nudges UP by 2 to push it back into the tail-visible state. Live verified.
- Card added to `/recipes/` under the big-symbols group.
- Doc page spells out:
  - **Where the block can live** — a table of anchor positions vs what's visible.
  - **How placement flows end-to-end** — through every pipeline stage (coordinator → FrameBuilder → StopSequencer / placeSymbols → \_finalizeFrame → getVisibleSymbols).
  - **What still throws** — MultiWays + big symbols (existing constraint), cross-reel via nudge (existing constraint), random-fill big symbols (existing constraint).

## Test plan

- [x] `pnpm --filter pixi-reels typecheck`
- [x] `pnpm --filter pixi-reels test` — 448 passing
- [x] `pnpm check:lint`
- [x] `pnpm --filter @pixi-reels/site build` — clean
- [x] Live verified `/recipes/big-symbol-partial-land/` in the dev server:
  - After spin lands: tail visible at row 0 (orange block clipped at top of window)
  - After down-nudge by 2: full block at rows 0+1+2
  - After up-nudge by 2: back to tail-visible
- [ ] Manual smoke against `examples/classic-spin` with real Sprite/Spine assets recommended before merge.

## Changeset

`.changeset/big-symbols-in-buffer.md` — `minor`, calls out the new permissive validation, the negative `anchor.row` in `getSymbolFootprint`, and the new recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)