### PR TITLE
feat: configurable anticipation — stagger, slowing, scatter, events, turbo (#181)

### DIFF
--- a/.changeset/anticipation-stagger.md
+++ b/.changeset/anticipation-stagger.md
@@ -1,0 +1,26 @@
+---
+"pixi-reels": minor
+---
+
+Add: staggered / sequential anticipation so teasing reels build tension one after another instead of all slowing down at once.
+
+`setAnticipation(reelIndices, stagger?)` now takes a second argument controlling when each reel BEGINS its slow-down (offsets are by tease-order, not raw reel index):
+
+- `0` (default) — every anticipation reel starts slowing together (unchanged behaviour).
+- `number` — reel at tease-order `k` starts `k * stagger` ms after the first.
+- `number[]` — explicit per-tease-order offset in ms.
+- `'sequential'` — each reel waits until the previous anticipation reel has fully landed before it starts.
+
+Add: progressive slow-down. Pass `setAnticipation(reels, { stagger, slowdown })` where `slowdown` (`{ from, to, holdFrom, holdTo }`) interpolates across the tease sequence, so each successive reel decelerates to a lower speed and/or holds longer than the last — the escalating "each reel crawls slower than the one before" build-up. Omit it for the previous flat 30%-and-hold tease.
+
+Add: `duration` override — `setAnticipation(reels, { duration })` sets the tease hold in ms regardless of the active speed profile, so anticipation keeps playing in Turbo / SuperTurbo (whose profiles use `anticipationDelay: 0` and previously skipped it entirely).
+
+Add: `anticipation:reel` (`{ reelIndex, order, total }`) and `anticipation:reelEnd` (`{ reelIndex }`) events — a dedicated per-reel tease start/end signal so games can drive tension SFX, pitch ramps (`order / (total - 1)`), and escalating visuals without re-deriving the tease set from `spin:stopping`. Fired only for reels that actually tease.
+
+Add: `anticipationForScatters(grid, { symbol, trigger, mode })` — derive the tease reel list straight from a result grid (`grid` is the same `ColumnTarget[]` you pass to `setResult`). Anticipation begins on the reel after the `trigger`-th scatter; `mode: 'all-remaining'` teases every following reel, `'scatter-only'` teases only reels that actually hold the symbol (so a 3-scatter result doesn't slow the empty reels).
+
+Fix: after an anticipation tease the reel now carries its slow speed into the stop and crawls onto its landing frame, instead of snapping back to full spin speed and doing a fast re-spin into position.
+
+`spin:stopping` now fires when a reel actually begins slowing (after its stagger offset), so tease SFX/VFX can sync to the real start. The stagger and slowdown reset at the start of every `spin()`.
+
+Also: `setStopDelays(null)` / `setDropOrder(null)` now CLEAR a per-reel stop-delay override and restore the default `i * speed.stopDelay` stagger — distinct from passing all-zeros (which lands every reel simultaneously).

--- a/apps/site/src/components/RecipeRunner.tsx
+++ b/apps/site/src/components/RecipeRunner.tsx
@@ -12,6 +12,7 @@ import {
   type ReelSet, ReelSymbol,
   EmptySymbol, HoldAndWinBuilder, BoardGrid,
   HorizontalReel, HorizontalReelBuilder,
+  anticipationForScatters,
 } from 'pixi-reels';
 import { SpineReelSymbol } from 'pixi-reels/spine';
 import { Spine } from '@esotericsoftware/spine-pixi-v8';
@@ -191,6 +192,7 @@ export function RecipeRunner({ code, height = 300 }: RecipeRunnerProps) {
           'coinValue', 'coinMultiplier', 'drawCoin',
           'HoldAndWinBuilder', 'BoardGrid',
           'HorizontalReel', 'HorizontalReelBuilder',
+          'anticipationForScatters',
           'GoldCoinSymbol', 'coinWaves', 'bezierFly', 'settleMoneyFace', 'freezeAtEnd', 'fitText',
           'SpineReelSymbol', 'Spine', 'loadGeneratedSpines', 'buildSpineMap',
           'loadHoldAndWinSprites',
@@ -211,6 +213,7 @@ export function RecipeRunner({ code, height = 300 }: RecipeRunnerProps) {
           coinValue, coinMultiplier, drawCoin,
           HoldAndWinBuilder, BoardGrid,
           HorizontalReel, HorizontalReelBuilder,
+          anticipationForScatters,
           GoldCoinSymbol, coinWaves, bezierFly, settleMoneyFace, freezeAtEnd, fitText,
           SpineReelSymbol, Spine, loadGeneratedSpines, buildSpineMap,
           loadHoldAndWinSprites,

--- a/apps/site/src/content/recipes/scatter-anticipation.mdx
+++ b/apps/site/src/content/recipes/scatter-anticipation.mdx
@@ -1,0 +1,60 @@
+---
+title: Scatter-driven anticipation
+group: tension
+oneLiner: Pick the tease reels straight from the result grid.
+description: Use anticipationForScatters to derive which reels should tease from
+  the scatter positions in the result, with an all-remaining or scatter-only
+  mode so empty reels aren't slowed unnecessarily.
+order: 50
+steps:
+  - Call anticipationForScatters(grid, { symbol, trigger, mode })
+  - "Anticipation begins on the reel after the trigger-th scatter"
+  - "mode 'all-remaining' teases every following reel; 'scatter-only' teases
+    only reels that actually hold the symbol"
+apis:
+  - anticipationForScatters
+  - ReelSet.setAnticipation
+  - ReelSet.setResult
+tags:
+  - anticipation
+  - tension
+  - scatter
+  - feature-trigger
+---
+
+<RecipeDemo code="scatter-anticipation" />
+
+<p class="text-sm opacity-70">The gold "F" cards are the feature / scatter symbol (its id in code is <code>SCAT</code>). This demo alternates modes each spin.</p>
+
+## Derive the tease reels from the grid
+
+You already know the result when you call `setResult`. Let it decide which reels tease instead of hard-coding indices:
+
+```ts
+import { anticipationForScatters } from 'pixi-reels';
+
+const reels = anticipationForScatters(grid, { symbol: 'SCAT', trigger: 2 });
+reelSet.setResult(grid);
+reelSet.setAnticipation(reels, { stagger: 'sequential', slowdown: { from: 0.5, to: 0.12 } });
+```
+
+Anticipation begins on the reel **after** the one that lands the `trigger`-th scatter. With `SCAT` on reels 0 and 1, that's reels `[2, 3, 4]`.
+
+## all-remaining vs scatter-only
+
+```ts
+// 4 scatters (reels 0,1,3,4). every following reel teases, including the
+// empty reel 2 — maximum tension.
+anticipationForScatters(grid, { symbol: 'SCAT', mode: 'all-remaining' }); // [2, 3, 4]
+
+// 3 scatters (reels 0,1,3). only reel 3 can extend the count, so only reel 3
+// teases; reels 2 and 4 stop normally.
+anticipationForScatters(grid, { symbol: 'SCAT', mode: 'scatter-only' });  // [3]
+```
+
+Use `'scatter-only'` when a result can't complete the feature on some reels and you don't want to fake tension on reels that don't matter. Returns `[]` when the grid never reaches `trigger`, so `setAnticipation([])` is a harmless no-op.
+
+## Related
+
+- [Staggered / sequential anticipation](/recipes/staggered-anticipation/)
+- [Slowing anticipation](/recipes/slowing-anticipation/)

--- a/apps/site/src/content/recipes/skip-anticipation.mdx
+++ b/apps/site/src/content/recipes/skip-anticipation.mdx
@@ -1,0 +1,51 @@
+---
+title: Skip the tease
+group: tension
+oneLiner: Let the player slam through a long anticipation at any point.
+description: Anticipation is skippable — a second button tap during the tease
+  slams the reels onto the result immediately, so an impatient player is never
+  trapped by a long dramatic build-up.
+order: 51
+steps:
+  - Run a long anticipation (here a sequential crawl)
+  - A second button press mid-tease calls skipSpin() / requestSkip()
+  - Every active tease is cut short and the reels land on the result at once
+apis:
+  - ReelSet.skipSpin
+  - ReelSet.requestSkip
+  - ReelSet.setAnticipation
+tags:
+  - anticipation
+  - tension
+  - skip
+---
+
+<RecipeDemo code="skip-anticipation" />
+
+<p class="text-sm opacity-70">Press <strong>Spin again while it's teasing</strong> to slam through the build-up.</p>
+
+## A tease you can always cut
+
+A long sequential crawl with a deep slow-down is dramatic — but a player who has seen it should never feel stuck waiting it out. `AnticipationPhase` is skippable, so a slam mid-tease force-completes every active tease and lands the reels on the result immediately.
+
+## Wiring the slam
+
+`skipSpin()` slams the current drop (and, first press of a round, applies the round's speed boost). Before `setResult()` arrives there is nothing to land on, so guard with `requestSkip()`, which queues the slam until the result is set:
+
+```ts
+button.addEventListener('click', () => {
+  if (reelSet.isSpinning) {
+    try { reelSet.skipSpin(); }      // slam the current drop + teases
+    catch { reelSet.requestSkip(); } // pre-result: queue the slam
+  } else {
+    startSpin();
+  }
+});
+```
+
+Because the slam force-completes the anticipation phases, any per-reel tension effect wired to `anticipation:reelEnd` (or `spin:reelLanded`) is torn down cleanly as each reel lands.
+
+## Related
+
+- [Slam-stop](/recipes/slam-stop/) — the base slam pattern.
+- [Staggered / sequential anticipation](/recipes/staggered-anticipation/)

--- a/apps/site/src/content/recipes/slowing-anticipation.mdx
+++ b/apps/site/src/content/recipes/slowing-anticipation.mdx
@@ -1,0 +1,58 @@
+---
+title: Slowing anticipation
+group: tension
+oneLiner: Each teasing reel crawls slower than the last, then stops exactly there.
+description: Use the slowdown option so each successive anticipation reel
+  decelerates deeper and holds longer, then carries that slow speed straight
+  into the landing instead of snapping back to full speed.
+order: 49
+steps:
+  - "Pass { stagger, slowdown } to setAnticipation"
+  - "slowdown interpolates from → to across the tease sequence (speed) and
+    holdFrom → holdTo (duration)"
+  - The reel crawls onto its landing frame at the slow speed. no fast re-spin
+apis:
+  - ReelSet.setAnticipation
+  - AnticipationSlowdown
+  - AnticipationPhase
+tags:
+  - anticipation
+  - tension
+  - slowdown
+---
+
+<RecipeDemo code="slowing-anticipation" />
+
+## Progressive deceleration
+
+The flat default drops every teasing reel to 30% of spin speed and holds. The `slowdown` option turns that into an **escalating** build-up: values interpolate across the tease sequence (first anticipation reel → last), so each reel slows deeper and/or holds longer than the one before it.
+
+```ts
+reelSet.setAnticipation([2, 3, 4], {
+  stagger: 300,
+  slowdown: {
+    from: 0.5,   // first tease reel → 50% of spin speed
+    to: 0.1,     // last tease reel  → 10% (a crawl)
+    holdFrom: 1, // first reel holds for anticipationDelay ×1
+    holdTo: 1.6, // last reel holds ×1.6 — extra tension on the decider
+  },
+});
+```
+
+`from`/`to` are fractions of `SpeedProfile.spinSpeed`. `holdFrom`/`holdTo` scale `anticipationDelay`. Omit `slowdown` entirely to keep the classic flat tease.
+
+## It stops where it slowed to
+
+A teasing reel now carries its slow speed straight into the stop and **crawls onto the landing frame** — it does not snap back to full speed for a fast spin-out. The deceleration you see is the deceleration that lands. Combine with `'sequential'` for the maximal one-reel-at-a-time build:
+
+```ts
+reelSet.setAnticipation([2, 3, 4], {
+  stagger: 'sequential',
+  slowdown: { from: 0.45, to: 0.08 },
+});
+```
+
+## Related
+
+- [Staggered / sequential anticipation](/recipes/staggered-anticipation/) — space the tease starts.
+- [Scatter-driven anticipation](/recipes/scatter-anticipation/) — pick the tease reels from the grid.

--- a/apps/site/src/content/recipes/staggered-anticipation.mdx
+++ b/apps/site/src/content/recipes/staggered-anticipation.mdx
@@ -1,0 +1,58 @@
+---
+title: Staggered / sequential anticipation
+group: tension
+oneLiner: Tease reels one after another instead of all slowing at once.
+description: Pass a stagger to setAnticipation so each teasing reel starts (or
+  finishes) after the last, instead of every anticipation reel slowing down at
+  the same instant.
+order: 48
+steps:
+  - Call setAnticipation([...reels], stagger) with a second argument
+  - "Use a number for a constant sweep, or 'sequential' to hold each reel until
+    the previous one has landed"
+  - spin:stopping fires when a reel actually begins slowing, so tension SFX sync
+    to the real start
+apis:
+  - ReelSet.setAnticipation
+  - spin:stopping event
+  - spin:reelLanded event
+tags:
+  - anticipation
+  - tension
+  - stagger
+  - sequential
+---
+
+<RecipeDemo code="staggered-anticipation" />
+
+## The problem with parallel anticipation
+
+By default every reel you pass to `setAnticipation` begins its slow-down at the same instant, so with `anticipationDelay` (e.g. 450 ms) much larger than `stopDelay` (e.g. 140 ms) the teases overlap almost entirely. it reads as one shared slow-down, then the later reels pop in quickly.
+
+## Stagger the tease start
+
+The second argument to `setAnticipation` spaces the teases by **tease-order** (their position in the list you pass, not their raw reel index):
+
+```ts
+reelSet.setAnticipation([2, 3, 4], 0);          // parallel (default)
+reelSet.setAnticipation([2, 3, 4], 450);        // constant 450ms sweep, left→right
+reelSet.setAnticipation([2, 3, 4], [0, 300, 750]); // explicit per-reel offsets
+reelSet.setAnticipation([2, 3, 4], 'sequential');  // wait for each to LAND
+```
+
+`'sequential'` is the strongest: reel 3 does not begin teasing until reel 2 has fully landed, and reel 4 waits for reel 3. one reel holds the whole floor at a time.
+
+## Sync tension SFX to the real start
+
+`spin:stopping` now fires when a reel *actually* begins slowing (after its stagger offset), not when the result arrives — so a per-reel tease sound lines up with what the player sees:
+
+```ts
+reelSet.events.on('spin:stopping', (reelIndex) => {
+  if (anticipationReels.includes(reelIndex)) playTensionSound(reelIndex);
+});
+```
+
+## Related
+
+- [Slowing anticipation](/recipes/slowing-anticipation/) — make each reel decelerate deeper than the last.
+- [Scatter-driven anticipation](/recipes/scatter-anticipation/) — pick the tease reels straight from the result grid.

--- a/apps/site/src/content/recipes/turbo-anticipation.mdx
+++ b/apps/site/src/content/recipes/turbo-anticipation.mdx
@@ -1,0 +1,48 @@
+---
+title: Anticipation in turbo
+group: tension
+oneLiner: Keep the tease playing in Turbo / SuperTurbo with a duration override.
+description: SuperTurbo profiles set anticipationDelay to 0, which skips the
+  tease. Pass a duration override to setAnticipation so the big scatter moment
+  still plays at turbo speed, with no profile juggling.
+order: 50.5
+steps:
+  - "SuperTurbo's profile has anticipationDelay: 0 → a plain setAnticipation skips the tease"
+  - "Pass { duration } to setAnticipation to set the hold explicitly"
+  - The tease plays even at turbo speed; stagger and slowdown still apply
+apis:
+  - ReelSet.setAnticipation
+  - AnticipationOptions.duration
+  - anticipation:reel event
+tags:
+  - anticipation
+  - tension
+  - turbo
+---
+
+<RecipeDemo code="turbo-anticipation" />
+
+## Turbo shouldn't kill the tease
+
+Anticipation duration comes from the active `SpeedProfile.anticipationDelay`. The built-in `TURBO` profile shortens it and `SUPER_TURBO` sets it to **0** — which means a plain `setAnticipation` produces no tease at all in turbo. But the "will I land the bonus?" moment is exactly what you *don't* want to skip, even for a fast player.
+
+## One override, no profile juggling
+
+Pass `duration` (ms) in the options object. It overrides the profile's `anticipationDelay` for this call, so the tease plays regardless of speed:
+
+```ts
+reelSet.setSpeed('superTurbo');           // anticipationDelay: 0
+reelSet.setResult(grid);
+reelSet.setAnticipation([2, 3, 4], {
+  duration: 420,                          // forces the tease even at turbo speed
+  stagger: 240,
+  slowdown: { from: 0.5, to: 0.12 },
+});
+```
+
+`stagger` and `slowdown` work exactly as they do at normal speed — `duration` only sets the base hold (and becomes the base that `slowdown.holdFrom/holdTo` scale). Drop the override and the same call reverts to whatever the active profile dictates, so normal spins tease and turbo spins stay instant unless you opt in.
+
+## Related
+
+- [Slowing anticipation](/recipes/slowing-anticipation/)
+- [Skip the tease](/recipes/skip-anticipation/)

--- a/apps/site/src/recipes/scatter-anticipation.recipe.ts
+++ b/apps/site/src/recipes/scatter-anticipation.recipe.ts
@@ -1,0 +1,89 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   anticipationForScatters, PIXI, app
+//
+// SCATTER-DRIVEN anticipation. Let the result grid decide which reels tease.
+// Alternates each spin between the two modes so you can feel the difference:
+//   - all-remaining: 4 scatters (reels 0,1,3,4) -> reels 2,3,4 ALL tease,
+//     even the empty reel 2.
+//   - scatter-only:  3 scatters (reels 0,1,3)   -> only reel 3 teases;
+//     reels 2 and 4 stop normally (no pointless slow-down).
+//
+// Each teasing reel wears the Hold & Win anticipation glow (the `in`→`loop`
+// additive sprite burst), driven off the anticipation:reel / reelEnd events.
+
+const IDS = ['9', '10', 'J', 'Q', 'K'];
+const SCAT = 'SCAT';
+const REELS = 5, ROWS = 3, SIZE = 80, GAP = 4;
+const CARDS = CARD_DECK.filter((c) => IDS.includes(c.id));
+function rv() { return IDS[Math.floor(Math.random() * IDS.length)]; }
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS).visibleRows(ROWS).symbolSize(SIZE, SIZE).symbolGap(GAP, GAP)
+  .symbols((r) => {
+    for (const c of CARDS) {
+      r.register(c.id, CardSymbol, { color: c.color, label: c.label, textColor: c.textColor });
+    }
+    r.register(SCAT, CardSymbol, { color: 0xffcc44, label: 'F', textColor: 0x3a2600 });
+  })
+  .speed('normal', { ...SpeedPresets.NORMAL, anticipationDelay: 500 })
+  .ticker(app.ticker)
+  .build();
+
+// ── Hold & Win anticipation glow, reused over each teasing reel ──
+const antSheet = await PIXI.Assets.load('/hw-sprites/anticipation.json');
+const antFrames = (pre) => Object.entries(antSheet.textures)
+  .filter(([k]) => k.startsWith(pre)).sort(([a], [b]) => a.localeCompare(b)).map(([, t]) => t);
+const ANT_IN = antFrames('in/'), ANT_LOOP = antFrames('loop/');
+const TOTAL_H = ROWS * SIZE + (ROWS - 1) * GAP;
+
+let teaseReels = []; // updated per spin from anticipationForScatters
+const glowLayer = new PIXI.Container();
+reelSet.addChild(glowLayer);
+const glows = new Map();
+const stopGlow = (i) => { const g = glows.get(i); if (g) { try { g.destroy(); } catch {} glows.delete(i); } };
+const startGlow = (i) => {
+  stopGlow(i);
+  const g = new PIXI.AnimatedSprite(ANT_IN.length ? ANT_IN : ANT_LOOP);
+  g.anchor.set(0.5);
+  g.position.set(i * (SIZE + GAP) + SIZE / 2, TOTAL_H / 2);
+  g.width = g.height = SIZE * 2.0; // concentrated burst, like the H&W cell glow
+  g.blendMode = 'add';
+  g.animationSpeed = 0.5; g.loop = false;
+  g.onComplete = () => { if (ANT_LOOP.length) { g.textures = ANT_LOOP; g.loop = true; g.play(); } };
+  glowLayer.addChild(g); g.play();
+  glows.set(i, g);
+};
+
+// The dedicated anticipation events fire ONLY for teasing reels, so the glow
+// needs no per-reel gate even though the tease set changes each spin.
+reelSet.events.on('anticipation:reel', ({ reelIndex }) => startGlow(reelIndex));
+reelSet.events.on('anticipation:reelEnd', ({ reelIndex }) => stopGlow(reelIndex));
+reelSet.events.on('spin:complete', () => { for (const i of [...glows.keys()]) stopGlow(i); });
+
+let spinCount = 0;
+
+return {
+  reelSet,
+  cleanup: () => { for (const i of [...glows.keys()]) stopGlow(i); try { glowLayer.destroy(); } catch {} },
+  onSpin: async () => {
+    spinCount++;
+    // Odd spins: 4 scatters + all-remaining. Even spins: 3 scatters + scatter-only.
+    const allRemaining = spinCount % 2 === 1;
+    const scatterReels = allRemaining ? [0, 1, 3, 4] : [0, 1, 3];
+    const mode = allRemaining ? 'all-remaining' : 'scatter-only';
+
+    const grid = Array.from({ length: REELS }, (_, c) => ({
+      visible: [rv(), scatterReels.includes(c) ? SCAT : rv(), rv()],
+    }));
+
+    // Derive the tease reels straight from the grid.
+    teaseReels = anticipationForScatters(grid, { symbol: SCAT, trigger: 2, mode });
+
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 220));
+    reelSet.setResult(grid);
+    reelSet.setAnticipation(teaseReels, { stagger: 'sequential', slowdown: { from: 0.5, to: 0.12 } });
+    await p;
+  },
+};

--- a/apps/site/src/recipes/skip-anticipation.recipe.ts
+++ b/apps/site/src/recipes/skip-anticipation.recipe.ts
@@ -1,0 +1,83 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK, PIXI, app
+//
+// SKIP THE TEASE. A long, dramatic sequential anticipation the player can cut
+// short at any point. Press the button again mid-tease and the reels slam onto
+// the result immediately. anticipation is skippable, so an impatient player is
+// never trapped by the build-up.
+
+const IDS = ['9', '10', 'J', 'Q', 'K'];
+const SCAT = 'SCAT';
+const REELS = 5, ROWS = 3, SIZE = 80, GAP = 4;
+const TEASE = [2, 3, 4];
+const CARDS = CARD_DECK.filter((c) => IDS.includes(c.id));
+function rv() { return IDS[Math.floor(Math.random() * IDS.length)]; }
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS).visibleRows(ROWS).symbolSize(SIZE, SIZE).symbolGap(GAP, GAP)
+  .symbols((r) => {
+    for (const c of CARDS) {
+      r.register(c.id, CardSymbol, { color: c.color, label: c.label, textColor: c.textColor });
+    }
+    r.register(SCAT, CardSymbol, { color: 0xffcc44, label: 'F', textColor: 0x3a2600 });
+  })
+  // Long anticipation window so there's plenty of tease to cut through.
+  .speed('normal', { ...SpeedPresets.NORMAL, anticipationDelay: 1200 })
+  .ticker(app.ticker)
+  .build();
+
+// ── Hold & Win anticipation glow, driven off the anticipation events ──
+const antSheet = await PIXI.Assets.load('/hw-sprites/anticipation.json');
+const antFrames = (pre) => Object.entries(antSheet.textures)
+  .filter(([k]) => k.startsWith(pre)).sort(([a], [b]) => a.localeCompare(b)).map(([, t]) => t);
+const ANT_IN = antFrames('in/'), ANT_LOOP = antFrames('loop/');
+const TOTAL_H = ROWS * SIZE + (ROWS - 1) * GAP;
+
+const glowLayer = new PIXI.Container();
+reelSet.addChild(glowLayer);
+const glows = new Map();
+const stopGlow = (i) => { const g = glows.get(i); if (g) { try { g.destroy(); } catch {} glows.delete(i); } };
+const startGlow = (i) => {
+  stopGlow(i);
+  const g = new PIXI.AnimatedSprite(ANT_IN.length ? ANT_IN : ANT_LOOP);
+  g.anchor.set(0.5);
+  g.position.set(i * (SIZE + GAP) + SIZE / 2, TOTAL_H / 2);
+  g.width = g.height = SIZE * 2.0;
+  g.blendMode = 'add';
+  g.animationSpeed = 0.5; g.loop = false;
+  g.onComplete = () => { if (ANT_LOOP.length) { g.textures = ANT_LOOP; g.loop = true; g.play(); } };
+  glowLayer.addChild(g); g.play();
+  glows.set(i, g);
+};
+
+reelSet.events.on('anticipation:reel', ({ reelIndex }) => startGlow(reelIndex));
+reelSet.events.on('anticipation:reelEnd', ({ reelIndex }) => stopGlow(reelIndex));
+reelSet.events.on('spin:complete', () => { for (const i of [...glows.keys()]) stopGlow(i); });
+
+return {
+  reelSet,
+  cleanup: () => { for (const i of [...glows.keys()]) stopGlow(i); try { glowLayer.destroy(); } catch {} },
+  // The demo runner presses this on a second button tap while spinning. It
+  // slams the current drop onto the result and cuts every tease short. Guarded
+  // so a tap before setResult() queues instead of throwing.
+  onSkip: () => { try { reelSet.skipSpin(); } catch { reelSet.requestSkip(); } },
+  onSpin: async () => {
+    const grid = [
+      { visible: [rv(), SCAT, rv()] },
+      { visible: [rv(), SCAT, rv()] },
+      { visible: [rv(), rv(), rv()] },
+      { visible: [rv(), rv(), rv()] },
+      { visible: [rv(), rv(), rv()] },
+    ];
+
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 200));
+    reelSet.setResult(grid);
+    // A long one-at-a-time crawl. tap the button again to blow through it.
+    reelSet.setAnticipation(TEASE, {
+      stagger: 'sequential',
+      slowdown: { from: 0.4, to: 0.06, holdTo: 1.5 },
+    });
+    await p;
+  },
+};

