### PR TITLE
docs(site): use ColumnTarget form in setResult examples

### DIFF
--- a/apps/site/src/content/guides/your-first-reelset.mdx
+++ b/apps/site/src/content/guides/your-first-reelset.mdx
@@ -80,11 +80,11 @@ Want a *specific* outcome? Call `setResult()` before the promise resolves:
 ```ts
 const promise = reelSet.spin();
 setTimeout(() => reelSet.setResult([
-  ['wild','seven','wild'],
-  ['seven','wild','seven'],
-  ['wild','seven','wild'],
-  ['seven','wild','seven'],
-  ['wild','seven','wild'],
+  { visible: ['wild','seven','wild'] },
+  { visible: ['seven','wild','seven'] },
+  { visible: ['wild','seven','wild'] },
+  { visible: ['seven','wild','seven'] },
+  { visible: ['wild','seven','wild'] },
 ]), 200);
 const result = await promise;
 ```

--- a/apps/site/src/content/recipes/big-symbols-mxn.mdx
+++ b/apps/site/src/content/recipes/big-symbols-mxn.mdx
@@ -140,15 +140,18 @@ The server response stays `string[][]` for every shape above. The server sets th
 3. **Public API never sees the sentinel.** `Reel.getVisibleSymbols()` and `ReelSet.getVisibleGrid()` resolve OCCUPIED. both same-reel and cross-reel. to the anchor's id.
 
 ```ts
-// 6×5 grid with a 2×4 wide banner anchored at (col=2, row=1):
-setResult([
+// 6×5 grid with a 2×4 wide banner anchored at (col=2, row=1).
+// The server still produces an anchor-only string[][]; wrap each
+// column as a ColumnTarget at the setResult boundary.
+const grid = [
   ['low1', 'low2', 'low1', 'low2', 'low1'],
   ['low1', 'low2', 'low1', 'low2', 'low1'],
   ['low1', 'wide',  '?',    '?',    'low2'],   // wide anchor + 'wide' OCCUPIED below
   ['low1', '?',     '?',    '?',    'low2'],
   ['low1', '?',     '?',    '?',    'low2'],
   ['low1', 'low2', 'low1', 'low2', 'low1'],
-]);
+];
+setResult(grid.map((visible) => ({ visible })));
 ```
 
 The `?` cells can be any string; the engine overwrites them. Keep them readable for debug logs.

--- a/apps/site/src/content/recipes/nudge-big-symbol.mdx
+++ b/apps/site/src/content/recipes/nudge-big-symbol.mdx
@@ -68,7 +68,8 @@ player nudges to drag the whole block into view.
 
 ```ts
 // 1. Land 1x2 MEGA at column 2, rows 0+1 (anchor at row 0).
-reelSet.setResult([..., [MEGA, MEGA, filler], ...]);
+const grid = [..., [MEGA, MEGA, filler], ...];
+reelSet.setResult(grid.map((visible) => ({ visible })));
 
 // 2. Nudge UP by 1 → anchor lives in bufferAbove now, only the bottom
 //    cell of the block is in the visible window. Top half is clipped.
@@ -89,7 +90,7 @@ visible portion of the sprite shows through naturally.
 ```ts
 // 1. Land a 1x2 wild on column 2 at rows 0+1.
 const grid = [col3(), col3(), [MEGA.id, MEGA.id, filler()], col3(), col3()];
-reelSet.setResult(grid);
+reelSet.setResult(grid.map((visible) => ({ visible })));
 
 // 2. Nudge column 2 down by 2. Anchor at strip[1] (visible row 0), h=2:
 //    survival = 1 + 2 - 1 + 2 = 4, which is < 5 (total). Block fits.


### PR DESCRIPTION
## What

Migrates the remaining doc snippets that called `setResult()` with the legacy `string[][]` form to the recommended `ColumnTarget` (`{ visible, bufferAbove?, bufferBelow? }`) form, matching every other recipe/guide and the underlying recipe code.

## Why

`setResult` still accepts `string[][]`, but the legacy form doesn't survive `structuredClone`/JSON/`postMessage`, and the rest of the docs standardize on `ColumnTarget`. A few snippets had drifted out of sync — including one in the **first guide a user reads**.

## Changes

- **your-first-reelset.mdx** — raw `string[][]` → `{ visible: [...] }`.
- **nudge-big-symbol.mdx** — two snippets had drifted from their own recipe (`nudge-big-symbol.recipe.ts` wraps with `.map((visible) => ({ visible }))`); docs now match.
- **big-symbols-mxn.mdx** — converted the direct `setResult` call to the `ColumnTarget` boundary while keeping the accurate "server response stays `string[][]`, anchor-only" narrative (the recipes genuinely return `string[][]` and the runner wraps each column).

## Deliberately untouched

- `migrating-to-1-0.mdx` — its `string[][]` snippet is the "before" half of a migration example.
- `grid[col][row] = anchor` idioms — building the server grid, correct as-is.
- `spinAndLand` / `expectGrid` helpers — take `string[][]` by design, not `setResult`.

Docs-only (fenced code blocks); no library change, so no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)