### PR TITLE
fix: reshape before the fall in cascade mode when shape is known at spin time

### DIFF
--- a/.changeset/cascade-reshape-before-fall.md
+++ b/.changeset/cascade-reshape-before-fall.md
@@ -1,0 +1,5 @@
+---
+"pixi-reels": patch
+---
+
+Fix: commit a MultiWays reshape BEFORE the fall in cascade (classic-tumble) mode when the target shape is known at spin time. `CascadeFallPhase` drops a reel's current visible rows, and the reshape used to run only after the fall (between SPIN and STOP, where standard mode's spin blur hides it), so in cascade mode a reel that changed height dropped its old, differently-sized board and then snapped to the new shape. a reel visibly changing height mid-tumble. Now, if `setShape()` is called BEFORE `spin({ mode: 'cascade' })`, the reshape commits before the fall so the reel falls at its target height. The legacy `spin()` then `setShape()` ordering is unchanged (the reshape still lands after SPIN). For a clean per-spin reshape in a classic tumble, call `setShape()` before `spin({ mode: 'cascade' })`.

--- a/packages/pixi-reels/src/spin/SpinController.ts
+++ b/packages/pixi-reels/src/spin/SpinController.ts
@@ -1138,6 +1138,24 @@ export class SpinController implements Disposable {
 
     const reel = this._reels[reelIndex];
     const isTumble = this._currentSpinMode === 'cascade';
+    const canAdjust = this._hooks.isMultiWaysSlot && this._phaseFactory.has('adjust');
+
+    // Cascade (classic-tumble) reshape ordering. In standard mode the reshape
+    // runs between SPIN and STOP (below), where the spin blur hides a reel
+    // changing height. Cascade mode has no such cover: `CascadeFallPhase` drops
+    // the reel's CURRENT visible rows, so if the reshape ran after the fall the
+    // reel would drop its OLD, differently-sized board and then snap to the new
+    // shape. a reel visibly changing height mid-tumble. When the target shape is
+    // already known at spin time (the game called `setShape()` BEFORE
+    // `spin({ mode: 'cascade' })`), commit the reshape HERE, before the fall, so
+    // the fall drops the reel at its target height. If the shape arrives later
+    // (legacy `spin()` then `setShape()`), `peekTargetShape()` is still null and
+    // this is skipped; the reshape falls back to the post-SPIN slot unchanged.
+    const reshapeBeforeFall = isTumble && canAdjust && this._hooks.peekTargetShape() !== null;
+    if (reshapeBeforeFall) {
+      await this._runAdjustForReel(reel, reelIndex, speed, generation);
+      if (generation !== this._spinGeneration) return;
+    }
 
     // START or FALL: chain via phase.run() promises (no busy-polling).
     if (isTumble) {
@@ -1181,8 +1199,9 @@ export class SpinController implements Disposable {
 
     // MultiWays: AdjustPhase commits the new shape and migrates pins between
     // SpinPhase and StopPhase. Inserted only when builder.multiways() was
-    // called. non-MultiWays slots skip this entirely.
-    if (this._hooks.isMultiWaysSlot && this._phaseFactory.has('adjust')) {
+    // called. non-MultiWays slots skip this entirely. Skipped when a cascade
+    // spin already committed the reshape before the fall (see above).
+    if (canAdjust && !reshapeBeforeFall) {
       await this._runAdjustForReel(reel, reelIndex, speed, generation);
       if (generation !== this._spinGeneration) return;
     }

--- a/packages/pixi-reels/tests/integration/cascadeReshapeBeforeFall.test.ts
+++ b/packages/pixi-reels/tests/integration/cascadeReshapeBeforeFall.test.ts
@@ -1,0 +1,113 @@
+/**
+ * MultiWays reshape ordering in CASCADE (classic-tumble) mode.
+ *
+ * `CascadeFallPhase` drops a reel's CURRENT visible rows. In standard mode the
+ * reshape runs between SPIN and STOP (spin blur hides it), but cascade mode has
+ * no such cover: if the reshape ran after the fall, a reel that changed height
+ * would drop its OLD, differently-sized board and then snap to the new shape.
+ *
+ * Fix: when the target shape is known at spin time (`setShape()` called BEFORE
+ * `spin({ mode: 'cascade' })`), the reshape commits BEFORE the fall, so the fall
+ * drops the reel at its target height. This test asserts the reel is already at
+ * its target `visibleRows` by `cascade:fall:start`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ReelSetBuilder } from '../../src/core/ReelSetBuilder.js';
+import { HeadlessSymbol } from '../../src/testing/HeadlessSymbol.js';
+import { FakeTicker } from '../../src/testing/FakeTicker.js';
+import { driveGsapWithTicker } from '../../src/utils/gsapTicker.js';
+import { getGsap } from '../../src/utils/gsapRef.js';
+import { SpeedPresets } from '../../src/config/SpeedPresets.js';
+import type { Ticker } from 'pixi.js';
+
+let stopGsap: (() => void) | null = null;
+let ticker: FakeTicker;
+
+beforeEach(() => {
+  ticker = new FakeTicker();
+  stopGsap = driveGsapWithTicker(ticker as unknown as Ticker);
+});
+afterEach(() => {
+  // These tests bail mid-fall and destroy the reel set, leaving in-flight phase
+  // timelines that reference now-destroyed views. Kill them BEFORE restoring
+  // gsap's own ticker, or a lazy tween init reads a null view's `.y`.
+  getGsap().globalTimeline.clear();
+  stopGsap?.();
+  stopGsap = null;
+  ticker.destroy();
+});
+
+function build() {
+  return new ReelSetBuilder()
+    .reels(5)
+    .multiways({ minRows: 2, maxRows: 5, reelPixelHeight: 500 })
+    .symbolSize(100, 100)
+    .symbols((r) => { for (const id of ['a', 'b', 'c']) r.register(id, HeadlessSymbol, {}); })
+    .weights({ a: 1, b: 1, c: 1 })
+    .speed('normal', { ...SpeedPresets.NORMAL, spinDelay: 0, accelerationDuration: 0 })
+    .tumble({
+      fall: { duration: 200, ease: 'power2.in', rowStagger: 0 },
+      dropIn: { duration: 200, ease: 'power2.in', rowStagger: 0, distance: 'auto' },
+    })
+    .ticker(ticker as unknown as Ticker)
+    .build();
+}
+
+describe('cascade reshape-before-fall (setShape before spin)', () => {
+  it('each reel is already at its target visibleRows by cascade:fall:start', async () => {
+    const reelSet = build();
+    try {
+      // MultiWays builds at maxRows (5). Commit a NEW, smaller jagged shape
+      // BEFORE the cascade spin so the reshape is known at spin time.
+      const target = [2, 3, 4, 3, 2];
+      expect(reelSet.reels.map((r) => r.visibleRows)).toEqual([5, 5, 5, 5, 5]);
+
+      const rowsAtFallStart: Record<number, number> = {};
+      reelSet.events.on('cascade:fall:start', (info: any) => {
+        rowsAtFallStart[info.reelIndex] = reelSet.reels[info.reelIndex].visibleRows;
+      });
+
+      reelSet.setShape(target);              // BEFORE spin — the fix's precondition
+      reelSet.spin({ mode: 'cascade' }).catch(() => {});
+      reelSet.setResult(target.map((rows) => ({ visible: Array.from({ length: rows }, () => 'a') })));
+
+      // Tick just far enough for every reel's fall to start.
+      for (let f = 0; f < 20 && Object.keys(rowsAtFallStart).length < 5; f++) {
+        ticker.tick(16);
+        await new Promise((r) => setTimeout(r, 0));
+      }
+
+      // The reshape committed before the fall: every reel fell at its target
+      // height, not the old maxRows shape.
+      expect(rowsAtFallStart).toEqual({ 0: 2, 1: 3, 2: 4, 3: 3, 4: 2 });
+    } finally {
+      reelSet.destroy();
+    }
+  });
+
+  it('legacy order (spin then setShape) still reshapes after the fall', async () => {
+    const reelSet = build();
+    try {
+      const target = [2, 3, 4, 3, 2];
+      const rowsAtFallStart: Record<number, number> = {};
+      reelSet.events.on('cascade:fall:start', (info: any) => {
+        rowsAtFallStart[info.reelIndex] = reelSet.reels[info.reelIndex].visibleRows;
+      });
+
+      // Shape arrives AFTER the spin — the fall runs on the old (maxRows) shape.
+      reelSet.spin({ mode: 'cascade' }).catch(() => {});
+      reelSet.setShape(target);
+      reelSet.setResult(target.map((rows) => ({ visible: Array.from({ length: rows }, () => 'a') })));
+
+      for (let f = 0; f < 20 && Object.keys(rowsAtFallStart).length < 5; f++) {
+        ticker.tick(16);
+        await new Promise((r) => setTimeout(r, 0));
+      }
+
+      // Unchanged legacy behavior: fall happened at the old shape.
+      expect(rowsAtFallStart).toEqual({ 0: 5, 1: 5, 2: 5, 3: 5, 4: 5 });
+    } finally {
+      reelSet.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`CascadeFallPhase` drops a reel's **current** visible rows. The MultiWays reshape (`AdjustPhase` / `_applyReshape`) ran only *after* the fall — fine in standard mode, where the spin blur hides a reel changing height, but in **cascade (classic-tumble) mode** there's no such cover. A reel that changed height dropped its **old, differently-sized board** and then snapped to the new shape: a reel visibly changing height mid-tumble.

Symptom in a downstream game: *"symbols appear when a reel starts falling and vanish when that reel updates"* — verified by frame capture (a reel whose target was 2 rows showed 4 stacked symbols mid-fall).

## Fix

In `SpinController._startReel`, when the target shape is already known at spin time (`setShape()` called **before** `spin({ mode: 'cascade' })`), commit the reshape **before** the fall so the reel falls at its target height. It's gated on `peekTargetShape()`, so:

- **Legacy order** `spin()` → `setShape()`: `peekTargetShape()` is still null when the fall starts, so the reshape falls back to the existing post-`SPIN` slot. unchanged.
- **Standard mode**: unchanged (reshape stays between `SPIN` and `STOP`).

For a clean per-spin reshape in a classic tumble, order it `setShape(shape)` → `spin({ mode: 'cascade' })` → `setResult(...)`.

## Tests

`tests/integration/cascadeReshapeBeforeFall.test.ts`:
- With `setShape()` before the cascade spin, every reel is already at its target `visibleRows` by `cascade:fall:start`.
- With the legacy `spin()` → `setShape()` order, the fall still runs at the old shape.

Full suite green (no regressions in pin-migration / multiways), typecheck + lint clean. Changeset: patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)