--- a/apps/site/src/recipes/slowing-anticipation.recipe.ts
+++ b/apps/site/src/recipes/slowing-anticipation.recipe.ts
@@ -1,0 +1,83 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK, PIXI, app
+//
+// SLOWING anticipation. Each teasing reel decelerates DEEPER than the last
+// (0.5x -> 0.1x spin speed) and holds longer, then crawls onto its landing
+// frame at that slow speed. no snap-back to full speed for the stop.
+//
+// Each teasing reel wears the Hold & Win anticipation glow (the `in`→`loop`
+// additive sprite burst), driven off the anticipation:reel / reelEnd events.
+
+const IDS = ['9', '10', 'J', 'Q', 'K'];
+const SCAT = 'SCAT';
+const REELS = 5, ROWS = 3, SIZE = 80, GAP = 4;
+const TEASE = [2, 3, 4];
+const CARDS = CARD_DECK.filter((c) => IDS.includes(c.id));
+function rv() { return IDS[Math.floor(Math.random() * IDS.length)]; }
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS).visibleRows(ROWS).symbolSize(SIZE, SIZE).symbolGap(GAP, GAP)
+  .symbols((r) => {
+    for (const c of CARDS) {
+      r.register(c.id, CardSymbol, { color: c.color, label: c.label, textColor: c.textColor });
+    }
+    r.register(SCAT, CardSymbol, { color: 0xffcc44, label: 'F', textColor: 0x3a2600 });
+  })
+  .speed('normal', { ...SpeedPresets.NORMAL, anticipationDelay: 500 })
+  .ticker(app.ticker)
+  .build();
+
+// ── Hold & Win anticipation glow, reused over each teasing reel ──
+const antSheet = await PIXI.Assets.load('/hw-sprites/anticipation.json');
+const antFrames = (pre) => Object.entries(antSheet.textures)
+  .filter(([k]) => k.startsWith(pre)).sort(([a], [b]) => a.localeCompare(b)).map(([, t]) => t);
+const ANT_IN = antFrames('in/'), ANT_LOOP = antFrames('loop/');
+const TOTAL_H = ROWS * SIZE + (ROWS - 1) * GAP;
+
+const glowLayer = new PIXI.Container();
+reelSet.addChild(glowLayer);
+const glows = new Map();
+const stopGlow = (i) => { const g = glows.get(i); if (g) { try { g.destroy(); } catch {} glows.delete(i); } };
+const startGlow = (i) => {
+  stopGlow(i);
+  const g = new PIXI.AnimatedSprite(ANT_IN.length ? ANT_IN : ANT_LOOP);
+  g.anchor.set(0.5);
+  g.position.set(i * (SIZE + GAP) + SIZE / 2, TOTAL_H / 2);
+  g.width = g.height = SIZE * 2.0; // concentrated burst, like the H&W cell glow
+  g.blendMode = 'add';
+  g.animationSpeed = 0.5; g.loop = false;
+  g.onComplete = () => { if (ANT_LOOP.length) { g.textures = ANT_LOOP; g.loop = true; g.play(); } };
+  glowLayer.addChild(g); g.play();
+  glows.set(i, g);
+};
+
+// The dedicated anticipation events fire ONLY for teasing reels, so no manual
+// gating is needed. `order` / `total` are here too if you want a pitch ramp.
+reelSet.events.on('anticipation:reel', ({ reelIndex }) => startGlow(reelIndex));
+reelSet.events.on('anticipation:reelEnd', ({ reelIndex }) => stopGlow(reelIndex));
+reelSet.events.on('spin:complete', () => { for (const i of [...glows.keys()]) stopGlow(i); });
+
+return {
+  reelSet,
+  cleanup: () => { for (const i of [...glows.keys()]) stopGlow(i); try { glowLayer.destroy(); } catch {} },
+  onSpin: async () => {
+    const grid = [
+      { visible: [rv(), SCAT, rv()] },
+      { visible: [rv(), SCAT, rv()] },
+      { visible: [rv(), rv(), rv()] },
+      { visible: [rv(), rv(), rv()] },
+      { visible: [rv(), rv(), rv()] },
+    ];
+
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 220));
+    reelSet.setResult(grid);
+    // Progressive slow-down: later reels crawl slower AND hold longer, then
+    // stop exactly where they slowed to.
+    reelSet.setAnticipation(TEASE, {
+      stagger: 300,
+      slowdown: { from: 0.5, to: 0.1, holdTo: 1.6 },
+    });
+    await p;
+  },
+};

