### PR TITLE
fix(big-symbols): keep buffer-anchored blocks intact and smooth through tumble cascades

### DIFF
--- a/.changeset/big-symbol-cascade-fall-anchor.md
+++ b/.changeset/big-symbol-cascade-fall-anchor.md
@@ -1,0 +1,5 @@
+---
+"pixi-reels": patch
+---
+
+Fix: buffer-anchored big symbols no longer render empty, and big-symbol blocks no longer jitter, when falling through a tumble cascade. `CascadePlacePhase` now preserves `bufferAbove` target cells, so a "tail-visible" block (anchor above the viewport) keeps its anchor through the animated place path instead of being overwritten with a random symbol and leaving its visible cell empty. The place and drop-in phases now animate each block anchor exactly once instead of once per occupied visible row — previously the duplicate drop tweens fought over the anchor's position (the jitter) and could land it a row off target.

--- a/packages/pixi-reels/src/spin/phases/CascadeDropInPhase.ts
+++ b/packages/pixi-reels/src/spin/phases/CascadeDropInPhase.ts
@@ -137,7 +137,19 @@ export class CascadeDropInPhase extends ReelPhase<CascadeDropInPhaseConfig> {
     //                  Survivors that slid in stage 1 are already at
     //                  their grid Y; reveal them at alpha = 1.
     const jobs: DropJob[] = [];
+    // Big symbols: every occupied cell of a block resolves (via getAnchorRow /
+    // getSymbolAt) to the SAME anchor view. Animate that view ONCE, driven by
+    // the first visible row of the block (top-to-bottom). Without this the
+    // anchor gets one job per occupied row, so: multiple GSAP tweens fight
+    // over its `view.y` (the jitter), `finalY = sym.view.y` is re-read after a
+    // sibling job already moved the view to its startY (wrong landing Y), and
+    // per-symbol listeners (landing squish/bounce) fire N times on one view.
+    const handledAnchors = new Set<number>();
     for (const off of offsets) {
+      const anchorRow = reel.getAnchorRow(off.row);
+      if (anchorRow !== off.row && handledAnchors.has(anchorRow)) continue;
+      handledAnchors.add(anchorRow);
+
       const sym = reel.getSymbolAt(off.row);
 
       if (off.offsetRows === 0) {

--- a/packages/pixi-reels/src/spin/phases/CascadePlacePhase.ts
+++ b/packages/pixi-reels/src/spin/phases/CascadePlacePhase.ts
@@ -47,18 +47,35 @@ export class CascadePlacePhase extends ReelPhase<CascadePlacePhaseConfig> {
     }
   }
 
+  /**
+   * Map the positional `targetFrame` (buffer-above … visible … buffer-below)
+   * into the index shape `Reel.placeSymbols` expects: visible rows at positive
+   * indices `[0..visibleRows)`, buffer-above rows as NEGATIVE-index properties
+   * (`[-1]` closest above … `[-bufferAbove]` furthest). placeSymbols reads
+   * buffer-above strip cells from those negative slots; a plain `slice` of just
+   * the visible window has none, so placeSymbols re-randomizes the buffer. that
+   * destroys a big-symbol anchor living in bufferAbove (a partial-visibility
+   * "tail-visible" block) and leaves its visible OCCUPIED stub uncovered, so
+   * the block's visible cell renders empty. Buffer-below cells are left to
+   * placeSymbols' random fill — they're masked and never carry a visible anchor.
+   */
+  private _placement(targetFrame: string[]): string[] {
+    const bufferAbove = this._reel.bufferAbove;
+    const placement = targetFrame.slice(bufferAbove, bufferAbove + this._reel.visibleRows);
+    for (let k = 1; k <= bufferAbove; k++) {
+      (placement as Record<number, string>)[-k] = targetFrame[bufferAbove - k];
+    }
+    return placement;
+  }
+
   private _doPlace(): void {
     this._delayedCall = null;
     if (!this._config) return;
 
     const reel = this._reel;
     const { targetFrame, events } = this._config;
-    const visible = targetFrame.slice(
-      reel.bufferAbove,
-      reel.bufferAbove + reel.visibleRows,
-    );
 
-    reel.placeSymbols(visible);
+    reel.placeSymbols(this._placement(targetFrame));
     // Defensive: CascadeFallPhase displaces views by `fallDistance` and pool
     // reuse can leak the post-fall y onto same-id replacements when
     // `_placeSymbolView` runs BEFORE the motion snap inside placeSymbols.
@@ -78,8 +95,19 @@ export class CascadePlacePhase extends ReelPhase<CascadePlacePhaseConfig> {
       this._config.winnerRows,
       { initial: this._config.initial },
     );
+    // Big symbols: every occupied cell of a block resolves to the SAME anchor
+    // view. Reveal it ONCE, keyed on the first visible row of the block
+    // (top-to-bottom), so the anchor's alpha reflects whether the BLOCK moves
+    // (mover ⇒ 0, stays hidden until the drop-in repositions it). Without the
+    // dedup the last occupied row wins, leaving a mover-anchor at alpha 1 at
+    // its grid Y. it flashes fully-formed there for a frame before the drop-in
+    // yanks it back up to fall again ("snap then re-drop").
     const placedSymbols: ReelSymbol[] = [];
+    const handledAnchors = new Set<number>();
     for (const off of offsets) {
+      const anchorRow = reel.getAnchorRow(off.row);
+      if (anchorRow !== off.row && handledAnchors.has(anchorRow)) continue;
+      handledAnchors.add(anchorRow);
       const sym = reel.getSymbolAt(off.row);
       sym.view.visible = true;
       sym.view.alpha = off.offsetRows === 0 ? 1 : 0;
@@ -108,11 +136,7 @@ export class CascadePlacePhase extends ReelPhase<CascadePlacePhaseConfig> {
     // (skip == "show me the final landed state right now").
     if (this._config) {
       const reel = this._reel;
-      const visible = this._config.targetFrame.slice(
-        reel.bufferAbove,
-        reel.bufferAbove + reel.visibleRows,
-      );
-      reel.placeSymbols(visible);
+      reel.placeSymbols(this._placement(this._config.targetFrame));
       for (let row = 0; row < reel.visibleRows; row++) {
         const view = reel.getSymbolAt(row).view;
         view.alpha = 1;

--- a/packages/pixi-reels/tests/integration/cascade-bigSymbol-visual.test.ts
+++ b/packages/pixi-reels/tests/integration/cascade-bigSymbol-visual.test.ts
@@ -1,0 +1,120 @@
+/**
+ * REPRODUCTION (pre-fix) of two visual bugs in the big-symbol cascade-fall
+ * recipe. The sibling `cascade-bigSymbol-fall.test.ts` asserts only logical
+ * strip/occupancy/grid state and lands via slamStop, so it misses both:
+ *
+ *   Bug 1 — a bufferAbove-anchored block (tail visible at row 0) is DESTROYED
+ *           by the animated tumble place path: CascadePlacePhase slices off
+ *           the buffer cells, so the anchor is overwritten with a random
+ *           symbol and the visible OCCUPIED stub renders empty.
+ *
+ *   Bug 2 — when the block lands fully visible, CascadeDropInPhase builds one
+ *           drop job per visible row; the occupied rows resolve to the SAME
+ *           anchor view, so the anchor's `view.y` ends at the wrong position
+ *           (and, with real durations, multiple tweens fight → jitter).
+ */
+import { describe, expect, it } from 'vitest';
+import type { Ticker } from 'pixi.js';
+import { ReelSetBuilder } from '../../src/core/ReelSetBuilder.js';
+import { HeadlessSymbol } from '../../src/testing/HeadlessSymbol.js';
+import { FakeTicker } from '../../src/testing/FakeTicker.js';
+import { OCCUPIED_SENTINEL } from '../../src/core/Reel.js';
+
+function buildHarness() {
+  const ticker = new FakeTicker();
+  const reelSet = new ReelSetBuilder()
+    .reels(3)
+    .visibleRows(4)
+    .bufferSymbols(2)
+    .symbolSize(50, 50)
+    .symbols((r) => {
+      for (const id of ['a', 'b', 'tall', 'match']) r.register(id, HeadlessSymbol, {});
+    })
+    .weights({ a: 1, b: 1, match: 1 })
+    .symbolData({ tall: { weight: 0, size: { w: 1, h: 3 } } })
+    .tumble({
+      fall:   { duration: 0, ease: 'none', rowStagger: 0 },
+      dropIn: { duration: 0, ease: 'none', rowStagger: 0, distance: 'perHole' },
+    })
+    .ticker(ticker as unknown as Ticker)
+    .build();
+
+  // Land the initial state through the spin pipeline (slamStop) so the
+  // coordinator paints OCCUPIED stubs and the anchor lands at strip[0].
+  return {
+    reelSet,
+    ticker,
+    destroy: () => { reelSet.destroy(); ticker.destroy(); },
+  };
+}
+
+// Initial land matches the recipe: 1x3 wild tail-visible at row 0 (anchor in
+// bufferAbove[1]), MATCH cluster at row 1.
+async function landInitial(reelSet: ReturnType<typeof buildHarness>['reelSet']) {
+  const spinDone = reelSet.spin();
+  reelSet.setResult([
+    { visible: ['a', 'match', 'a', 'a'], bufferAbove: [undefined, 'tall'] },
+    { visible: ['b', 'match', 'b', 'b'] },
+    { visible: ['b', 'match', 'b', 'b'] },
+  ]);
+  reelSet.slamStop();
+  await spinDone;
+}
+
+describe('big-symbol cascade-fall. visual/positional state (repro)', () => {
+  it('BUG 2: anchor view.y is correct after the recipe refill (row-1 cluster clears, block falls to visible[0..2])', async () => {
+    const { reelSet, destroy } = buildHarness();
+    try {
+      await landInitial(reelSet);
+
+      // Recipe cascade: row-1 cluster wins, wild block drops to visible[0..2].
+      await reelSet.refill({
+        winners: [{ reel: 0, row: 1 }, { reel: 1, row: 1 }, { reel: 2, row: 1 }],
+        grid: [
+          { visible: ['tall', 'a', 'a', 'a'], bufferAbove: ['a'] },
+          { visible: ['b', 'b', 'b', 'b'] },
+          { visible: ['b', 'b', 'b', 'b'] },
+        ],
+      });
+
+      const reel0 = reelSet.reels[0];
+      // Anchor moved to strip[2] (visible row 0).
+      expect(reel0.symbols[2].symbolId).toBe('tall');
+      const slotH = reel0.motion.slotHeight;
+      // Visible row 0 sits at local Y = 0; a top-anchored 1x3 block's anchor
+      // view must land exactly there. The duplicate-job bug leaves it at -slotH.
+      expect(reel0.symbols[2].view.y).toBe(0 * slotH);
+    } finally {
+      destroy();
+    }
+  });
+
+  it('BUG 1: a bufferAbove-anchored block survives the animated tumble place path', async () => {
+    const { reelSet, destroy } = buildHarness();
+    try {
+      await landInitial(reelSet);
+
+      // Refill that RE-LANDS the block tail-visible (anchor back in
+      // bufferAbove[1], tail at row 0). This exercises CascadePlacePhase on
+      // a buffer-anchored block exactly like the recipe's initial animated land.
+      await reelSet.refill({
+        winners: [{ reel: 0, row: 1 }, { reel: 1, row: 1 }, { reel: 2, row: 1 }],
+        grid: [
+          { visible: ['a', 'a', 'a', 'a'], bufferAbove: [undefined, 'tall'] },
+          { visible: ['b', 'b', 'b', 'b'] },
+          { visible: ['b', 'b', 'b', 'b'] },
+        ],
+      });
+
+      const reel0 = reelSet.reels[0];
+      // Anchor must still live at strip[0]; the visible tail (row 0) must
+      // resolve to 'tall', not an empty OCCUPIED stub.
+      expect(reel0.symbols[0].symbolId).toBe('tall');
+      expect(reelSet.getVisibleGrid()[0][0]).toBe('tall');
+      // Sanity: visible row 0 is an occupied cell of the block.
+      expect(reel0.symbols[2].symbolId).toBe(OCCUPIED_SENTINEL);
+    } finally {
+      destroy();
+    }
+  });
+});


### PR DESCRIPTION
## What

Fixes two visual bugs in the **big-symbol cascade-fall** recipe (`big-symbol-cascade-fall.recipe.ts`):

1. **Empty cell at top-left before the cascade.** A `1×3` wild anchored in `bufferAbove` (tail visible at row 0) rendered as an empty cell.
2. **The block jitters into its target when it falls** after the winning row clears.

Both share one root cause: the tumble-cascade phases iterated **per visible row** and didn't treat a big-symbol block as a single unit.

## Root causes & fixes

**Bug 1 — `CascadePlacePhase` discarded buffer-above cells.**
The phase placed only `targetFrame.slice(bufferAbove, …)` — a plain slice with no negative-index buffer cells. `Reel.placeSymbols` reads buffer-above strip cells from negative indices, so it **re-randomized the buffer** and overwrote the anchor of a tail-visible block, leaving the visible `OCCUPIED` stub uncovered → empty cell.
→ New `_placement()` helper maps the full positional frame into the negative/positive index shape `placeSymbols` expects (applied in both `_doPlace` and the skip path).

**Bug 2 — duplicate drop jobs per block.**
Both `CascadePlacePhase` and `CascadeDropInPhase` built one job per visible row, but every occupied row of a block resolves (via `getSymbolAt`) to the **same anchor view**. The anchor got 2–3 jobs → multiple GSAP tweens fighting over one `view.y` (the jitter), `finalY = sym.view.y` re-read after a sibling job had moved the view (landing a row off), the squish/bounce listener firing N× on one view, and a "snap-then-re-drop" alpha flash from the place phase.
→ Both phases now dedupe by anchor (`getAnchorRow`) and animate/reveal each block exactly once.

## Why this was uncaught

The existing `cascade-bigSymbol-fall.test.ts` lands via `slamStop()` (bypasses `CascadePlacePhase`) and only asserts logical strip/occupancy state — never the animated place path or `view.y`.

## Verification

New `cascade-bigSymbol-visual.test.ts` reproduces both as true red→green through the **real phase code**:
- Bug 1: anchor was a random `'b'` → now `'tall'`
- Bug 2: anchor `view.y` was `-50` (a slot too high) → now `0`

Verified via **state** (`view.y`, strip identities, occupancy) rather than canvas screenshots, per the repo's AI-agent guidance ("PixiJS renders to canvas. AI agents cannot see it. Use the debug system instead").

```
typecheck: clean   tests: 496 passed (67 files)   lint: clean
```

**Scope:** targets `bufferAbove`-anchored blocks (the reported case). `bufferBelow` blocks are unaffected — their anchor is in the visible window and the off-screen tail is masked.

Patch changeset included (`fix:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)