--- a/apps/site/src/recipes/staggered-anticipation.recipe.ts
+++ b/apps/site/src/recipes/staggered-anticipation.recipe.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK, PIXI, app
+//
+// STAGGERED / SEQUENTIAL anticipation. With 2 scatters already showing, the
+// last three reels tease ONE AFTER ANOTHER instead of all slowing at once.
+// `'sequential'` holds each reel until the previous one has fully landed.
+//
+// Each teasing reel wears the Hold & Win anticipation glow (the same `in`→`loop`
+// additive sprite burst the H&W last-cell tension uses), driven off
+// the anticipation:reel / anticipation:reelEnd events.
+
+const IDS = ['9', '10', 'J', 'Q', 'K'];
+const SCAT = 'SCAT';
+const REELS = 5, ROWS = 3, SIZE = 80, GAP = 4;
+const TEASE = [2, 3, 4];
+const CARDS = CARD_DECK.filter((c) => IDS.includes(c.id));
+function rv() { return IDS[Math.floor(Math.random() * IDS.length)]; }
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS).visibleRows(ROWS).symbolSize(SIZE, SIZE).symbolGap(GAP, GAP)
+  .symbols((r) => {
+    for (const c of CARDS) {
+      r.register(c.id, CardSymbol, { color: c.color, label: c.label, textColor: c.textColor });
+    }
+    // Feature / scatter symbol: id SCAT, drawn as a gold "F" card.
+    r.register(SCAT, CardSymbol, { color: 0xffcc44, label: 'F', textColor: 0x3a2600 });
+  })
+  .speed('normal', { ...SpeedPresets.NORMAL, anticipationDelay: 550 })
+  .ticker(app.ticker)
+  .build();
+
+// ── Hold & Win anticipation glow, reused over each teasing reel ──
+const antSheet = await PIXI.Assets.load('/hw-sprites/anticipation.json');
+const antFrames = (pre) => Object.entries(antSheet.textures)
+  .filter(([k]) => k.startsWith(pre)).sort(([a], [b]) => a.localeCompare(b)).map(([, t]) => t);
+const ANT_IN = antFrames('in/'), ANT_LOOP = antFrames('loop/');
+const TOTAL_H = ROWS * SIZE + (ROWS - 1) * GAP;
+
+const glowLayer = new PIXI.Container();
+reelSet.addChild(glowLayer); // child of the reel set → inherits its transform
+const glows = new Map();
+const stopGlow = (i) => { const g = glows.get(i); if (g) { try { g.destroy(); } catch {} glows.delete(i); } };
+const startGlow = (i) => {
+  stopGlow(i);
+  const g = new PIXI.AnimatedSprite(ANT_IN.length ? ANT_IN : ANT_LOOP);
+  g.anchor.set(0.5);
+  g.position.set(i * (SIZE + GAP) + SIZE / 2, TOTAL_H / 2);
+  g.width = g.height = SIZE * 2.0; // concentrated burst, like the H&W cell glow
+  g.blendMode = 'add';                              // additive → reads as light
+  g.animationSpeed = 0.5; g.loop = false;
+  g.onComplete = () => { if (ANT_LOOP.length) { g.textures = ANT_LOOP; g.loop = true; g.play(); } };
+  glowLayer.addChild(g); g.play();
+  glows.set(i, g);
+};
+
+// The dedicated anticipation events fire ONLY for teasing reels, so no manual
+// gating is needed. `order` / `total` are here too if you want a pitch ramp.
+reelSet.events.on('anticipation:reel', ({ reelIndex }) => startGlow(reelIndex));
+reelSet.events.on('anticipation:reelEnd', ({ reelIndex }) => stopGlow(reelIndex));
+reelSet.events.on('spin:complete', () => { for (const i of [...glows.keys()]) stopGlow(i); });
+
+return {
+  reelSet,
+  cleanup: () => { for (const i of [...glows.keys()]) stopGlow(i); try { glowLayer.destroy(); } catch {} },
+  onSpin: async () => {
+    // 2 scatters on reels 0 and 1 → the last three reels are all live.
+    const grid = [
+      { visible: [rv(), SCAT, rv()] },
+      { visible: [rv(), SCAT, rv()] },
+      { visible: [rv(), rv(), rv()] },
+      { visible: [rv(), rv(), rv()] },
+      { visible: [rv(), rv(), rv()] },
+    ];
+
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 220));
+    reelSet.setResult(grid);
+    // Each reel waits until the previous anticipation reel has LANDED.
+    reelSet.setAnticipation(TEASE, 'sequential');
+    await p;
+  },
+};

--- a/apps/site/src/recipes/turbo-anticipation.recipe.ts
+++ b/apps/site/src/recipes/turbo-anticipation.recipe.ts
@@ -1,0 +1,81 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK, PIXI, app
+//
+// TURBO anticipation. SuperTurbo's profile has `anticipationDelay: 0`, so a
+// plain setAnticipation would skip the tease entirely. The per-call `duration`
+// override forces it to play anyway — the big "will I hit the bonus?" moment
+// survives turbo. No profile juggling.
+
+const IDS = ['9', '10', 'J', 'Q', 'K'];
+const SCAT = 'SCAT';
+const REELS = 5, ROWS = 3, SIZE = 80, GAP = 4;
+const TEASE = [2, 3, 4];
+const CARDS = CARD_DECK.filter((c) => IDS.includes(c.id));
+function rv() { return IDS[Math.floor(Math.random() * IDS.length)]; }
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS).visibleRows(ROWS).symbolSize(SIZE, SIZE).symbolGap(GAP, GAP)
+  .symbols((r) => {
+    for (const c of CARDS) {
+      r.register(c.id, CardSymbol, { color: c.color, label: c.label, textColor: c.textColor });
+    }
+    r.register(SCAT, CardSymbol, { color: 0xffcc44, label: 'F', textColor: 0x3a2600 });
+  })
+  // Only SuperTurbo is registered — its anticipationDelay is 0.
+  .speed('superTurbo', SpeedPresets.SUPER_TURBO)
+  .initialSpeed('superTurbo')
+  .ticker(app.ticker)
+  .build();
+
+// ── Hold & Win anticipation glow, driven off the anticipation events ──
+const antSheet = await PIXI.Assets.load('/hw-sprites/anticipation.json');
+const antFrames = (pre) => Object.entries(antSheet.textures)
+  .filter(([k]) => k.startsWith(pre)).sort(([a], [b]) => a.localeCompare(b)).map(([, t]) => t);
+const ANT_IN = antFrames('in/'), ANT_LOOP = antFrames('loop/');
+const TOTAL_H = ROWS * SIZE + (ROWS - 1) * GAP;
+
+const glowLayer = new PIXI.Container();
+reelSet.addChild(glowLayer);
+const glows = new Map();
+const stopGlow = (i) => { const g = glows.get(i); if (g) { try { g.destroy(); } catch {} glows.delete(i); } };
+const startGlow = (i) => {
+  stopGlow(i);
+  const g = new PIXI.AnimatedSprite(ANT_IN.length ? ANT_IN : ANT_LOOP);
+  g.anchor.set(0.5);
+  g.position.set(i * (SIZE + GAP) + SIZE / 2, TOTAL_H / 2);
+  g.width = g.height = SIZE * 2.0;
+  g.blendMode = 'add';
+  g.animationSpeed = 0.5; g.loop = false;
+  g.onComplete = () => { if (ANT_LOOP.length) { g.textures = ANT_LOOP; g.loop = true; g.play(); } };
+  glowLayer.addChild(g); g.play();
+  glows.set(i, g);
+};
+
+reelSet.events.on('anticipation:reel', ({ reelIndex }) => startGlow(reelIndex));
+reelSet.events.on('anticipation:reelEnd', ({ reelIndex }) => stopGlow(reelIndex));
+reelSet.events.on('spin:complete', () => { for (const i of [...glows.keys()]) stopGlow(i); });
+
+return {
+  reelSet,
+  cleanup: () => { for (const i of [...glows.keys()]) stopGlow(i); try { glowLayer.destroy(); } catch {} },
+  onSpin: async () => {
+    const grid = [
+      { visible: [rv(), SCAT, rv()] },
+      { visible: [rv(), SCAT, rv()] },
+      { visible: [rv(), rv(), rv()] },
+      { visible: [rv(), rv(), rv()] },
+      { visible: [rv(), rv(), rv()] },
+    ];
+
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 120));
+    reelSet.setResult(grid);
+    // The reels rip past at SuperTurbo speed, but `duration` keeps the tease:
+    reelSet.setAnticipation(TEASE, {
+      duration: 420,           // overrides the profile's anticipationDelay of 0
+      stagger: 240,
+      slowdown: { from: 0.5, to: 0.12 },
+    });
+    await p;
+  },
+};

--- a/packages/pixi-reels/src/config/types.ts
+++ b/packages/pixi-reels/src/config/types.ts
@@ -66,6 +66,50 @@ export interface SpinOptions {
   timeoutMs?: number;
 }
 
+/**
+ * How the START of each anticipation reel's slow-down is spaced (offsets are
+ * by tease-order, i.e. position within the anticipation set, not raw reel
+ * index):
+ *   - `0` (default) — every anticipation reel begins slowing together.
+ *   - `number` — reel at tease-order `k` starts `k * value` ms after the first.
+ *   - `number[]` — explicit per-tease-order offset in ms.
+ *   - `'sequential'` — each reel waits until the previous anticipation reel
+ *     has fully landed before it starts.
+ */
+export type AnticipationStagger = number | number[] | 'sequential';
+
+/**
+ * Progressive slow-down across the tease sequence. Values interpolate linearly
+ * across tease-order (first anticipation reel → last), so each successive reel
+ * decelerates deeper and/or holds longer than the one before it. This is what
+ * turns a flat "everyone drops to 30%" tease into an escalating "each reel
+ * crawls slower than the last" build-up.
+ */
+export interface AnticipationSlowdown {
+  /** Speed multiplier (fraction of spin speed) the FIRST tease reel slows to. Default `0.3`. */
+  from?: number;
+  /** Speed multiplier the LAST tease reel slows to. Default = `from` (flat). Lower = slower/more tension. */
+  to?: number;
+  /** Hold-duration multiplier for the FIRST tease reel (scales `anticipationDelay`). Default `1`. */
+  holdFrom?: number;
+  /** Hold-duration multiplier for the LAST tease reel. Default = `holdFrom`. `>1` = later reels hold longer. */
+  holdTo?: number;
+}
+
+/** Full anticipation configuration. The object form of `setAnticipation`'s second argument. */
+export interface AnticipationOptions {
+  stagger?: AnticipationStagger;
+  slowdown?: AnticipationSlowdown;
+  /**
+   * Explicit tease hold in ms, overriding the active speed profile's
+   * `anticipationDelay`. Pass a positive value to keep the tease playing in
+   * Turbo / SuperTurbo (whose profiles set `anticipationDelay: 0`, which would
+   * otherwise skip anticipation entirely). When `slowdown.holdFrom/holdTo` are
+   * also set, this is the base they scale.
+   */
+  duration?: number;
+}
+
 /** Timing and animation profile for a speed mode. */
 export interface SpeedProfile {
   readonly name: string;

--- a/packages/pixi-reels/src/core/ReelSet.ts
+++ b/packages/pixi-reels/src/core/ReelSet.ts
@@ -1,6 +1,13 @@
 import { Container } from 'pixi.js';
 import type { Disposable } from '../utils/Disposable.js';
-import type { ReelSetInternalConfig, CellBounds, SymbolData, SpinOptions } from '../config/types.js';
+import type {
+  ReelSetInternalConfig,
+  CellBounds,
+  SymbolData,
+  SpinOptions,
+  AnticipationStagger,
+  AnticipationOptions,
+} from '../config/types.js';
 import { EventEmitter } from '../events/EventEmitter.js';
 import type { ReelSetEvents, SpinResult, RunCascadeResult as RunCascadeResultBase } from '../events/ReelEvents.js';
 import { Reel, } from './Reel.js';
@@ -959,9 +966,57 @@ export class ReelSet extends Container implements Disposable {
     return summary;
   }
 
-  /** Set which reels should show anticipation before stopping. */
-  setAnticipation(reelIndices: number[]): void {
-    this._spinController.setAnticipation(reelIndices);
+  /**
+   * Set which reels should show anticipation before stopping, and how their
+   * slow-downs are spaced via `stagger`:
+   *
+   *   - `0` (default): every anticipation reel begins slowing at once (the
+   *     historical parallel behaviour).
+   *   - `number`: reel at tease-order `k` starts its slow-down `k * stagger`
+   *     ms after the first, so the tease sweeps across the reels.
+   *   - `number[]`: explicit per-tease-order offset in ms.
+   *   - `'sequential'`: each reel waits until the previous anticipation reel
+   *     has fully landed before it starts. maximal one-at-a-time tension.
+   *
+   * Offsets are by tease-order (position in `reelIndices`), not raw reel
+   * index. Reset at the start of every `spin()`.
+   *
+   * Pass a `{ stagger, slowdown, duration }` object to shape the tease more:
+   *   - `slowdown` interpolates across the tease sequence so each successive
+   *     reel slows to a lower speed (`from` → `to`) and/or holds longer
+   *     (`holdFrom` → `holdTo`) — the escalating "each reel crawls slower than
+   *     the last" build-up. See {@link AnticipationSlowdown}.
+   *   - `duration` (ms) overrides the profile's `anticipationDelay`, so the
+   *     tease plays even in Turbo / SuperTurbo (whose profiles use
+   *     `anticipationDelay: 0` and would otherwise skip anticipation).
+   *
+   * Listen to `anticipation:reel` ({ reelIndex, order, total }) to drive
+   * per-step tension SFX / a pitch ramp, and `anticipation:reelEnd` to stop it.
+   *
+   * @example
+   * // Classic "2 scatters showing" sweep across the last three reels:
+   * reelSet.setResult(grid);
+   * reelSet.setAnticipation([2, 3, 4], 450);          // 450ms apart
+   * reelSet.setAnticipation([2, 3, 4], 'sequential');  // strict one-by-one
+   *
+   * // Keep the tease alive in turbo (profile anticipationDelay is 0):
+   * reelSet.setAnticipation([2, 3, 4], { duration: 350, stagger: 200 });
+   *
+   * // Escalating slow-down: later reels crawl slower and hold longer.
+   * reelSet.setAnticipation([2, 3, 4], {
+   *   stagger: 400,
+   *   slowdown: { from: 0.45, to: 0.12, holdTo: 2 },
+   * });
+   *
+   * // Drive which reels tease straight from the result grid:
+   * const reels = anticipationForScatters(grid, { symbol: 'SCAT', trigger: 2 });
+   * reelSet.setAnticipation(reels, { stagger: 'sequential', slowdown: { from: 0.4, to: 0.1 } });
+   */
+  setAnticipation(
+    reelIndices: number[],
+    options: AnticipationStagger | AnticipationOptions = 0,
+  ): void {
+    this._spinController.setAnticipation(reelIndices, options);
   }
 
   /**
@@ -974,11 +1029,18 @@ export class ReelSet extends Container implements Disposable {
    * want every internal `refill()` to honor it. If your rounds use
    * different patterns, re-set explicitly per round.
    *
+   * Pass `null` to CLEAR the override and restore the default
+   * `i * speed.stopDelay` stagger. this is distinct from `[]` / all-zeros
+   * (which lands every reel simultaneously). Use it to undo a one-off
+   * per-round pattern without hard-coding the default back in.
+   *
    * @example
    * // Stagger the last two reels more than the default for dramatic effect:
    * reelSet.setStopDelays([0, 140, 280, 600, 1100]);
+   * // ...later, go back to the profile default:
+   * reelSet.setStopDelays(null);
    */
-  setStopDelays(delays: number[]): void {
+  setStopDelays(delays: number[] | null): void {
     this._spinController.setStopDelays(delays);
   }
 
@@ -1273,8 +1335,13 @@ export class ReelSet extends Container implements Disposable {
    * reelSet.setDropOrder('rtl');  // right-to-left
    * reelSet.setDropOrder('all');  // all columns simultaneously
    * reelSet.setDropOrder([0, 0, 200, 200, 400]); // custom per-reel delays
+   * reelSet.setDropOrder(null);   // clear the override, restore the default
    */
-  setDropOrder(order: 'ltr' | 'rtl' | 'all' | number[], stepMs?: number): void {
+  setDropOrder(order: 'ltr' | 'rtl' | 'all' | number[] | null, stepMs?: number): void {
+    if (order === null) {
+      this._spinController.setStopDelays(null);
+      return;
+    }
     if (Array.isArray(order)) {
       this._spinController.setStopDelays(order);
       return;

--- a/packages/pixi-reels/src/events/ReelEvents.ts
+++ b/packages/pixi-reels/src/events/ReelEvents.ts
@@ -42,6 +42,24 @@ export interface ReelSetEvents extends Record<string, unknown[]> {
   'spin:start': [];
   'spin:allStarted': [];
   'spin:stopping': [reelIndex: number];
+  /**
+   * A reel has BEGUN its anticipation tease (fired after any stagger offset,
+   * i.e. the moment it actually starts slowing). Carries the reel's place in
+   * the tease sequence so you can drive per-step tension SFX / a pitch ramp
+   * (`order / (total - 1)`) / escalating visuals without re-deriving which
+   * reels are teasing from `spin:stopping`. Only fires for reels that tease
+   * (in the anticipation set AND the effective hold is > 0).
+   *   - `reelIndex`: the reel now teasing.
+   *   - `order`: 0-based position within the anticipation set (0 = first tease).
+   *   - `total`: number of reels teasing this spin.
+   */
+  'anticipation:reel': [info: { reelIndex: number; order: number; total: number }];
+  /**
+   * A teasing reel's tease has ENDED (the reel landed). Fires only for reels
+   * that actually teased, just before that reel's `spin:reelLanded`. Pair with
+   * `anticipation:reel` to bracket a per-reel tension effect.
+   */
+  'anticipation:reelEnd': [info: { reelIndex: number }];
   'spin:reelLanded': [reelIndex: number, symbols: string[]];
   'spin:allLanded': [result: SpinResult];
   'spin:complete': [result: SpinResult];

--- a/packages/pixi-reels/src/index.ts
+++ b/packages/pixi-reels/src/index.ts
@@ -26,6 +26,9 @@ export type {
   MaskConfig,
   MultiWaysConfig,
   ReelAnchor,
+  AnticipationStagger,
+  AnticipationSlowdown,
+  AnticipationOptions,
 } from './config/types.js';
 export type { ReelMaskRect, MaskStrategy } from './core/ReelViewport.js';
 export { RectMaskStrategy, SharedRectMaskStrategy } from './core/ReelViewport.js';
@@ -58,6 +61,10 @@ export type { SpinPhaseConfig } from './spin/phases/SpinPhase.js';
 export type { StopPhaseConfig } from './spin/phases/StopPhase.js';
 export type { AnticipationPhaseConfig } from './spin/phases/AnticipationPhase.js';
 export type { AdjustPhaseConfig } from './spin/phases/AdjustPhase.js';
+
+// Anticipation recipes
+export { anticipationForScatters } from './spin/anticipationRecipes.js';
+export type { ScatterAnticipationOptions } from './spin/anticipationRecipes.js';
 
 // Tumble cascade
 export type { TumbleConfig, TumbleFallConfig, TumbleDropInConfig } from './cascade/TumbleConfig.js';

--- a/packages/pixi-reels/src/spin/SpinController.ts
+++ b/packages/pixi-reels/src/spin/SpinController.ts
@@ -1,6 +1,13 @@
 import type { Ticker } from 'pixi.js';
 import type { Reel } from '../core/Reel.js';
-import type { SpeedProfile, SpinOptions, SymbolData } from '../config/types.js';
+import type {
+  AnticipationOptions,
+  AnticipationSlowdown,
+  AnticipationStagger,
+  SpeedProfile,
+  SpinOptions,
+  SymbolData,
+} from '../config/types.js';
 import type { SpeedManager } from '../speed/SpeedManager.js';
 import type { FrameBuilder } from '../frame/FrameBuilder.js';
 import type { SpinResult } from '../events/ReelEvents.js';
@@ -106,6 +113,39 @@ export class SpinController implements Disposable {
   private _spinStartTime = 0;
   private _resultSymbols: string[][] | null = null;
   private _anticipationReels: number[] = [];
+  /**
+   * How the START of each anticipation reel's slow-down is spaced. See
+   * {@link setAnticipation}. `0` (or a single tease reel) reproduces the
+   * legacy behaviour where every anticipation reel begins slowing at once.
+   */
+  private _anticipationStagger: AnticipationStagger = 0;
+  /**
+   * Progressive slow-down curve applied across the tease sequence, or `null`
+   * for the flat default (every anticipation reel drops to the phase default
+   * of 30% spin speed). See {@link setAnticipation}. Cleared per spin.
+   */
+  private _anticipationSlowdown: AnticipationSlowdown | null = null;
+  /**
+   * Explicit anticipation hold (ms) that OVERRIDES the active speed profile's
+   * `anticipationDelay`. Set via `setAnticipation(reels, { duration })`. `null`
+   * means "use the profile". A positive value also lets the tease play when the
+   * profile's `anticipationDelay` is `0` (Turbo / SuperTurbo). Cleared per spin.
+   */
+  private _anticipationDuration: number | null = null;
+  /**
+   * Reels that actually entered a tease this spin. populated when
+   * `anticipation:reel` fires, drained in `_markLanded` to fire
+   * `anticipation:reelEnd` only for reels that teased. Cleared per spin.
+   */
+  private _teasingReels = new Set<number>();
+  /**
+   * `'sequential'` anticipation chaining state: one deferred per anticipation
+   * reel, resolved when that reel lands (in `_markLanded`). Reel at tease-order
+   * `k` awaits the deferred of the reel at order `k-1` before starting its
+   * tease. Rebuilt each `setAnticipation('sequential')`; cleared per spin.
+   */
+  private _reelLandedResolvers: Map<number, () => void> = new Map();
+  private _reelLandedPromises: Map<number, Promise<void>> = new Map();
   private _stopDelayOverride: number[] | null = null;
   private _activePhases: Map<number, ReelPhase<any>> = new Map();
   private _landedReels = new Set<number>();
@@ -274,6 +314,12 @@ export class SpinController implements Disposable {
     this._spinStartTime = performance.now();
     this._resultSymbols = null;
     this._anticipationReels = [];
+    this._anticipationStagger = 0;
+    this._anticipationSlowdown = null;
+    this._anticipationDuration = null;
+    this._teasingReels.clear();
+    this._reelLandedResolvers.clear();
+    this._reelLandedPromises.clear();
     // NOTE: _stopDelayOverride is NOT cleared here. The contract is that
     // `setDropOrder()` (or `setStopDelays()`) is called right before
     // `spin()` / `refill()` and represents user intent for the upcoming
@@ -479,6 +525,12 @@ export class SpinController implements Disposable {
     this._spinStartTime = performance.now();
     this._resultSymbols = null;
     this._anticipationReels = [];
+    this._anticipationStagger = 0;
+    this._anticipationSlowdown = null;
+    this._anticipationDuration = null;
+    this._teasingReels.clear();
+    this._reelLandedResolvers.clear();
+    this._reelLandedPromises.clear();
     // _stopDelayOverride preserved across entry. see spin() for rationale.
     // Cascade recipes set `setDropOrder('all')` right before refill() and
     // would otherwise see their setting clobbered, falling back to the
@@ -751,20 +803,71 @@ export class SpinController implements Disposable {
     this._markLanded(reelIndex);
   }
 
-  setAnticipation(reelIndices: number[]): void {
+  /**
+   * Mark reels to tease, and shape how they slow down.
+   *
+   * The second argument is either a bare `stagger` value or a full
+   * `{ stagger, slowdown }` options object.
+   *
+   * `stagger` controls when each anticipation reel BEGINS slowing (offsets
+   * are by tease-order. position within `reelIndices`. not raw reel index):
+   *   - `0` (default): all teases start together (legacy parallel behaviour).
+   *   - `number`: reel at tease-order `k` starts after `k * stagger` ms.
+   *   - `number[]`: explicit per-tease-order offset in ms (`stagger[k]`).
+   *   - `'sequential'`: each reel waits until the previous anticipation reel
+   *     has fully landed before it starts. maximal one-at-a-time tension.
+   *
+   * `slowdown` makes the deceleration progressive across the sequence: each
+   * successive reel slows to a lower speed (`from` → `to`) and/or holds longer
+   * (`holdFrom` → `holdTo`). Omit it for the flat 30%-and-hold default.
+   *
+   * `duration` overrides the active speed profile's `anticipationDelay` (ms).
+   * Pass a positive value to make the tease play even in Turbo / SuperTurbo,
+   * whose profiles have `anticipationDelay: 0` and would otherwise skip it.
+   */
+  setAnticipation(
+    reelIndices: number[],
+    options: AnticipationStagger | AnticipationOptions = 0,
+  ): void {
+    const opts: AnticipationOptions =
+      typeof options === 'object' && !Array.isArray(options)
+        ? options
+        : { stagger: options };
+    const stagger = opts.stagger ?? 0;
+
     // Held reels never reach AnticipationPhase, but filter here too so the
     // public API is forgiving. callers can pass a flat list without
     // tracking which indices are held this spin.
     this._anticipationReels = reelIndices.filter((i) => !this._heldReels.has(i));
+    this._anticipationStagger = stagger;
+    this._anticipationSlowdown = opts.slowdown ?? null;
+    this._anticipationDuration = opts.duration ?? null;
+    this._teasingReels.clear();
+
+    // Sequential chaining needs a landed-deferred per anticipation reel so a
+    // reel can await the previous one's landing. Build them here (setResult
+    // resolves the spin phases synchronously, so the deferreds must exist
+    // before the anticipation branch runs on the next microtask).
+    this._reelLandedResolvers.clear();
+    this._reelLandedPromises.clear();
+    if (stagger === 'sequential') {
+      for (const i of this._anticipationReels) {
+        this._reelLandedPromises.set(
+          i,
+          new Promise<void>((resolve) => this._reelLandedResolvers.set(i, resolve)),
+        );
+      }
+    }
   }
 
   /**
    * Override the per-reel stop delay (in ms). Pass one value per reel.
    * When set, these replace the staggered `reelIndex * speed.stopDelay`
-   * pattern for the current spin. Cleared at the start of each new spin.
+   * pattern. Pass `null` to CLEAR the override and restore that default
+   * (distinct from passing all-zeros, which lands every reel at once).
    */
-  setStopDelays(delays: number[]): void {
-    this._stopDelayOverride = [...delays];
+  setStopDelays(delays: number[] | null): void {
+    this._stopDelayOverride = delays ? [...delays] : null;
   }
 
   /**
@@ -1081,12 +1184,37 @@ export class SpinController implements Disposable {
     const stopDelay = this._stopDelayFor(reelIndex, speed);
     const targetFrame = this._frameFor(reelIndex);
 
-    if (this._anticipationReels.includes(reelIndex) && speed.anticipationDelay > 0) {
+    // Effective tease hold: the per-call `duration` override wins over the
+    // profile's `anticipationDelay`, so a positive override plays the tease
+    // even in Turbo / SuperTurbo (whose profiles set anticipationDelay: 0).
+    const antBaseDuration = this._anticipationDuration ?? speed.anticipationDelay;
+
+    let didAnticipate = false;
+    if (this._anticipationReels.includes(reelIndex) && antBaseDuration > 0) {
+      // Stagger the START of the slow-down so anticipation reels tease one
+      // after another instead of all at once. The reel keeps spinning at full
+      // speed during this wait (its SpinPhase resolved but `reel.speed` is
+      // still spinSpeed and the ticker keeps advancing it), so earlier reels
+      // visibly hold while later ones stay at full blur.
+      const proceed = await this._awaitAnticipationOffset(reelIndex, generation);
+      if (!proceed) return; // slam / new spin superseded us during the wait
+
+      // A dedicated tease-start signal carrying the reel's place in the
+      // sequence, so games can layer per-step SFX / pitch ramps without
+      // re-deriving which reels are teasing from `spin:stopping`.
+      const order = this._anticipationReels.indexOf(reelIndex);
+      this._teasingReels.add(reelIndex);
+      this._events.emit('anticipation:reel', {
+        reelIndex,
+        order,
+        total: this._anticipationReels.length,
+      });
       this._events.emit('spin:stopping', reelIndex);
       const anticipationPhase = this._phaseFactory.create<any>('anticipation', reel, speed);
       this._activePhases.set(reelIndex, anticipationPhase);
-      await anticipationPhase.run({} as AnticipationPhaseConfig);
+      await anticipationPhase.run(this._anticipationConfigFor(reelIndex, speed));
       if (generation !== this._spinGeneration) return;
+      didAnticipate = true;
     } else {
       this._events.emit('spin:stopping', reelIndex);
     }
@@ -1116,7 +1244,13 @@ export class SpinController implements Disposable {
     } else {
       const stopPhase = this._phaseFactory.create<any>('stop', reel, speed);
       this._activePhases.set(reelIndex, stopPhase);
-      await stopPhase.run({ targetFrame, delay: stopDelay } satisfies StopPhaseConfig);
+      // After a tease, carry the slow anticipation speed into the stop so the
+      // reel crawls to its landing position instead of re-accelerating.
+      await stopPhase.run({
+        targetFrame,
+        delay: stopDelay,
+        preserveSpeed: didAnticipate,
+      } satisfies StopPhaseConfig);
       if (generation !== this._spinGeneration) return;
     }
 
@@ -1167,6 +1301,84 @@ export class SpinController implements Disposable {
     const adjust = this._phaseFactory.create<any>('adjust', reel, speed);
     this._activePhases.set(reelIndex, adjust);
     await adjust.run({ pinOverlays } satisfies AdjustPhaseConfig);
+  }
+
+  /**
+   * Wait for a reel's anticipation-start offset before it begins slowing.
+   * Returns `false` if the spin generation changed during the wait (a slam or
+   * a fresh spin superseded this task) so the caller bails cleanly.
+   *
+   * Offsets are keyed by tease-order (position within `_anticipationReels`),
+   * not raw reel index, so teasing `[2,3,4]` spaces them `[0, S, 2S]`
+   * regardless of which physical reels they are.
+   */
+  private async _awaitAnticipationOffset(
+    reelIndex: number,
+    generation: number,
+  ): Promise<boolean> {
+    const order = this._anticipationReels.indexOf(reelIndex);
+    if (order <= 0) return true; // first tease reel starts immediately
+
+    const stagger = this._anticipationStagger;
+    if (stagger === 'sequential') {
+      const prevLanded = this._reelLandedPromises.get(this._anticipationReels[order - 1]);
+      if (prevLanded) {
+        await prevLanded;
+        if (generation !== this._spinGeneration) return false;
+      }
+      return true;
+    }
+
+    const offsetMs = Array.isArray(stagger) ? (stagger[order] ?? 0) : order * stagger;
+    if (offsetMs > 0) {
+      await new Promise<void>((r) => setTimeout(r, offsetMs));
+      if (generation !== this._spinGeneration) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Build the per-reel AnticipationPhase config from the active `slowdown`
+   * curve and `duration` override. Interpolates `from`→`to` (speed) and
+   * `holdFrom`→`holdTo` (duration) across tease-order so each successive reel
+   * decelerates deeper / holds longer. Base hold is the `duration` override
+   * when set, else the profile's `anticipationDelay`. Returns an empty config
+   * (phase defaults: 30% speed, `anticipationDelay` hold) when neither a
+   * slowdown nor a duration override is configured.
+   */
+  private _anticipationConfigFor(
+    reelIndex: number,
+    speed: SpeedProfile,
+  ): AnticipationPhaseConfig {
+    const slowdown = this._anticipationSlowdown;
+    const baseDuration = this._anticipationDuration;
+
+    // No slowdown curve: only the (optional) duration override matters. Passing
+    // it explicitly is what lets the tease run when the profile's
+    // anticipationDelay is 0 (Turbo / SuperTurbo).
+    if (!slowdown) {
+      return baseDuration != null ? { duration: baseDuration } : {};
+    }
+
+    const count = this._anticipationReels.length;
+    const order = this._anticipationReels.indexOf(reelIndex);
+    // Fraction along the tease sequence: 0 for the first reel, 1 for the last.
+    const f = count > 1 ? order / (count - 1) : 0;
+
+    const from = slowdown.from ?? 0.3;
+    const to = slowdown.to ?? from;
+    const holdFrom = slowdown.holdFrom ?? 1;
+    const holdTo = slowdown.holdTo ?? holdFrom;
+    const base = baseDuration ?? speed.anticipationDelay;
+
+    const config: AnticipationPhaseConfig = {
+      speedMultiplier: from + (to - from) * f,
+    };
+    const holdMult = holdFrom + (holdTo - holdFrom) * f;
+    // Set duration whenever an override is active OR the hold is scaled; leave
+    // it off only when the plain profile hold (holdMult 1, no override) applies.
+    if (baseDuration != null || holdMult !== 1) config.duration = base * holdMult;
+    return config;
   }
 
   private _stopDelayFor(reelIndex: number, speed: SpeedProfile): number {
@@ -1359,6 +1571,22 @@ export class SpinController implements Disposable {
   private _markLanded(reelIndex: number): void {
     if (this._landedReels.has(reelIndex)) return;
     this._landedReels.add(reelIndex);
+
+    // Unblock the next reel in a 'sequential' anticipation chain (no-op for
+    // other stagger modes, which register no resolvers).
+    const landedResolve = this._reelLandedResolvers.get(reelIndex);
+    if (landedResolve) {
+      this._reelLandedResolvers.delete(reelIndex);
+      landedResolve();
+    }
+
+    // Tease-end signal, fired only for reels that actually teased this spin, so
+    // a listener can stop that reel's tension SFX / glow without tracking the
+    // anticipation set itself. Fired before `spin:reelLanded` so consumers see
+    // "tease over" then "reel landed" in a natural order.
+    if (this._teasingReels.delete(reelIndex)) {
+      this._events.emit('anticipation:reelEnd', { reelIndex });
+    }
 
     const reel = this._reels[reelIndex];
     const symbols = reel.getVisibleSymbols();

--- a/packages/pixi-reels/src/spin/anticipationRecipes.ts
+++ b/packages/pixi-reels/src/spin/anticipationRecipes.ts
@@ -1,0 +1,82 @@
+import type { ColumnTarget } from '../frame/ColumnTarget.js';
+
+export interface ScatterAnticipationOptions {
+  /** The trigger symbol id to scan for (e.g. `'SCAT'`). */
+  symbol: string;
+  /**
+   * How many of `symbol` must be showing before anticipation kicks in.
+   * Anticipation begins on the reel AFTER the one that lands the
+   * `trigger`-th symbol. Default `2` (the classic "2 scatters and the rest
+   * of the reels start teasing").
+   */
+  trigger?: number;
+  /**
+   * Which of the remaining reels should tease:
+   *   - `'all-remaining'` (default): every reel after the trigger reel teases,
+   *     whether or not it actually holds the symbol. Maximum tension.
+   *   - `'scatter-only'`: only reels that actually contain the symbol tease.
+   *     Use when a result can't complete the feature on some reels and you
+   *     don't want to fake tension on reels that don't matter (e.g. a grid
+   *     with only 3 scatters total shouldn't slow the empty reels between/after
+   *     them).
+   */
+  mode?: 'all-remaining' | 'scatter-only';
+}
+
+/**
+ * Decide which reels should show anticipation, straight from a result grid.
+ *
+ * Scans reels left→right counting `symbol` occurrences; once the running total
+ * reaches `trigger`, the reels AFTER that point become the anticipation set
+ * (per `mode`). Feed the return value straight into
+ * `reelSet.setAnticipation(...)`.
+ *
+ * Returns an empty array when the grid never reaches `trigger` (no tease).
+ *
+ * `grid` is the same `ColumnTarget[]` you pass to `reelSet.setResult(...)`, so
+ * you can hand the result straight through. Only visible cells are scanned.
+ * buffer symbols are off-screen and never trigger tension.
+ *
+ * @example
+ * // Result has SCAT on reels 0 and 1 → tease reels [2,3,4].
+ * const grid = [{ visible: ['A','SCAT','B'] }, { visible: ['SCAT','A','B'] }, ...];
+ * const reels = anticipationForScatters(grid, { symbol: 'SCAT', trigger: 2 });
+ * reelSet.setResult(grid);
+ * reelSet.setAnticipation(reels, { stagger: 'sequential', slowdown: { from: 0.4, to: 0.1 } });
+ *
+ * @example
+ * // Only 3 scatters total (reels 0,1,3): 'scatter-only' teases just reel [3],
+ * // leaving reels 2 and 4 to stop normally.
+ * const reels = anticipationForScatters(grid, { symbol: 'SCAT', mode: 'scatter-only' });
+ */
+export function anticipationForScatters(
+  grid: ColumnTarget[],
+  opts: ScatterAnticipationOptions,
+): number[] {
+  const trigger = opts.trigger ?? 2;
+  const mode = opts.mode ?? 'all-remaining';
+
+  // Count the trigger symbol per reel. Only visible cells are scanned; buffer
+  // symbols are off-screen and must not trigger tension.
+  const perReelCount = grid.map(
+    (col) => col.visible.filter((id) => id === opts.symbol).length,
+  );
+
+  // Find the reel at which the running total first reaches `trigger`.
+  let running = 0;
+  let triggerReel = -1;
+  for (let i = 0; i < perReelCount.length; i++) {
+    running += perReelCount[i];
+    if (running >= trigger) {
+      triggerReel = i;
+      break;
+    }
+  }
+  if (triggerReel === -1) return [];
+
+  const result: number[] = [];
+  for (let i = triggerReel + 1; i < grid.length; i++) {
+    if (mode === 'all-remaining' || perReelCount[i] > 0) result.push(i);
+  }
+  return result;
+}

--- a/packages/pixi-reels/src/spin/phases/AnticipationPhase.ts
+++ b/packages/pixi-reels/src/spin/phases/AnticipationPhase.ts
@@ -13,8 +13,9 @@ export interface AnticipationPhaseConfig {
  * Anticipation phase: slow-down tease before a reel stops.
  *
  * Decelerates to a fraction of spin speed, holds for a duration, then hands
- * off to StopPhase. StopPhase resets speed to full spin speed at the start
- * of its spin-out stage, so leaving speed low here is fine.
+ * off to StopPhase. The controller runs StopPhase with `preserveSpeed: true`
+ * after a tease, so this low speed carries into the spin-out and the reel
+ * crawls onto its landing frame instead of re-accelerating.
  */
 export class AnticipationPhase extends ReelPhase<AnticipationPhaseConfig> {
   readonly name = 'anticipation';

--- a/packages/pixi-reels/src/spin/phases/StopPhase.ts
+++ b/packages/pixi-reels/src/spin/phases/StopPhase.ts
@@ -7,6 +7,15 @@ export interface StopPhaseConfig {
   targetFrame: string[];
   /** Delay before this reel starts stopping (for staggered stop). */
   delay?: number;
+  /**
+   * Keep the reel's CURRENT speed into the spin-out instead of restoring full
+   * spin speed. Set by the controller when this stop follows an anticipation
+   * tease, so the reel crawls its target into place at the slow anticipation
+   * speed and stops exactly there. rather than snapping back to full speed and
+   * doing a fast spin-out. A small floor is applied so a `slowdown.to: 0`
+   * curve can't stall the reel.
+   */
+  preserveSpeed?: boolean;
 }
 
 /**
@@ -53,9 +62,17 @@ export class StopPhase extends ReelPhase<StopPhaseConfig> {
 
     reel.setStopFrame(this._config.targetFrame);
     reel.isStopping = true;
-    // Restore full spin speed. anticipation or other phases may have lowered
-    // it. The full momentum carries through the final frame placement.
-    reel.speed = speed.spinSpeed;
+    if (this._config.preserveSpeed) {
+      // Following an anticipation tease: keep the current (slow) speed so the
+      // reel crawls its target frame into place and stops exactly there,
+      // rather than re-accelerating to full speed. Floor it so a near-zero
+      // anticipation speed can't stall the spin-out forever.
+      reel.speed = Math.max(reel.speed, speed.spinSpeed * 0.08);
+    } else {
+      // Restore full spin speed. anticipation or other phases may have lowered
+      // it. The full momentum carries through the final frame placement.
+      reel.speed = speed.spinSpeed;
+    }
 
     this._stage = 'spinning';
   }

--- a/packages/pixi-reels/tests/unit/anticipationForScatters.test.ts
+++ b/packages/pixi-reels/tests/unit/anticipationForScatters.test.ts
@@ -1,0 +1,73 @@
+/**
+ * anticipationForScatters — pick the tease reels straight from a result grid.
+ */
+import { describe, it, expect } from 'vitest';
+import { anticipationForScatters } from '../../src/spin/anticipationRecipes.js';
+import type { ColumnTarget } from '../../src/frame/ColumnTarget.js';
+
+// 5x3 grid helper (ColumnTarget[], same shape setResult takes). `scatterReels`
+// lists which reels get one SCAT (row 1).
+function grid(scatterReels: number[]): ColumnTarget[] {
+  return Array.from({ length: 5 }, (_, r) => {
+    const visible = ['a', 'a', 'a'];
+    if (scatterReels.includes(r)) visible[1] = 'SCAT';
+    return { visible };
+  });
+}
+
+describe('anticipationForScatters', () => {
+  it('teases every reel after the trigger reel (all-remaining, default)', () => {
+    // SCAT on reels 0 and 1 → 2 scatters reached at reel 1 → tease [2,3,4].
+    expect(anticipationForScatters(grid([0, 1]), { symbol: 'SCAT' })).toEqual([2, 3, 4]);
+  });
+
+  it("'scatter-only' teases only remaining reels that hold the symbol", () => {
+    // SCAT on reels 0,1,3 → trigger at reel 1 → candidates [2,3,4] → only [3].
+    expect(
+      anticipationForScatters(grid([0, 1, 3]), { symbol: 'SCAT', mode: 'scatter-only' }),
+    ).toEqual([3]);
+  });
+
+  it('returns [] when the trigger count is never reached', () => {
+    // Only 1 scatter, trigger defaults to 2 → no tease.
+    expect(anticipationForScatters(grid([2]), { symbol: 'SCAT' })).toEqual([]);
+  });
+
+  it('honors a custom trigger threshold', () => {
+    // SCAT on reels 0,1,2; trigger 3 reached at reel 2 → tease [3,4].
+    expect(
+      anticipationForScatters(grid([0, 1, 2]), { symbol: 'SCAT', trigger: 3 }),
+    ).toEqual([3, 4]);
+  });
+
+  it('counts multiple symbols on the same reel', () => {
+    // Two SCAT on reel 0 alone reaches trigger 2 at reel 0 → tease [1,2,3,4].
+    const g = grid([]);
+    g[0] = { visible: ['SCAT', 'SCAT', 'a'] };
+    expect(anticipationForScatters(g, { symbol: 'SCAT' })).toEqual([1, 2, 3, 4]);
+  });
+
+  it('does not count buffer cells (ColumnTarget form)', () => {
+    // A SCAT parked in bufferBelow is off-screen and must not trigger tension.
+    const targets: ColumnTarget[] = [
+      { visible: ['a', 'SCAT', 'a'] },
+      { visible: ['a', 'a', 'a'], bufferBelow: ['SCAT'] }, // off-screen, ignored
+      { visible: ['a', 'a', 'a'] },
+      { visible: ['a', 'a', 'a'] },
+      { visible: ['a', 'a', 'a'] },
+    ];
+    // Only 1 VISIBLE scatter → trigger 2 not reached → [].
+    expect(anticipationForScatters(targets, { symbol: 'SCAT' })).toEqual([]);
+  });
+
+  it('accepts the ColumnTarget form and scans visible cells', () => {
+    const targets: ColumnTarget[] = [
+      { visible: ['a', 'SCAT', 'a'] },
+      { visible: ['SCAT', 'a', 'a'] },
+      { visible: ['a', 'a', 'a'] },
+      { visible: ['a', 'a', 'a'] },
+      { visible: ['a', 'a', 'a'] },
+    ];
+    expect(anticipationForScatters(targets, { symbol: 'SCAT' })).toEqual([2, 3, 4]);
+  });
+});

--- a/packages/pixi-reels/tests/unit/anticipationStagger.test.ts
+++ b/packages/pixi-reels/tests/unit/anticipationStagger.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Issue #181 — sequential / staggered anticipation.
+ *
+ * Before this change every anticipation reel began its slow-down at the same
+ * instant (only the final landing was staggered, by the tiny `stopDelay`), so
+ * the teases overlapped almost entirely. These tests pin the START of each
+ * reel's tease.
+ *
+ * Mechanism notes that make these assertions robust:
+ *   - `spin:stopping` fires the moment a reel BEGINS slowing (after its
+ *     stagger offset), so it is the timestamp of the tease start.
+ *   - With `stagger: 0` the first-and-every anticipation reel takes the
+ *     synchronous path (no `setTimeout`), so all their `spin:stopping` events
+ *     fire in the same microtask — sub-millisecond apart.
+ *   - With a numeric stagger the reel at tease-order `k>0` waits
+ *     `k * stagger` ms via a real `setTimeout`, producing measurable gaps.
+ *   - GSAP self-ticks in node, so the anticipation + stop phases complete on
+ *     their own and the spin promise resolves without a manual driver. We
+ *     still pump the FakeTicker so reel motion / `_onTick` run realistically.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestReelSet, captureEvents } from '../../src/testing/index.js';
+import type { SpeedProfile } from '../../src/config/types.js';
+import type { ColumnTarget } from '../../src/frame/ColumnTarget.js';
+
+// Fast profile so a full anticipation spin completes in well under a second.
+// spinDelay 0 = all reels start together; minimumSpinTime 0 = SpinPhase can
+// resolve as soon as setResult arrives.
+const FAST: SpeedProfile = {
+  name: 'fast',
+  spinDelay: 0,
+  spinSpeed: 30,
+  stopDelay: 0,
+  anticipationDelay: 40,
+  bounceDistance: 0,
+  bounceDuration: 20,
+  accelerationEase: 'power1.in',
+  decelerationEase: 'power1.out',
+  accelerationDuration: 20,
+  minimumSpinTime: 0,
+};
+
+// Same but with a real per-reel stop stagger, for the setStopDelays(null) test.
+const FAST_STAGGERED_STOP: SpeedProfile = { ...FAST, name: 'fastStop', stopDelay: 30 };
+
+// Longer anticipation hold so we can sample reel speed mid-tease deterministically.
+const SLOW_ANTIC: SpeedProfile = { ...FAST, name: 'slowAntic', anticipationDelay: 220 };
+
+// Turbo-like: profile has NO anticipation window. tease only plays via a
+// per-call `duration` override.
+const TURBO0: SpeedProfile = { ...FAST, name: 'turbo0', anticipationDelay: 0 };
+
+const GRID: ColumnTarget[] = Array.from({ length: 5 }, () => ({
+  visible: ['a', 'b', 'c'],
+}));
+
+function makeHarness(profile: SpeedProfile) {
+  const h = createTestReelSet({ reels: 5, visibleRows: 3, symbolIds: ['a', 'b', 'c'] });
+  h.reelSet.speed.addProfile(profile.name, profile);
+  h.reelSet.setSpeed(profile.name);
+  // Pump the reel-set ticker in real time so reel.update / _onTick run.
+  const pump = setInterval(() => h.ticker.tick(16), 16);
+  return {
+    ...h,
+    stopPump() {
+      clearInterval(pump);
+    },
+  };
+}
+
+describe('anticipation stagger (issue #181)', () => {
+  let harness: ReturnType<typeof makeHarness> | null = null;
+
+  beforeEach(() => {
+    harness = null;
+  });
+
+  afterEach(() => {
+    if (harness) {
+      harness.stopPump();
+      harness.destroy();
+      harness = null;
+    }
+  });
+
+  it('numeric stagger starts each tease in order with measurable gaps', async () => {
+    const h = (harness = makeHarness(FAST));
+    const teaseAt = new Map<number, number>();
+    h.reelSet.events.on('spin:stopping', (i) => {
+      if (!teaseAt.has(i)) teaseAt.set(i, performance.now());
+    });
+
+    const p = h.reelSet.spin();
+    h.reelSet.setResult(GRID);
+    h.reelSet.setAnticipation([2, 3, 4], 60);
+    await p;
+
+    const t2 = teaseAt.get(2)!;
+    const t3 = teaseAt.get(3)!;
+    const t4 = teaseAt.get(4)!;
+    expect(t2).toBeDefined();
+    expect(t3).toBeDefined();
+    expect(t4).toBeDefined();
+    // Strict tease order across the anticipation set.
+    expect(t2).toBeLessThan(t3);
+    expect(t3).toBeLessThan(t4);
+    // Each subsequent tease starts meaningfully later (stagger = 60ms; assert a
+    // conservative floor to stay robust under CI timer jitter).
+    expect(t3 - t2).toBeGreaterThan(30);
+    expect(t4 - t3).toBeGreaterThan(30);
+  });
+
+  it('stagger 0 (default) starts all teases together', async () => {
+    const h = (harness = makeHarness(FAST));
+    const teaseAt = new Map<number, number>();
+    h.reelSet.events.on('spin:stopping', (i) => {
+      if (!teaseAt.has(i)) teaseAt.set(i, performance.now());
+    });
+
+    const p = h.reelSet.spin();
+    h.reelSet.setResult(GRID);
+    h.reelSet.setAnticipation([2, 3, 4]); // stagger defaults to 0
+    await p;
+
+    const stamps = [2, 3, 4].map((i) => teaseAt.get(i)!);
+    const spread = Math.max(...stamps) - Math.min(...stamps);
+    // No setTimeout on the stagger-0 path → all fire in the same microtask.
+    expect(spread).toBeLessThan(10);
+  });
+
+  it("'sequential' holds each tease until the previous reel has landed", async () => {
+    const h = (harness = makeHarness(FAST));
+    const log = captureEvents(h.reelSet, ['spin:stopping', 'spin:reelLanded']);
+
+    const p = h.reelSet.spin();
+    h.reelSet.setResult(GRID);
+    h.reelSet.setAnticipation([2, 3, 4], 'sequential');
+    await p;
+
+    // Index in the ordered event log of "reel i started teasing" and
+    // "reel i landed".
+    const teaseIdx = (i: number) =>
+      log.findIndex((e) => e.event === 'spin:stopping' && e.args[0] === i);
+    const landedIdx = (i: number) =>
+      log.findIndex((e) => e.event === 'spin:reelLanded' && e.args[0] === i);
+
+    // The core sequential guarantee: reel 3 does not begin its tease until
+    // reel 2 has landed; reel 4 not until reel 3 has landed.
+    expect(teaseIdx(3)).toBeGreaterThan(landedIdx(2));
+    expect(teaseIdx(4)).toBeGreaterThan(landedIdx(3));
+  });
+
+  it('stagger resets to 0 on the next spin (no carryover)', async () => {
+    const h = (harness = makeHarness(FAST));
+
+    // Spin 1: sequential.
+    let p = h.reelSet.spin();
+    h.reelSet.setResult(GRID);
+    h.reelSet.setAnticipation([2, 3, 4], 'sequential');
+    await p;
+
+    // Spin 2: anticipation set again but WITHOUT a stagger arg → must be parallel.
+    const teaseAt = new Map<number, number>();
+    h.reelSet.events.on('spin:stopping', (i) => {
+      if (!teaseAt.has(i)) teaseAt.set(i, performance.now());
+    });
+    p = h.reelSet.spin();
+    h.reelSet.setResult(GRID);
+    h.reelSet.setAnticipation([2, 3, 4]);
+    await p;
+
+    const stamps = [2, 3, 4].map((i) => teaseAt.get(i)!);
+    expect(Math.max(...stamps) - Math.min(...stamps)).toBeLessThan(10);
+  });
+
+  it('slowdown makes each successive reel decelerate to a lower speed', async () => {
+    const h = (harness = makeHarness(SLOW_ANTIC));
+
+    // Sample each tease reel's speed mid-hold: 120ms after it starts slowing
+    // (deceleration finishes at ~35% of the 220ms hold = ~77ms, so by 120ms
+    // the reel sits at its target anticipation speed).
+    const holdSpeed = new Map<number, number>();
+    h.reelSet.events.on('spin:stopping', (i) => {
+      if (![2, 3, 4].includes(i)) return;
+      setTimeout(() => {
+        holdSpeed.set(i, h.reelSet.reels[i].speed);
+      }, 120);
+    });
+
+    const p = h.reelSet.spin();
+    h.reelSet.setResult(GRID);
+    // Parallel start so all three tease at once; from 0.6 -> 0.1 across [2,3,4].
+    h.reelSet.setAnticipation([2, 3, 4], { stagger: 0, slowdown: { from: 0.6, to: 0.1 } });
+    await p;
+
+    const s2 = holdSpeed.get(2)!;
+    const s3 = holdSpeed.get(3)!;
+    const s4 = holdSpeed.get(4)!;
+    expect(s2).toBeGreaterThan(0);
+    // Progressive slow-down: reel 2 fastest, reel 4 slowest.
+    expect(s2).toBeGreaterThan(s3);
+    expect(s3).toBeGreaterThan(s4);
+    // reel 2 ~ 0.6*spinSpeed(30)=18, reel 4 ~ 0.1*30=3 → a clear spread.
+    expect(s2 - s4).toBeGreaterThan(6);
+  });
+
+  it('does not re-accelerate to full speed on the stop after a tease', async () => {
+    // Regression: previously StopPhase reset speed to full spinSpeed for its
+    // spin-out, so a teased reel slowed down and then did a fast re-spin into
+    // place. It must instead carry the slow anticipation speed into the stop.
+    const h = (harness = makeHarness(SLOW_ANTIC)); // spinSpeed 30, anticipationDelay 220
+    const reel = h.reelSet.reels[3];
+
+    // Only start watching once the tease has begun (spin:stopping), so the
+    // start-up ramp (0→30, which also passes through the slow band) doesn't
+    // count.
+    let teasing = false;
+    h.reelSet.events.on('spin:stopping', (i) => {
+      if (i === 3) teasing = true;
+    });
+
+    let slowed = false;
+    let maxAfterSlow = 0;
+    const sampler = setInterval(() => {
+      const s = reel.speed;
+      // Once the reel has decelerated into the tease hold...
+      if (teasing && s > 0 && s < 12) slowed = true;
+      // ...it must never speed back up toward full spin speed.
+      if (slowed && s > maxAfterSlow) maxAfterSlow = s;
+    }, 6);
+
+    const p = h.reelSet.spin();
+    h.reelSet.setResult(GRID);
+    h.reelSet.setAnticipation([3]); // default slowdown → ~0.3*30 = 9 px/frame
+    await p;
+    clearInterval(sampler);
+
+    expect(slowed).toBe(true);
+    // Slow crawl (~9) into landing, never a jump back to ~30. Generous ceiling
+    // to stay robust while still catching a reset to full speed.
+    expect(maxAfterSlow).toBeLessThan(18);
+  });
+
+  it('emits anticipation:reel (with order/total) and anticipation:reelEnd per tease reel', async () => {
+    const h = (harness = makeHarness(FAST));
+    const starts: Array<{ reelIndex: number; order: number; total: number }> = [];
+    const ends: number[] = [];
+    h.reelSet.events.on('anticipation:reel', (info) => starts.push(info));
+    h.reelSet.events.on('anticipation:reelEnd', (info) => ends.push(info.reelIndex));
+
+    const p = h.reelSet.spin();
+    h.reelSet.setResult(GRID);
+    h.reelSet.setAnticipation([2, 3, 4], 60);
+    await p;
+
+    // One start per tease reel, in tease order, with correct order/total.
+    expect(starts).toEqual([
+      { reelIndex: 2, order: 0, total: 3 },
+      { reelIndex: 3, order: 1, total: 3 },
+      { reelIndex: 4, order: 2, total: 3 },
+    ]);
+    // One end per tease reel (order of landing may vary, so compare as a set).
+    expect([...ends].sort()).toEqual([2, 3, 4]);
+    // Non-tease reels never fire the anticipation events.
+    expect(starts.some((s) => s.reelIndex === 0 || s.reelIndex === 1)).toBe(false);
+  });
+
+  it('does not fire anticipation events for reels that never tease', async () => {
+    const h = (harness = makeHarness(FAST));
+    const starts: number[] = [];
+    h.reelSet.events.on('anticipation:reel', (i) => starts.push(i.reelIndex));
+
+    const p = h.reelSet.spin();
+    h.reelSet.setResult(GRID);
+    // No setAnticipation call → no teases at all.
+    await p;
+
+    expect(starts).toEqual([]);
+  });
+
+  it('duration override makes the tease play when the profile has anticipationDelay 0 (turbo)', async () => {
+    const h = (harness = makeHarness(TURBO0));
+    const starts: number[] = [];
+    h.reelSet.events.on('anticipation:reel', (i) => starts.push(i.reelIndex));
+
+    const p = h.reelSet.spin();
+    h.reelSet.setResult(GRID);
+    // Without a duration override this would skip anticipation entirely.
+    h.reelSet.setAnticipation([2, 3, 4], { duration: 80, stagger: 40 });
+    await p;
+
+    expect([...starts].sort()).toEqual([2, 3, 4]);
+  });
+
+  it('turbo profile with NO duration override skips anticipation', async () => {
+    const h = (harness = makeHarness(TURBO0));
+    const starts: number[] = [];
+    h.reelSet.events.on('anticipation:reel', (i) => starts.push(i.reelIndex));
+
+    const p = h.reelSet.spin();
+    h.reelSet.setResult(GRID);
+    h.reelSet.setAnticipation([2, 3, 4], 40); // stagger only, no duration
+    await p;
+
+    expect(starts).toEqual([]); // anticipationDelay 0 + no override → no tease
+  });
+
+  it('setStopDelays(null) restores the default i*stopDelay stagger', async () => {
+    const h = (harness = makeHarness(FAST_STAGGERED_STOP));
+
+    // Measure the reel0→reel4 landing gap for one round. A fresh per-round map
+    // records the first landing timestamp of each reel.
+    const measureRound = async (): Promise<number> => {
+      const landAt = new Map<number, number>();
+      const onLanded = (i: number): void => {
+        if (!landAt.has(i)) landAt.set(i, performance.now());
+      };
+      h.reelSet.events.on('spin:reelLanded', onLanded);
+      const p = h.reelSet.spin();
+      h.reelSet.setResult(GRID);
+      await p;
+      h.reelSet.events.off('spin:reelLanded', onLanded);
+      return landAt.get(4)! - landAt.get(0)!;
+    };
+
+    // Round 1: custom override lands reel 4 ~300ms after reel 0.
+    h.reelSet.setStopDelays([0, 0, 0, 0, 300]);
+    const overrideGap = await measureRound();
+    expect(overrideGap).toBeGreaterThan(200);
+
+    // Round 2: clear the override → reverts to default i*30 = 120ms for reel 4,
+    // much tighter than the 300ms override (proves it did not stay sticky and
+    // did not zero-out either).
+    h.reelSet.setStopDelays(null);
+    const defaultGap = await measureRound();
+    expect(defaultGap).toBeLessThan(overrideGap - 100);
+  });
+});


### PR DESCRIPTION
Closes #181.

Turns the flat, parallel anticipation into a fully configurable tease. The reporter asked for a sequential/stagger mechanism and progressive slow-down; this delivers that and more.

## `setAnticipation(reels, stagger | { stagger, slowdown, duration })`

- **`stagger`** — `number` (constant step) | `number[]` (per-tease-order) | `'sequential'` (each reel waits until the previous **lands**). Spaces when each reel *begins* slowing, by tease-order — fixes the "all reels slow at once" complaint.
- **`slowdown`** `{ from, to, holdFrom, holdTo }` — progressive deceleration: each successive reel crawls slower and/or holds longer than the last.
- **`duration`** — overrides the profile's `anticipationDelay`, so the tease still plays in **Turbo / SuperTurbo** (whose profiles use `anticipationDelay: 0`).

## Also

- **Fix:** after a tease the reel keeps its slow speed into the stop and **crawls onto its landing frame**, instead of snapping back to full speed and doing a fast re-spin into position.
- **Events:** `anticipation:reel` (`{ reelIndex, order, total }`) / `anticipation:reelEnd` (`{ reelIndex }`) for per-reel tension SFX / pitch ramps — no more overloading `spin:stopping`.
- **`anticipationForScatters(grid, { symbol, trigger, mode })`** — derive the tease reels straight from a result grid (same `ColumnTarget[]` as `setResult`). `mode: 'all-remaining' | 'scatter-only'`.
- **`setStopDelays(null)` / `setDropOrder(null)`** — clear a per-reel stop-delay override (restore the default stagger).

## Docs

Five new `tension` recipes — **staggered**, **slowing**, **scatter**, **turbo**, **skip** — each with the Hold & Win anticipation glow driven off the new events.

## Testing

- **567 tests pass** (stagger ordering, sequential chaining, slowdown depth, no-re-accelerate-on-stop, events order/total, turbo `duration` override + turbo-without-override skips, `anticipationForScatters` modes).
- Typecheck + lint + library build green. Changeset: `minor`.
- Verified live in the docs site: all five recipes run; sequential chains reel→reel on landing; slowdown reaches 15→9.3→3.6 px/frame across reels; turbo tease fires despite SuperTurbo; mid-tease slam lands 2ms after the tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)