### PR TITLE
Symbol pools: control what may spawn on which reel and in which buffer end

### DIFF
--- a/.changeset/symbol-pools.md
+++ b/.changeset/symbol-pools.md
@@ -16,7 +16,16 @@ reelSet.randomSymbols.set({ weights: { WILD: 40 } }, { reel: 2 });
 reelSet.randomSymbols.set(null, { reel: 2 });
 ```
 
-Layers resolve base weights -> global spinning -> per-reel spinning -> global buffer -> per-reel buffer. Weights override per symbol id, exclusions accumulate, and a narrower layer can never re-admit what a wider one banned. A weight of `0` bans a symbol as surely as `exclude` does, in a pool and in `weights()` alike. Pools govern the RANDOM draw only. an explicit `setResult` / `initialFrame` target is the game speaking and always wins. `weights(scope?)` reports the effective table, so a game can assert its own configuration in a test.
+The two ends of the strip can be governed separately: `slots` takes `'bufferStart'` and `'bufferEnd'` as well as `'buffer'` (both) and `'spinning'` (everything). `bufferStart` is the side at the smaller main coordinate - above on a vertical set, left on a horizontal one - the same end `ColumnTarget.bufferStart` addresses, whichever way the reel travels.
+
+```ts
+// Nothing peeks in from above; the cell below the grid is left alone.
+reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'bufferStart' });
+// ...on one reel only.
+reelSet.randomSymbols.set({ exclude: ['COIN'] }, { reel: 2, slots: 'bufferEnd' });
+```
+
+Layers resolve base weights -> global spinning -> per-reel spinning -> global buffer -> per-reel buffer -> global side -> per-reel side. Weights override per symbol id, exclusions accumulate, and a narrower layer can never re-admit what a wider one banned. A weight of `0` bans a symbol as surely as `exclude` does, in a pool and in `weights()` alike. Pools govern the RANDOM draw only. an explicit `setResult` / `initialFrame` target is the game speaking and always wins. `weights(scope?)` reports the effective table, so a game can assert its own configuration in a test; ask for `'buffer'` to see what both sides inherit, or for a side to see exactly what it draws from.
 
 Two failure modes now fail loud instead of quietly doing nothing: naming an unregistered symbol id in a pool throws (with the registered ids listed), and a pool that leaves some reachable scope with nothing to draw throws at the call that caused it, naming the scope, rather than mid-spin on whichever reel wraps first. The rejected pool is not installed. `setExcludeSpinning` / `setExcludeBuffer` keep working as sugar over the global spinning / buffer pools.
 

--- a/.changeset/symbol-pools.md
+++ b/.changeset/symbol-pools.md
@@ -1,0 +1,23 @@
+---
+'pixi-reels': minor
+---
+
+Add: symbol pools. `builder.randomSymbols(pool, scope)` and the runtime `reelSet.randomSymbols` decide what the engine may draw for cells the game does not name. A pool is `{ weights?, exclude? }`; its scope is `{ reel?, slots?: 'spinning' | 'buffer' }`.
+
+Until now `weights()` was one table for the whole set, and the only levers past it. `setExcludeSpinning` / `setExcludeBuffer` on `RandomSymbolProvider` were unreachable from a built set (the provider is deliberately not exported, and `Reel` keeps its reference private), so "keep this symbol out of the buffer cells" meant writing a `FrameMiddleware`. Two things games actually ask for now have a call:
+
+```ts
+// A coin may blur past mid-spin, but must never park half-visible
+// above or below the grid.
+reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'buffer' });
+
+// Reel 2 runs hot on wilds for the feature, then back to the base table.
+reelSet.randomSymbols.set({ weights: { WILD: 40 } }, { reel: 2 });
+reelSet.randomSymbols.set(null, { reel: 2 });
+```
+
+Layers resolve base weights -> global spinning -> per-reel spinning -> global buffer -> per-reel buffer. Weights override per symbol id, exclusions accumulate, and a narrower layer can never re-admit what a wider one banned. A weight of `0` bans a symbol as surely as `exclude` does, in a pool and in `weights()` alike. Pools govern the RANDOM draw only. an explicit `setResult` / `initialFrame` target is the game speaking and always wins. `weights(scope?)` reports the effective table, so a game can assert its own configuration in a test.
+
+Two failure modes now fail loud instead of quietly doing nothing: naming an unregistered symbol id in a pool throws (with the registered ids listed), and a pool that leaves some reachable scope with nothing to draw throws at the call that caused it, naming the scope, rather than mid-spin on whichever reel wraps first. The rejected pool is not installed. `setExcludeSpinning` / `setExcludeBuffer` keep working as sugar over the global spinning / buffer pools.
+
+`Reel.placeStrip` now random-fills each empty slot from the pool that slot belongs to. it used to apply the buffer rules to visible cells too, which mattered the moment "buffer" stopped meaning "everything a skip places".

--- a/.changeset/unmask-never-lifts-buffer-cells.md
+++ b/.changeset/unmask-never-lifts-buffer-cells.md
@@ -1,0 +1,11 @@
+---
+'pixi-reels': patch
+---
+
+Fix: an `unmask: true` symbol in a BUFFER cell no longer renders above the mask, where it hung outside the grid in plain sight.
+
+`unmask` lifts a view out of the reel's masked container. That is an at-rest presentation for a cell the player is looking at, and `notifyLanded()` has always lifted visible cells only. But the lift decision itself was made from the symbol id alone, so any at-rest write to a buffer slot lifted it as well. and a buffer slot is parked outside the window precisely because the mask should hide it.
+
+The path that showed it in a real game was a skip. `StopPhase.onSkip` lands the full strip (buffers included) through `placeStrip`, so a skip taken once the bounce has started. i.e. after `notifyLanded()` put the reel back at rest. lifted every unmask symbol the target frame had in `bufferStart` / `bufferEnd`, and they stayed up there until the next spin pulled them back down. `Reel.reshape` growing a strip at rest did the same to its new tail cells.
+
+The lift now takes the slot into account, so a buffer cell never lifts. A second case needed the reverse: a symbol lifted while it was VISIBLE can still travel into a buffer slot without being replaced. a nudge rotates the array and only the wrapped symbol goes through `_replaceSymbol`, so an unmask symbol nudged out of the window kept its seat above the mask. Every settle now re-masks any lifted view that ended up outside the window.

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -8,7 +8,7 @@ Site: https://pixi-reels.schmooky.dev
 Repo: https://github.com/schmooky/pixi-reels
 Package: https://www.npmjs.com/package/pixi-reels
 
-Generated: 2026-08-06T11:07:41.615Z
+Generated: 2026-08-06T11:20:18.598Z
 
 ## Quick start
 
@@ -1684,7 +1684,7 @@ function applyPool() {
 // Everything lives in one composition root with room above the grid for the
 // banner, returned as `stage` so the runner scales and centres the whole
 // thing rather than clipping the parts that sit above the reels.
-const PAD_TOP = 76;
+const PAD_TOP = 94;
 const stage = new PIXI.Container();
 reelSet.y = PAD_TOP;
 stage.addChild(reelSet);
@@ -1715,10 +1715,19 @@ hint.text = 'the labels above and below each reel ARE its hidden cells';
 stage.addChild(hint);
 
 // One label per hidden cell, sitting where that cell sits: above the grid
-// for bufferStart, below it for bufferEnd.
+// for bufferStart, below it for bufferEnd. Each column also carries its own
+// index, because reel indices are 0-based: `{ reel: 1 }` is the SECOND reel.
 const startLabels = [];
 const endLabels = [];
 for (let i = 0; i < COLS; i++) {
+  const index = text(10, '500');
+  index.style.fill = 0x94a3b8;
+  index.anchor.set(0.5, 1);
+  index.x = i * (SIZE + GAP) + SIZE / 2;
+  index.y = PAD_TOP - 22;
+  index.text = `reel ${i}`;
+  stage.addChild(index);
+
   const top = text(11, '700');
   top.anchor.set(0.5, 1);
   top.x = i * (SIZE + GAP) + SIZE / 2;
@@ -1755,7 +1764,7 @@ function refreshLabels() {
     state === 'off'
       ? 'COIN parks in every hidden cell'
       : state === 'reel 1 only'
-        ? 'only the middle reel stays clean'
+        ? 'only reel 1 stays clean -- indices are 0-based, so that is the SECOND reel'
         : 'no COIN parks off-window on any reel';
   banner.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;
   meaning.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;
@@ -10569,6 +10578,17 @@ stage.addChild(title);
 
 for (let i = 0; i < COLS; i++) {
   const scoped = CAPTIONS[i] !== 'base table';
+  // The index goes on the demo, not just in the source: reel indices are
+  // 0-based, so `{ reel: 2 }` is the THIRD reel, not the second.
+  const index = new PIXI.Text({
+    text: `reel ${i}`,
+    style: { fontFamily: 'ui-monospace, monospace', fontSize: 10, fontWeight: '700', fill: 0x94a3b8 },
+  });
+  index.anchor.set(0.5, 0);
+  index.x = i * (SIZE + GAP) + SIZE / 2;
+  index.y = gridBottom + 8;
+  stage.addChild(index);
+
   const caption = new PIXI.Text({
     text: CAPTIONS[i],
     style: {
@@ -10579,8 +10599,8 @@ for (let i = 0; i < COLS; i++) {
     },
   });
   caption.anchor.set(0.5, 0);
-  caption.x = i * (SIZE + GAP) + SIZE / 2;
-  caption.y = gridBottom + 8;
+  caption.x = index.x;
+  caption.y = gridBottom + 22;
   stage.addChild(caption);
 }
 

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -8,7 +8,7 @@ Site: https://pixi-reels.schmooky.dev
 Repo: https://github.com/schmooky/pixi-reels
 Package: https://www.npmjs.com/package/pixi-reels
 
-Generated: 2026-08-04T15:37:51.130Z
+Generated: 2026-08-06T11:07:41.615Z
 
 ## Quick start
 
@@ -223,7 +223,7 @@ Steps:
 
 ### Symbols, layering & motion blur
 URL: https://pixi-reels.schmooky.dev/recipes/symbols/
-Tags: symbols, layering, static-spin, motion-blur, spine, horizontal, orientation
+Tags: symbols, pools, buffers, weights, layering, static-spin, motion-blur, spine, horizontal, orientation
 APIs: 
 Steps:
   - 
@@ -1607,6 +1607,186 @@ return {
 
     hud.text = `revealed · total ${total} · top ${PRIZE[top.id]} (${top.id})`;
     busy = false;
+  },
+};
+```
+
+### buffer-pool-exclude
+URL: https://pixi-reels.schmooky.dev/recipes/buffer-pool-exclude/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   PIXI, app
+//
+// Keep a symbol out of the buffer cells -- everywhere, or on one reel.
+//
+// The buffer cells are the hidden slots just outside the visible window.
+// They are filled at random like the rest of the strip, so a symbol you
+// only ever want the player to see INSIDE the grid can quietly park there:
+// half-visible under a short mask, lifted above it by `unmask: true`, or
+// scrolling into view on the next spin.
+//
+// `randomSymbols.set(pool, scope)` narrows that draw and nothing else. The
+// scope takes both fields at once, so `{ reel: 1, slots: 'buffer' }` is the
+// buffers of ONE reel. This demo cycles the three states on each spin and
+// prints what every hidden cell actually holds, so you can watch it work.
+
+const COIN = 'coin';
+const COIN_CARD = { id: COIN, color: 0xf6c945, label: 'COIN', textColor: 0x3b2f00 };
+const FILLER = ['7', '8', '9', '10'];
+
+const COLS = 3, ROWS = 3, SIZE = 90, GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(COLS)
+  .visibleCells(ROWS)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  // One hidden cell each side. Both are read out below.
+  .bufferSymbols(1)
+  .symbols((r) => {
+    for (const sym of [...CARD_DECK, COIN_CARD]) {
+      r.register(sym.id, CardSymbol, { color: sym.color, label: sym.label, textColor: sym.textColor });
+    }
+  })
+  // Coin-heavy on purpose: with no pool, nearly every random cell is a COIN,
+  // so the buffers fill with them and the readouts light up. Every registered
+  // id is listed - an id left out of `weights()` keeps the default of 10,
+  // which would quietly water this down.
+  .weights({ '7': 2, '8': 2, '9': 2, '10': 2, J: 2, Q: 2, K: 2, A: 2, [COIN]: 300 })
+  .speed('normal', { ...SpeedPresets.NORMAL, minimumSpinTime: 900 })
+  // Visible cells start as ordinary cards, so the only COINs on screen are
+  // the ones the pool is about.
+  .initialFrame(Array.from({ length: 3 }, () => ({ visible: ['7', '8', '9'] })))
+  .ticker(app.ticker)
+  .build();
+
+// --- The calls this recipe is about -----------------------------------
+// Three states, cycled one per spin. `null` removes a pool again, and each
+// scope is its own layer: clearing the per-reel one does not touch the
+// global one. Everything else about the set is unchanged either way -- COIN
+// keeps its weight of 80 on the spinning strip in all three states.
+const MODES = ['off', 'reel 1 only', 'every reel'];
+let mode = 0;
+
+function applyPool() {
+  const banned = { exclude: [COIN] };
+  // Reel 1's own buffer layer.
+  reelSet.randomSymbols.set(MODES[mode] === 'reel 1 only' ? banned : null, {
+    reel: 1,
+    slots: 'buffer',
+  });
+  // The set-wide buffer layer.
+  reelSet.randomSymbols.set(MODES[mode] === 'every reel' ? banned : null, { slots: 'buffer' });
+}
+
+// --- Readouts: what is actually in the hidden cells --------------------
+// Everything lives in one composition root with room above the grid for the
+// banner, returned as `stage` so the runner scales and centres the whole
+// thing rather than clipping the parts that sit above the reels.
+const PAD_TOP = 76;
+const stage = new PIXI.Container();
+reelSet.y = PAD_TOP;
+stage.addChild(reelSet);
+
+const text = (size, weight) =>
+  new PIXI.Text({
+    text: '',
+    style: {
+      fontFamily: 'ui-monospace, monospace',
+      fontSize: size,
+      fontWeight: weight,
+      fill: 0x475569,
+    },
+  });
+
+const banner = text(14, '700');
+banner.y = 0;
+stage.addChild(banner);
+
+const meaning = text(11, '600');
+meaning.y = 20;
+stage.addChild(meaning);
+
+const hint = text(10, '500');
+hint.style.fill = 0x94a3b8;
+hint.y = 40;
+hint.text = 'the labels above and below each reel ARE its hidden cells';
+stage.addChild(hint);
+
+// One label per hidden cell, sitting where that cell sits: above the grid
+// for bufferStart, below it for bufferEnd.
+const startLabels = [];
+const endLabels = [];
+for (let i = 0; i < COLS; i++) {
+  const top = text(11, '700');
+  top.anchor.set(0.5, 1);
+  top.x = i * (SIZE + GAP) + SIZE / 2;
+  top.y = PAD_TOP - 4;
+  stage.addChild(top);
+  startLabels.push(top);
+
+  const bottom = text(11, '700');
+  bottom.anchor.set(0.5, 0);
+  bottom.x = top.x;
+  bottom.y = PAD_TOP + ROWS * (SIZE + GAP) - GAP + 6;
+  stage.addChild(bottom);
+  endLabels.push(bottom);
+}
+
+function refreshLabels() {
+  for (let i = 0; i < COLS; i++) {
+    const strip = reelSet.reels[i].symbols;
+    const first = strip[0].symbolId;
+    const last = strip[strip.length - 1].symbolId;
+    startLabels[i].text = first;
+    startLabels[i].style.fill = first === COIN ? 0xd97706 : 0x16a34a;
+    endLabels[i].text = last;
+    endLabels[i].style.fill = last === COIN ? 0xd97706 : 0x16a34a;
+  }
+  const state = MODES[mode];
+  banner.text =
+    state === 'off'
+      ? 'no buffer pool'
+      : state === 'reel 1 only'
+        ? "set({ exclude: ['COIN'] }, { reel: 1, slots: 'buffer' })"
+        : "set({ exclude: ['COIN'] }, { slots: 'buffer' })";
+  meaning.text =
+    state === 'off'
+      ? 'COIN parks in every hidden cell'
+      : state === 'reel 1 only'
+        ? 'only the middle reel stays clean'
+        : 'no COIN parks off-window on any reel';
+  banner.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;
+  meaning.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;
+}
+
+const tick = () => refreshLabels();
+app.ticker.add(tick);
+applyPool();
+refreshLabels();
+
+return {
+  reelSet,
+  stage,
+  onSpin: async () => {
+    // Step to the next state so consecutive spins show all three.
+    mode = (mode + 1) % MODES.length;
+    applyPool();
+
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 200));
+    // Visible cells come from the server, as always. Only the cells nobody
+    // named -- here, the buffers -- are drawn from the pools.
+    reelSet.setResult(
+      Array.from({ length: COLS }, () => ({
+        visible: Array.from({ length: ROWS }, () => FILLER[Math.floor(Math.random() * FILLER.length)]),
+      })),
+    );
+    await p;
+  },
+  cleanup: () => {
+    app.ticker.remove(tick);
   },
 };
 ```
@@ -10320,6 +10500,108 @@ return {
 };
 ```
 
+### per-reel-symbol-pool
+URL: https://pixi-reels.schmooky.dev/recipes/per-reel-symbol-pool/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   WILD_CARD, PIXI, app
+//
+// Give one reel its own draw table.
+//
+// `builder.weights({...})` is one table for the whole set. A pool scoped to
+// `{ reel: n }` layers on top of it for that reel alone, so the strip
+// streaming past reel 2 can be nothing but wilds while its neighbours keep
+// the base mix -- no middleware, no second ReelSet.
+//
+// Watch the spin, not the landing: pools decide what SCROLLS past. What
+// stops on screen is whatever `setResult` says, exactly as before.
+
+const WILD = WILD_CARD.id;
+const LOW = ['7', '8'];
+const HIGH = ['J', 'Q', 'K', 'A'];
+
+const COLS = 5, ROWS = 3, SIZE = 84, GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(COLS)
+  .visibleCells(ROWS)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .symbols((r) => {
+    for (const sym of [...CARD_DECK, WILD_CARD]) {
+      r.register(sym.id, CardSymbol, { color: sym.color, label: sym.label, textColor: sym.textColor });
+    }
+  })
+  // The base table every reel starts from: low cards common, wild rare.
+  .weights({ '7': 20, '8': 20, '9': 14, '10': 14, J: 8, Q: 8, K: 6, A: 6, [WILD]: 2 })
+  // --- The three pools this recipe is about ---------------------------
+  // Build-time form. `reelSet.randomSymbols.set(pool, scope)` takes the same
+  // pool and scope at run time, which is where a feature-mode swap belongs.
+  //
+  // Reel 0: low cards only. Weight 0 bans a symbol as surely as `exclude`.
+  .randomSymbols({ weights: { '9': 0, '10': 0, J: 0, Q: 0, K: 0, A: 0, [WILD]: 0 } }, { reel: 0 })
+  // Reel 2: a wild reel while it spins.
+  .randomSymbols({ weights: { [WILD]: 400 } }, { reel: 2 })
+  // Reel 4: never teases a wild at all.
+  .randomSymbols({ exclude: [WILD] }, { reel: 4 })
+  .speed('normal', { ...SpeedPresets.NORMAL, minimumSpinTime: 1400, stopDelay: 220 })
+  .ticker(app.ticker)
+  .build();
+
+// --- Captions, so the rule under each reel is readable -----------------
+// One composition root with headroom for the title, returned as `stage`: the
+// runner scales and centres that instead of clipping what sits above y = 0.
+const CAPTIONS = ['low cards only', 'base table', 'WILD x400', 'base table', 'no WILD'];
+const PAD_TOP = 30;
+const gridBottom = PAD_TOP + ROWS * (SIZE + GAP) - GAP;
+
+const stage = new PIXI.Container();
+reelSet.y = PAD_TOP;
+stage.addChild(reelSet);
+
+const title = new PIXI.Text({
+  text: 'one weights() table, three per-reel pools on top',
+  style: { fontFamily: 'ui-monospace, monospace', fontSize: 13, fontWeight: '700', fill: 0x475569 },
+});
+title.y = 0;
+stage.addChild(title);
+
+for (let i = 0; i < COLS; i++) {
+  const scoped = CAPTIONS[i] !== 'base table';
+  const caption = new PIXI.Text({
+    text: CAPTIONS[i],
+    style: {
+      fontFamily: 'ui-monospace, monospace',
+      fontSize: 10,
+      fontWeight: scoped ? '700' : '500',
+      fill: scoped ? 0x16a34a : 0x94a3b8,
+    },
+  });
+  caption.anchor.set(0.5, 0);
+  caption.x = i * (SIZE + GAP) + SIZE / 2;
+  caption.y = gridBottom + 8;
+  stage.addChild(caption);
+}
+
+// The engine only reports what it will draw; assert your own config with it.
+// eslint-disable-next-line no-console -- the point of the line is to be read
+console.log('reel 2 draw table:', reelSet.randomSymbols.weights({ reel: 2 }));
+
+return {
+  reelSet,
+  stage,
+  nextResult: () =>
+    // A perfectly ordinary server result. The pools never touch it.
+    Array.from({ length: COLS }, () =>
+      Array.from({ length: ROWS }, () => {
+        const pool = Math.random() < 0.5 ? LOW : HIGH;
+        return pool[Math.floor(Math.random() * pool.length)];
+      }),
+    ),
+};
+```
+
 ### positional-multiplier-pin
 URL: https://pixi-reels.schmooky.dev/recipes/positional-multiplier-pin/
 ```ts
@@ -14118,6 +14400,151 @@ return {
       stagger: 240,
       slowdown: { from: 0.5, to: 0.12 },
     });
+    await p;
+  },
+};
+```
+
+### unmask-stays-in-the-grid
+URL: https://pixi-reels.schmooky.dev/recipes/unmask-stays-in-the-grid/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   ReelSymbol, PIXI, app
+//
+// `unmask: true` lifts VISIBLE cells only.
+//
+// An unmasked symbol is parented to the viewport-wide unmasked container on
+// land, so art wider than its cell can overflow the grid instead of being
+// clipped. That is a presentation for a cell the player is looking at: the
+// same id sitting in a BUFFER cell stays under the mask, because a buffer
+// cell is parked outside the window precisely so nobody sees it.
+//
+// Both cases are on screen at once below. Same symbol, one cell apart.
+
+const PLATE = 'plate';
+const FILLER = ['7', '8', '9', '10'];
+
+const COLS = 4, ROWS = 3, SIZE = 88, GAP = 6;
+const GRID_W = COLS * (SIZE + GAP) - GAP;
+const GRID_H = ROWS * (SIZE + GAP) - GAP;
+
+// A deliberately oversized symbol: 1.7x its cell in both directions, so a
+// lifted one overflows the grid edge and its neighbours, and a masked one
+// would be impossible to miss if it ever leaked.
+class PlateSymbol extends ReelSymbol {
+  onActivate() {
+    this._draw();
+  }
+  onDeactivate() {}
+  async playWin() {}
+  stopAnimation() {}
+  resize(width, height) {
+    this._w = width;
+    this._h = height;
+    this._draw();
+  }
+  _draw() {
+    if (!this._w) return;
+    this.view.removeChildren();
+    const w = this._w * 1.7;
+    const h = this._h * 1.7;
+    const x = (this._w - w) / 2;
+    const y = (this._h - h) / 2;
+    this.view.addChild(
+      new PIXI.Graphics()
+        .roundRect(x, y, w, h, 14)
+        .fill({ color: 0x7c3aed })
+        .stroke({ color: 0xfef08a, width: 4 }),
+    );
+    const label = new PIXI.Text({
+      text: 'JACKPOT',
+      style: { fontFamily: 'ui-monospace, monospace', fontSize: 15, fontWeight: '900', fill: 0xfef08a },
+    });
+    label.anchor.set(0.5);
+    label.x = this._w / 2;
+    label.y = this._h / 2;
+    this.view.addChild(label);
+  }
+}
+
+const spare = () => FILLER[Math.floor(Math.random() * FILLER.length)];
+const result = () => [
+  { visible: [spare(), spare(), spare()] },
+  // Visible cell 0 -> lifted above the mask on land.
+  { visible: [PLATE, spare(), spare()] },
+  { visible: [spare(), spare(), spare()] },
+  // Buffer cell above the window -> masked, invisible, and it must stay that
+  // way through a skip as well: hit SPIN then SKIP and nothing pops out.
+  { visible: [spare(), spare(), spare()], bufferStart: [PLATE] },
+];
+
+const reelSet = new ReelSetBuilder()
+  .reels(COLS)
+  .visibleCells(ROWS)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .bufferSymbols(1)
+  .symbols((r) => {
+    for (const sym of CARD_DECK) {
+      r.register(sym.id, CardSymbol, { color: sym.color, label: sym.label, textColor: sym.textColor });
+    }
+    r.register(PLATE, PlateSymbol, {});
+  })
+  // The plate is never drawn at random: it only ever lands where the result
+  // puts it. A pool is the tidy way to say so.
+  .randomSymbols({ exclude: [PLATE] })
+  .symbolData({ [PLATE]: { unmask: true, zIndex: 10 } })
+  .speed('normal', { ...SpeedPresets.NORMAL, minimumSpinTime: 900 })
+  .initialFrame(result())
+  .ticker(app.ticker)
+  .build();
+
+// --- Captions ----------------------------------------------------------
+// The lifted plate overflows ABOVE the grid, and the buffer cell it is
+// compared against sits above it too, so the composition needs real headroom.
+// One root with the reels pushed down, returned as `stage`.
+const PAD_TOP = 118;
+const stage = new PIXI.Container();
+reelSet.y = PAD_TOP;
+stage.addChild(reelSet);
+
+const caption = (text, color, x, y, anchorX) => {
+  const t = new PIXI.Text({
+    text,
+    style: { fontFamily: 'ui-monospace, monospace', fontSize: 11, fontWeight: '700', fill: color },
+  });
+  t.anchor.set(anchorX, 0);
+  t.x = x;
+  t.y = y;
+  stage.addChild(t);
+  return t;
+};
+
+caption('same symbol, one cell apart', 0x475569, 0, 0, 0);
+caption('reel 1, top VISIBLE cell: lifted, overflows the grid', 0x7c3aed, 0, 16, 0);
+caption('reel 3, BUFFER cell above: clipped by the mask at the grid edge', 0x94a3b8, 0, 32, 0);
+
+// Mark where the buffered plate actually is, since the point of it is what
+// you canNOT see. The dashes sit one cell above the grid, over reel 3.
+const ghost = new PIXI.Graphics();
+const gx = 3 * (SIZE + GAP);
+const ghostY = PAD_TOP - SIZE - GAP + SIZE / 2;
+for (let i = 0; i < 6; i++) {
+  ghost.rect(gx + i * (SIZE / 6) + 3, ghostY, SIZE / 12, 2);
+}
+ghost.fill({ color: 0x94a3b8 });
+const ghostLabel = caption('plate is parked here', 0x94a3b8, gx + SIZE / 2, ghostY + 6, 0.5);
+ghostLabel.style.fontSize = 9;
+stage.addChild(ghost);
+
+return {
+  reelSet,
+  stage,
+  onSpin: async () => {
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 200));
+    reelSet.setResult(result());
     await p;
   },
 };

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -8,7 +8,7 @@ Site: https://pixi-reels.schmooky.dev
 Repo: https://github.com/schmooky/pixi-reels
 Package: https://www.npmjs.com/package/pixi-reels
 
-Generated: 2026-08-06T11:20:18.598Z
+Generated: 2026-08-06T11:31:32.949Z
 
 ## Quick start
 
@@ -1628,8 +1628,11 @@ URL: https://pixi-reels.schmooky.dev/recipes/buffer-pool-exclude/
 //
 // `randomSymbols.set(pool, scope)` narrows that draw and nothing else. The
 // scope takes both fields at once, so `{ reel: 1, slots: 'buffer' }` is the
-// buffers of ONE reel. This demo cycles the three states on each spin and
-// prints what every hidden cell actually holds, so you can watch it work.
+// buffers of ONE reel, and the two ends have their own names:
+// `'bufferStart'` is the side at the smaller main coordinate (above here,
+// left on a horizontal set) and `'bufferEnd'` the other. This demo cycles
+// the four states one per spin and prints what every hidden cell actually
+// holds, so you can watch it work.
 
 const COIN = 'coin';
 const COIN_CARD = { id: COIN, color: 0xf6c945, label: 'COIN', textColor: 0x3b2f00 };
@@ -1666,18 +1669,20 @@ const reelSet = new ReelSetBuilder()
 // scope is its own layer: clearing the per-reel one does not touch the
 // global one. Everything else about the set is unchanged either way -- COIN
 // keeps its weight of 80 on the spinning strip in all three states.
-const MODES = ['off', 'reel 1 only', 'every reel'];
+const MODES = ['off', 'reel 1 only', 'above only', 'every reel'];
 let mode = 0;
 
 function applyPool() {
   const banned = { exclude: [COIN] };
-  // Reel 1's own buffer layer.
-  reelSet.randomSymbols.set(MODES[mode] === 'reel 1 only' ? banned : null, {
+  const state = MODES[mode];
+  // Three separate layers. setting one never disturbs the others, and
+  // passing `null` removes just that one.
+  reelSet.randomSymbols.set(state === 'reel 1 only' ? banned : null, {
     reel: 1,
     slots: 'buffer',
   });
-  // The set-wide buffer layer.
-  reelSet.randomSymbols.set(MODES[mode] === 'every reel' ? banned : null, { slots: 'buffer' });
+  reelSet.randomSymbols.set(state === 'above only' ? banned : null, { slots: 'bufferStart' });
+  reelSet.randomSymbols.set(state === 'every reel' ? banned : null, { slots: 'buffer' });
 }
 
 // --- Readouts: what is actually in the hidden cells --------------------
@@ -1754,18 +1759,20 @@ function refreshLabels() {
     endLabels[i].style.fill = last === COIN ? 0xd97706 : 0x16a34a;
   }
   const state = MODES[mode];
-  banner.text =
-    state === 'off'
-      ? 'no buffer pool'
-      : state === 'reel 1 only'
-        ? "set({ exclude: ['COIN'] }, { reel: 1, slots: 'buffer' })"
-        : "set({ exclude: ['COIN'] }, { slots: 'buffer' })";
-  meaning.text =
-    state === 'off'
-      ? 'COIN parks in every hidden cell'
-      : state === 'reel 1 only'
-        ? 'only reel 1 stays clean -- indices are 0-based, so that is the SECOND reel'
-        : 'no COIN parks off-window on any reel';
+  const CALLS = {
+    off: 'no buffer pool',
+    'reel 1 only': "set({ exclude: ['COIN'] }, { reel: 1, slots: 'buffer' })",
+    'above only': "set({ exclude: ['COIN'] }, { slots: 'bufferStart' })",
+    'every reel': "set({ exclude: ['COIN'] }, { slots: 'buffer' })",
+  };
+  const MEANINGS = {
+    off: 'COIN parks in every hidden cell',
+    'reel 1 only': 'only reel 1 stays clean -- indices are 0-based, so that is the SECOND reel',
+    'above only': 'the cells ABOVE the grid are clean, the ones below are untouched',
+    'every reel': 'no COIN parks off-window on any reel, either end',
+  };
+  banner.text = CALLS[state];
+  meaning.text = MEANINGS[state];
   banner.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;
   meaning.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;
 }

--- a/apps/site/src/content/docs/api-builder.mdx
+++ b/apps/site/src/content/docs/api-builder.mdx
@@ -27,7 +27,7 @@ Missing any of these throws at `.build()` with a human-readable list of problems
 | `.symbolGap(x, y)` | `{ x: 0, y: 0 }` |
 | `.bufferSymbols(n)` or `.bufferSymbols({ start, end })` | `1` (clamped to ≥ 1. the motion layer needs one buffer cell each side for wrap detection). `start` is the smaller main coordinate (above for vertical, left for horizontal), whichever way the reel travels. |
 | `.weights({ id: n })` | `10` for each registered symbol |
-| `.randomSymbols(pool, scope?)` | No pools. Narrows the RANDOM draw on top of `weights()`. `pool` is `{ weights?, exclude? }`; `scope` is `{ reel?, slots?: 'spinning' \| 'buffer' }` (default: every reel, every random cell). Buffer pools stack on the spinning ones. Same pools at run time: `reelSet.randomSymbols`. |
+| `.randomSymbols(pool, scope?)` | No pools. Narrows the RANDOM draw on top of `weights()`. `pool` is `{ weights?, exclude? }`; `scope` is `{ reel?, slots?: 'spinning' \| 'buffer' \| 'bufferStart' \| 'bufferEnd' }` (default: every reel, every random cell). Each layer stacks on the wider ones, so a side pool narrows what `'buffer'` already allows. Same pools at run time: `reelSet.randomSymbols`. |
 | `.symbolData({ id: { zIndex, unmask, size, weight } })` | Per-symbol metadata. Auto-routes `unmask`; `size: { reels, cells }` beyond 1x1 declares a big symbol. `reels` spans the cross axis, `cells` the main axis, in every orientation. |
 | `.reelExtents([n,...])` | Per-reel MAIN-axis extents for pyramid layouts (pixel height when vertical, width when horizontal). Derived from the cell count if unset. |
 | `.reelAnchor('start' \| 'center' \| 'end')` | `'center'`. alignment of short reels along the MAIN axis, inside the longest reel's extent. |

--- a/apps/site/src/content/docs/api-builder.mdx
+++ b/apps/site/src/content/docs/api-builder.mdx
@@ -27,6 +27,7 @@ Missing any of these throws at `.build()` with a human-readable list of problems
 | `.symbolGap(x, y)` | `{ x: 0, y: 0 }` |
 | `.bufferSymbols(n)` or `.bufferSymbols({ start, end })` | `1` (clamped to ≥ 1. the motion layer needs one buffer cell each side for wrap detection). `start` is the smaller main coordinate (above for vertical, left for horizontal), whichever way the reel travels. |
 | `.weights({ id: n })` | `10` for each registered symbol |
+| `.randomSymbols(pool, scope?)` | No pools. Narrows the RANDOM draw on top of `weights()`. `pool` is `{ weights?, exclude? }`; `scope` is `{ reel?, slots?: 'spinning' \| 'buffer' }` (default: every reel, every random cell). Buffer pools stack on the spinning ones. Same pools at run time: `reelSet.randomSymbols`. |
 | `.symbolData({ id: { zIndex, unmask, size, weight } })` | Per-symbol metadata. Auto-routes `unmask`; `size: { reels, cells }` beyond 1x1 declares a big symbol. `reels` spans the cross axis, `cells` the main axis, in every orientation. |
 | `.reelExtents([n,...])` | Per-reel MAIN-axis extents for pyramid layouts (pixel height when vertical, width when horizontal). Derived from the cell count if unset. |
 | `.reelAnchor('start' \| 'center' \| 'end')` | `'center'`. alignment of short reels along the MAIN axis, inside the longest reel's extent. |

--- a/apps/site/src/content/docs/api-reelset.mdx
+++ b/apps/site/src/content/docs/api-reelset.mdx
@@ -160,6 +160,27 @@ The library ships [`WinPresenter`](/docs/api-events/) as a higher-level events-d
 | `getBlockBounds` | `(reel, cell) => CellBounds` | Pixel rect covering a big symbol's whole `N×M` block. Returns the cell bounds for 1×1. |
 | `getSymbolFootprint` | `(reel, cell) => { anchor: { reel, cell }; size: { reels, cells } }` | Resolves OCCUPIED stubs to the anchor cell and reports the block size. |
 
+## Random symbol pools
+
+| Accessor | Description |
+|---|---|
+| `randomSymbols` | `RandomSymbolControl`. `{ set(pool, scope?), clear(), weights(scope?) }`. Narrows what the engine may draw for cells you did not name -- globally or per reel, for the whole strip or for the buffer cells alone. |
+
+```ts
+// Nothing collectible may sit half-visible above or below the grid.
+reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'buffer' });
+
+// Reel 2 runs hot on wilds for the feature, then back to normal.
+reelSet.randomSymbols.set({ weights: { WILD: 40 } }, { reel: 2 });
+reelSet.randomSymbols.set(null, { reel: 2 });
+```
+
+A pool governs the RANDOM draw only. an explicit `setResult` target always
+wins. Layers resolve base weights -> global spinning -> per-reel spinning ->
+global buffer -> per-reel buffer; weights override per id, exclusions
+accumulate, and a narrower layer can never re-admit what a wider one banned.
+Build-time equivalent: `builder.randomSymbols(pool, scope)`.
+
 ## Frame middleware (runtime-mutable)
 
 | Accessor | Description |

--- a/apps/site/src/content/docs/api-reelset.mdx
+++ b/apps/site/src/content/docs/api-reelset.mdx
@@ -164,11 +164,15 @@ The library ships [`WinPresenter`](/docs/api-events/) as a higher-level events-d
 
 | Accessor | Description |
 |---|---|
-| `randomSymbols` | `RandomSymbolControl`. `{ set(pool, scope?), clear(), weights(scope?) }`. Narrows what the engine may draw for cells you did not name -- globally or per reel, for the whole strip or for the buffer cells alone. |
+| `randomSymbols` | `RandomSymbolControl`. `{ set(pool, scope?), clear(), weights(scope?) }`. Narrows what the engine may draw for cells you did not name -- globally or per reel, for the whole strip, for both buffer ends, or for one end on its own. |
 
 ```ts
 // Nothing collectible may sit half-visible above or below the grid.
 reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'buffer' });
+
+// ...or just above it. `bufferStart` is the smaller main coordinate (above
+// when vertical, left when horizontal), the same end ColumnTarget names.
+reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'bufferStart' });
 
 // Reel 2 runs hot on wilds for the feature, then back to normal.
 reelSet.randomSymbols.set({ weights: { WILD: 40 } }, { reel: 2 });
@@ -177,8 +181,10 @@ reelSet.randomSymbols.set(null, { reel: 2 });
 
 A pool governs the RANDOM draw only. an explicit `setResult` target always
 wins. Layers resolve base weights -> global spinning -> per-reel spinning ->
-global buffer -> per-reel buffer; weights override per id, exclusions
-accumulate, and a narrower layer can never re-admit what a wider one banned.
+global buffer -> per-reel buffer -> global side -> per-reel side; weights
+override per id, exclusions accumulate, and a narrower layer can never
+re-admit what a wider one banned. `weights({ slots: 'buffer' })` reports what
+both sides inherit; ask for a side to see exactly what it draws from.
 Build-time equivalent: `builder.randomSymbols(pool, scope)`.
 
 ## Frame middleware (runtime-mutable)

--- a/apps/site/src/content/guides/buffer-indexing.mdx
+++ b/apps/site/src/content/guides/buffer-indexing.mdx
@@ -91,10 +91,19 @@ reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'buffer' });
 builder.randomSymbols({ exclude: ['COIN'] }, { slots: 'buffer' });
 ```
 
-Add `{ reel: n }` to the scope for one reel only. Weights work the same way as
-exclusions -- `{ weights: { COIN: 0 } }` bans it just as surely. Buffer pools
-stack on top of the spinning ones: what the strip may not show, the buffer may
-not show either. An explicit `bufferStart` / `bufferEnd` target is the game
+The two ends take their own pools, under the names this page already uses:
+
+```ts
+// Nothing peeks in from above; the cell below the grid is left alone.
+reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'bufferStart' });
+```
+
+Add `{ reel: n }` to any of them for one reel only -- `{ reel: 2, slots:
+'bufferEnd' }` is one end of one reel. Weights work the same way as
+exclusions: `{ weights: { COIN: 0 } }` bans it just as surely. Each layer
+stacks on the wider ones: what the strip may not show, no buffer cell may
+show either, and what a `'buffer'` pool bans is banned at both ends whatever
+the side pools say. An explicit `bufferStart` / `bufferEnd` target is the game
 speaking and always wins over a pool.
 
 ## Big symbols in buffers

--- a/apps/site/src/content/guides/buffer-indexing.mdx
+++ b/apps/site/src/content/guides/buffer-indexing.mdx
@@ -78,10 +78,24 @@ than dropping it silently, so you find out at the call, not three spins later.
 
 Anything you leave unset gets a random symbol.
 
-Buffer cells are filled in the same pass, from the same weight table -- there
-is no separate buffer weighting. To make off-window fill differ from what
-lands in view, register your own `FrameMiddleware` at a priority above
-`random-fill`.
+Buffer cells are filled in the same pass. By default they draw from the same
+weight table as the strip, but they do not have to. A pool with
+`slots: 'buffer'` narrows the off-window cells only:
+
+```ts
+// A coin may blur past mid-spin, but must never park half-visible
+// above or below the grid.
+reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'buffer' });
+
+// Same thing at build time, so even the initial strip obeys it.
+builder.randomSymbols({ exclude: ['COIN'] }, { slots: 'buffer' });
+```
+
+Add `{ reel: n }` to the scope for one reel only. Weights work the same way as
+exclusions -- `{ weights: { COIN: 0 } }` bans it just as surely. Buffer pools
+stack on top of the spinning ones: what the strip may not show, the buffer may
+not show either. An explicit `bufferStart` / `bufferEnd` target is the game
+speaking and always wins over a pool.
 
 ## Big symbols in buffers
 

--- a/apps/site/src/content/guides/symbols.mdx
+++ b/apps/site/src/content/guides/symbols.mdx
@@ -104,3 +104,16 @@ it spins, and the buffer cells.
 
 A grid from `setResult()` ignores weights completely. The server decides what
 lands. Weights decide what blurs past on the way there.
+
+`weights()` is one table for the whole set. To vary it -- ban a symbol from
+the buffer cells, or make one reel draw differently -- layer a pool on top:
+
+```ts
+builder.randomSymbols({ exclude: ['EMPTY'] });                     // every reel
+builder.randomSymbols({ exclude: ['COIN'] }, { slots: 'buffer' }); // buffers only
+builder.randomSymbols({ weights: { WILD: 40 } }, { reel: 2 });     // reel 2 only
+```
+
+The same pools are reachable at run time as `reelSet.randomSymbols.set(...)`,
+which is where a game-mode switch belongs. See
+[Buffer indexing](/guides/buffer-indexing/).

--- a/apps/site/src/content/recipes/symbols.mdx
+++ b/apps/site/src/content/recipes/symbols.mdx
@@ -90,7 +90,7 @@ Each spin steps the pool through off, `{ reel: 1, slots: 'buffer' }`, and `{ slo
 
 Watch the spin rather than the landing: reel 0 draws low cards only, reel 2 is a wild reel while it scrolls, reel 4 never teases a wild. Same `weights()` underneath all five.
 
-<RecipeDemo code="per-reel-symbol-pool" height={360} />
+<RecipeDemo code="per-reel-symbol-pool" height={400} />
 
 <a id="symbol-layering"></a>
 

--- a/apps/site/src/content/recipes/symbols.mdx
+++ b/apps/site/src/content/recipes/symbols.mdx
@@ -5,6 +5,9 @@ oneLiner: Symbol classes, three-tier layering (zIndex, unmask, promote), multi-s
 order: 70
 tags:
   - symbols
+  - pools
+  - buffers
+  - weights
   - layering
   - static-spin
   - motion-blur
@@ -71,6 +74,24 @@ A symbol morphs into a different (usually higher) one mid-round via setSymbolAt.
 
 <RecipeDemo code="symbol-transform" />
 
+<a id="symbol-pools"></a>
+
+## Which symbols may spawn where
+
+`weights()` is one table for the whole set. A pool layers on top of it for a scope: one reel, the buffer cells, or one reel's buffer cells. It governs the RANDOM draw only - an explicit `setResult` target always wins.
+
+**Keep a symbol out of the hidden cells (globally, or on one reel):**
+
+Each spin steps the pool through off, `{ reel: 1, slots: 'buffer' }`, and `{ slots: 'buffer' }`. The labels above and below the grid read the hidden cells live, so you can see COIN stop parking there - on the middle reel first, then everywhere.
+
+<RecipeDemo code="buffer-pool-exclude" height={440} />
+
+**Give one reel its own draw table:**
+
+Watch the spin rather than the landing: reel 0 draws low cards only, reel 2 is a wild reel while it scrolls, reel 4 never teases a wild. Same `weights()` underneath all five.
+
+<RecipeDemo code="per-reel-symbol-pool" height={360} />
+
 <a id="symbol-layering"></a>
 
 ## Symbol layering - zIndex, unmask, promote
@@ -84,6 +105,10 @@ Three tiers of "draw my symbol on top": within one reel, above every reel and th
 **Cross-reel and out-of-mask (unmask, at rest):**
 
 <RecipeDemo code="layering-unmask" height={420} />
+
+**Gotcha:** unmask lifts VISIBLE cells only. The same id in a buffer cell stays under the mask, so oversized art cannot hang outside the grid from a slot the player was never meant to see. The demo below lands both at once - and holds through a skip, which is the moment that used to leak.
+
+<RecipeDemo code="unmask-stays-in-the-grid" height={400} />
 
 **Per-instance (promote the landed view into spotlightContainer):**
 

--- a/apps/site/src/recipes/buffer-pool-exclude.recipe.ts
+++ b/apps/site/src/recipes/buffer-pool-exclude.recipe.ts
@@ -12,8 +12,11 @@
 //
 // `randomSymbols.set(pool, scope)` narrows that draw and nothing else. The
 // scope takes both fields at once, so `{ reel: 1, slots: 'buffer' }` is the
-// buffers of ONE reel. This demo cycles the three states on each spin and
-// prints what every hidden cell actually holds, so you can watch it work.
+// buffers of ONE reel, and the two ends have their own names:
+// `'bufferStart'` is the side at the smaller main coordinate (above here,
+// left on a horizontal set) and `'bufferEnd'` the other. This demo cycles
+// the four states one per spin and prints what every hidden cell actually
+// holds, so you can watch it work.
 
 const COIN = 'coin';
 const COIN_CARD = { id: COIN, color: 0xf6c945, label: 'COIN', textColor: 0x3b2f00 };
@@ -50,18 +53,20 @@ const reelSet = new ReelSetBuilder()
 // scope is its own layer: clearing the per-reel one does not touch the
 // global one. Everything else about the set is unchanged either way -- COIN
 // keeps its weight of 80 on the spinning strip in all three states.
-const MODES = ['off', 'reel 1 only', 'every reel'];
+const MODES = ['off', 'reel 1 only', 'above only', 'every reel'];
 let mode = 0;
 
 function applyPool() {
   const banned = { exclude: [COIN] };
-  // Reel 1's own buffer layer.
-  reelSet.randomSymbols.set(MODES[mode] === 'reel 1 only' ? banned : null, {
+  const state = MODES[mode];
+  // Three separate layers. setting one never disturbs the others, and
+  // passing `null` removes just that one.
+  reelSet.randomSymbols.set(state === 'reel 1 only' ? banned : null, {
     reel: 1,
     slots: 'buffer',
   });
-  // The set-wide buffer layer.
-  reelSet.randomSymbols.set(MODES[mode] === 'every reel' ? banned : null, { slots: 'buffer' });
+  reelSet.randomSymbols.set(state === 'above only' ? banned : null, { slots: 'bufferStart' });
+  reelSet.randomSymbols.set(state === 'every reel' ? banned : null, { slots: 'buffer' });
 }
 
 // --- Readouts: what is actually in the hidden cells --------------------
@@ -138,18 +143,20 @@ function refreshLabels() {
     endLabels[i].style.fill = last === COIN ? 0xd97706 : 0x16a34a;
   }
   const state = MODES[mode];
-  banner.text =
-    state === 'off'
-      ? 'no buffer pool'
-      : state === 'reel 1 only'
-        ? "set({ exclude: ['COIN'] }, { reel: 1, slots: 'buffer' })"
-        : "set({ exclude: ['COIN'] }, { slots: 'buffer' })";
-  meaning.text =
-    state === 'off'
-      ? 'COIN parks in every hidden cell'
-      : state === 'reel 1 only'
-        ? 'only reel 1 stays clean -- indices are 0-based, so that is the SECOND reel'
-        : 'no COIN parks off-window on any reel';
+  const CALLS = {
+    off: 'no buffer pool',
+    'reel 1 only': "set({ exclude: ['COIN'] }, { reel: 1, slots: 'buffer' })",
+    'above only': "set({ exclude: ['COIN'] }, { slots: 'bufferStart' })",
+    'every reel': "set({ exclude: ['COIN'] }, { slots: 'buffer' })",
+  };
+  const MEANINGS = {
+    off: 'COIN parks in every hidden cell',
+    'reel 1 only': 'only reel 1 stays clean -- indices are 0-based, so that is the SECOND reel',
+    'above only': 'the cells ABOVE the grid are clean, the ones below are untouched',
+    'every reel': 'no COIN parks off-window on any reel, either end',
+  };
+  banner.text = CALLS[state];
+  meaning.text = MEANINGS[state];
   banner.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;
   meaning.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;
 }

--- a/apps/site/src/recipes/buffer-pool-exclude.recipe.ts
+++ b/apps/site/src/recipes/buffer-pool-exclude.recipe.ts
@@ -1,0 +1,175 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   PIXI, app
+//
+// Keep a symbol out of the buffer cells -- everywhere, or on one reel.
+//
+// The buffer cells are the hidden slots just outside the visible window.
+// They are filled at random like the rest of the strip, so a symbol you
+// only ever want the player to see INSIDE the grid can quietly park there:
+// half-visible under a short mask, lifted above it by `unmask: true`, or
+// scrolling into view on the next spin.
+//
+// `randomSymbols.set(pool, scope)` narrows that draw and nothing else. The
+// scope takes both fields at once, so `{ reel: 1, slots: 'buffer' }` is the
+// buffers of ONE reel. This demo cycles the three states on each spin and
+// prints what every hidden cell actually holds, so you can watch it work.
+
+const COIN = 'coin';
+const COIN_CARD = { id: COIN, color: 0xf6c945, label: 'COIN', textColor: 0x3b2f00 };
+const FILLER = ['7', '8', '9', '10'];
+
+const COLS = 3, ROWS = 3, SIZE = 90, GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(COLS)
+  .visibleCells(ROWS)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  // One hidden cell each side. Both are read out below.
+  .bufferSymbols(1)
+  .symbols((r) => {
+    for (const sym of [...CARD_DECK, COIN_CARD]) {
+      r.register(sym.id, CardSymbol, { color: sym.color, label: sym.label, textColor: sym.textColor });
+    }
+  })
+  // Coin-heavy on purpose: with no pool, nearly every random cell is a COIN,
+  // so the buffers fill with them and the readouts light up. Every registered
+  // id is listed - an id left out of `weights()` keeps the default of 10,
+  // which would quietly water this down.
+  .weights({ '7': 2, '8': 2, '9': 2, '10': 2, J: 2, Q: 2, K: 2, A: 2, [COIN]: 300 })
+  .speed('normal', { ...SpeedPresets.NORMAL, minimumSpinTime: 900 })
+  // Visible cells start as ordinary cards, so the only COINs on screen are
+  // the ones the pool is about.
+  .initialFrame(Array.from({ length: 3 }, () => ({ visible: ['7', '8', '9'] })))
+  .ticker(app.ticker)
+  .build();
+
+// --- The calls this recipe is about -----------------------------------
+// Three states, cycled one per spin. `null` removes a pool again, and each
+// scope is its own layer: clearing the per-reel one does not touch the
+// global one. Everything else about the set is unchanged either way -- COIN
+// keeps its weight of 80 on the spinning strip in all three states.
+const MODES = ['off', 'reel 1 only', 'every reel'];
+let mode = 0;
+
+function applyPool() {
+  const banned = { exclude: [COIN] };
+  // Reel 1's own buffer layer.
+  reelSet.randomSymbols.set(MODES[mode] === 'reel 1 only' ? banned : null, {
+    reel: 1,
+    slots: 'buffer',
+  });
+  // The set-wide buffer layer.
+  reelSet.randomSymbols.set(MODES[mode] === 'every reel' ? banned : null, { slots: 'buffer' });
+}
+
+// --- Readouts: what is actually in the hidden cells --------------------
+// Everything lives in one composition root with room above the grid for the
+// banner, returned as `stage` so the runner scales and centres the whole
+// thing rather than clipping the parts that sit above the reels.
+const PAD_TOP = 76;
+const stage = new PIXI.Container();
+reelSet.y = PAD_TOP;
+stage.addChild(reelSet);
+
+const text = (size, weight) =>
+  new PIXI.Text({
+    text: '',
+    style: {
+      fontFamily: 'ui-monospace, monospace',
+      fontSize: size,
+      fontWeight: weight,
+      fill: 0x475569,
+    },
+  });
+
+const banner = text(14, '700');
+banner.y = 0;
+stage.addChild(banner);
+
+const meaning = text(11, '600');
+meaning.y = 20;
+stage.addChild(meaning);
+
+const hint = text(10, '500');
+hint.style.fill = 0x94a3b8;
+hint.y = 40;
+hint.text = 'the labels above and below each reel ARE its hidden cells';
+stage.addChild(hint);
+
+// One label per hidden cell, sitting where that cell sits: above the grid
+// for bufferStart, below it for bufferEnd.
+const startLabels = [];
+const endLabels = [];
+for (let i = 0; i < COLS; i++) {
+  const top = text(11, '700');
+  top.anchor.set(0.5, 1);
+  top.x = i * (SIZE + GAP) + SIZE / 2;
+  top.y = PAD_TOP - 4;
+  stage.addChild(top);
+  startLabels.push(top);
+
+  const bottom = text(11, '700');
+  bottom.anchor.set(0.5, 0);
+  bottom.x = top.x;
+  bottom.y = PAD_TOP + ROWS * (SIZE + GAP) - GAP + 6;
+  stage.addChild(bottom);
+  endLabels.push(bottom);
+}
+
+function refreshLabels() {
+  for (let i = 0; i < COLS; i++) {
+    const strip = reelSet.reels[i].symbols;
+    const first = strip[0].symbolId;
+    const last = strip[strip.length - 1].symbolId;
+    startLabels[i].text = first;
+    startLabels[i].style.fill = first === COIN ? 0xd97706 : 0x16a34a;
+    endLabels[i].text = last;
+    endLabels[i].style.fill = last === COIN ? 0xd97706 : 0x16a34a;
+  }
+  const state = MODES[mode];
+  banner.text =
+    state === 'off'
+      ? 'no buffer pool'
+      : state === 'reel 1 only'
+        ? "set({ exclude: ['COIN'] }, { reel: 1, slots: 'buffer' })"
+        : "set({ exclude: ['COIN'] }, { slots: 'buffer' })";
+  meaning.text =
+    state === 'off'
+      ? 'COIN parks in every hidden cell'
+      : state === 'reel 1 only'
+        ? 'only the middle reel stays clean'
+        : 'no COIN parks off-window on any reel';
+  banner.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;
+  meaning.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;
+}
+
+const tick = () => refreshLabels();
+app.ticker.add(tick);
+applyPool();
+refreshLabels();
+
+return {
+  reelSet,
+  stage,
+  onSpin: async () => {
+    // Step to the next state so consecutive spins show all three.
+    mode = (mode + 1) % MODES.length;
+    applyPool();
+
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 200));
+    // Visible cells come from the server, as always. Only the cells nobody
+    // named -- here, the buffers -- are drawn from the pools.
+    reelSet.setResult(
+      Array.from({ length: COLS }, () => ({
+        visible: Array.from({ length: ROWS }, () => FILLER[Math.floor(Math.random() * FILLER.length)]),
+      })),
+    );
+    await p;
+  },
+  cleanup: () => {
+    app.ticker.remove(tick);
+  },
+};

--- a/apps/site/src/recipes/buffer-pool-exclude.recipe.ts
+++ b/apps/site/src/recipes/buffer-pool-exclude.recipe.ts
@@ -68,7 +68,7 @@ function applyPool() {
 // Everything lives in one composition root with room above the grid for the
 // banner, returned as `stage` so the runner scales and centres the whole
 // thing rather than clipping the parts that sit above the reels.
-const PAD_TOP = 76;
+const PAD_TOP = 94;
 const stage = new PIXI.Container();
 reelSet.y = PAD_TOP;
 stage.addChild(reelSet);
@@ -99,10 +99,19 @@ hint.text = 'the labels above and below each reel ARE its hidden cells';
 stage.addChild(hint);
 
 // One label per hidden cell, sitting where that cell sits: above the grid
-// for bufferStart, below it for bufferEnd.
+// for bufferStart, below it for bufferEnd. Each column also carries its own
+// index, because reel indices are 0-based: `{ reel: 1 }` is the SECOND reel.
 const startLabels = [];
 const endLabels = [];
 for (let i = 0; i < COLS; i++) {
+  const index = text(10, '500');
+  index.style.fill = 0x94a3b8;
+  index.anchor.set(0.5, 1);
+  index.x = i * (SIZE + GAP) + SIZE / 2;
+  index.y = PAD_TOP - 22;
+  index.text = `reel ${i}`;
+  stage.addChild(index);
+
   const top = text(11, '700');
   top.anchor.set(0.5, 1);
   top.x = i * (SIZE + GAP) + SIZE / 2;
@@ -139,7 +148,7 @@ function refreshLabels() {
     state === 'off'
       ? 'COIN parks in every hidden cell'
       : state === 'reel 1 only'
-        ? 'only the middle reel stays clean'
+        ? 'only reel 1 stays clean -- indices are 0-based, so that is the SECOND reel'
         : 'no COIN parks off-window on any reel';
   banner.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;
   meaning.style.fill = state === 'off' ? 0xd97706 : 0x16a34a;

--- a/apps/site/src/recipes/per-reel-symbol-pool.recipe.ts
+++ b/apps/site/src/recipes/per-reel-symbol-pool.recipe.ts
@@ -64,6 +64,17 @@ stage.addChild(title);
 
 for (let i = 0; i < COLS; i++) {
   const scoped = CAPTIONS[i] !== 'base table';
+  // The index goes on the demo, not just in the source: reel indices are
+  // 0-based, so `{ reel: 2 }` is the THIRD reel, not the second.
+  const index = new PIXI.Text({
+    text: `reel ${i}`,
+    style: { fontFamily: 'ui-monospace, monospace', fontSize: 10, fontWeight: '700', fill: 0x94a3b8 },
+  });
+  index.anchor.set(0.5, 0);
+  index.x = i * (SIZE + GAP) + SIZE / 2;
+  index.y = gridBottom + 8;
+  stage.addChild(index);
+
   const caption = new PIXI.Text({
     text: CAPTIONS[i],
     style: {
@@ -74,8 +85,8 @@ for (let i = 0; i < COLS; i++) {
     },
   });
   caption.anchor.set(0.5, 0);
-  caption.x = i * (SIZE + GAP) + SIZE / 2;
-  caption.y = gridBottom + 8;
+  caption.x = index.x;
+  caption.y = gridBottom + 22;
   stage.addChild(caption);
 }
 

--- a/apps/site/src/recipes/per-reel-symbol-pool.recipe.ts
+++ b/apps/site/src/recipes/per-reel-symbol-pool.recipe.ts
@@ -1,0 +1,97 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   WILD_CARD, PIXI, app
+//
+// Give one reel its own draw table.
+//
+// `builder.weights({...})` is one table for the whole set. A pool scoped to
+// `{ reel: n }` layers on top of it for that reel alone, so the strip
+// streaming past reel 2 can be nothing but wilds while its neighbours keep
+// the base mix -- no middleware, no second ReelSet.
+//
+// Watch the spin, not the landing: pools decide what SCROLLS past. What
+// stops on screen is whatever `setResult` says, exactly as before.
+
+const WILD = WILD_CARD.id;
+const LOW = ['7', '8'];
+const HIGH = ['J', 'Q', 'K', 'A'];
+
+const COLS = 5, ROWS = 3, SIZE = 84, GAP = 4;
+
+const reelSet = new ReelSetBuilder()
+  .reels(COLS)
+  .visibleCells(ROWS)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .symbols((r) => {
+    for (const sym of [...CARD_DECK, WILD_CARD]) {
+      r.register(sym.id, CardSymbol, { color: sym.color, label: sym.label, textColor: sym.textColor });
+    }
+  })
+  // The base table every reel starts from: low cards common, wild rare.
+  .weights({ '7': 20, '8': 20, '9': 14, '10': 14, J: 8, Q: 8, K: 6, A: 6, [WILD]: 2 })
+  // --- The three pools this recipe is about ---------------------------
+  // Build-time form. `reelSet.randomSymbols.set(pool, scope)` takes the same
+  // pool and scope at run time, which is where a feature-mode swap belongs.
+  //
+  // Reel 0: low cards only. Weight 0 bans a symbol as surely as `exclude`.
+  .randomSymbols({ weights: { '9': 0, '10': 0, J: 0, Q: 0, K: 0, A: 0, [WILD]: 0 } }, { reel: 0 })
+  // Reel 2: a wild reel while it spins.
+  .randomSymbols({ weights: { [WILD]: 400 } }, { reel: 2 })
+  // Reel 4: never teases a wild at all.
+  .randomSymbols({ exclude: [WILD] }, { reel: 4 })
+  .speed('normal', { ...SpeedPresets.NORMAL, minimumSpinTime: 1400, stopDelay: 220 })
+  .ticker(app.ticker)
+  .build();
+
+// --- Captions, so the rule under each reel is readable -----------------
+// One composition root with headroom for the title, returned as `stage`: the
+// runner scales and centres that instead of clipping what sits above y = 0.
+const CAPTIONS = ['low cards only', 'base table', 'WILD x400', 'base table', 'no WILD'];
+const PAD_TOP = 30;
+const gridBottom = PAD_TOP + ROWS * (SIZE + GAP) - GAP;
+
+const stage = new PIXI.Container();
+reelSet.y = PAD_TOP;
+stage.addChild(reelSet);
+
+const title = new PIXI.Text({
+  text: 'one weights() table, three per-reel pools on top',
+  style: { fontFamily: 'ui-monospace, monospace', fontSize: 13, fontWeight: '700', fill: 0x475569 },
+});
+title.y = 0;
+stage.addChild(title);
+
+for (let i = 0; i < COLS; i++) {
+  const scoped = CAPTIONS[i] !== 'base table';
+  const caption = new PIXI.Text({
+    text: CAPTIONS[i],
+    style: {
+      fontFamily: 'ui-monospace, monospace',
+      fontSize: 10,
+      fontWeight: scoped ? '700' : '500',
+      fill: scoped ? 0x16a34a : 0x94a3b8,
+    },
+  });
+  caption.anchor.set(0.5, 0);
+  caption.x = i * (SIZE + GAP) + SIZE / 2;
+  caption.y = gridBottom + 8;
+  stage.addChild(caption);
+}
+
+// The engine only reports what it will draw; assert your own config with it.
+// eslint-disable-next-line no-console -- the point of the line is to be read
+console.log('reel 2 draw table:', reelSet.randomSymbols.weights({ reel: 2 }));
+
+return {
+  reelSet,
+  stage,
+  nextResult: () =>
+    // A perfectly ordinary server result. The pools never touch it.
+    Array.from({ length: COLS }, () =>
+      Array.from({ length: ROWS }, () => {
+        const pool = Math.random() < 0.5 ? LOW : HIGH;
+        return pool[Math.floor(Math.random() * pool.length)];
+      }),
+    ),
+};

--- a/apps/site/src/recipes/unmask-stays-in-the-grid.recipe.ts
+++ b/apps/site/src/recipes/unmask-stays-in-the-grid.recipe.ts
@@ -1,0 +1,140 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, CardSymbol, CARD_DECK,
+//                   ReelSymbol, PIXI, app
+//
+// `unmask: true` lifts VISIBLE cells only.
+//
+// An unmasked symbol is parented to the viewport-wide unmasked container on
+// land, so art wider than its cell can overflow the grid instead of being
+// clipped. That is a presentation for a cell the player is looking at: the
+// same id sitting in a BUFFER cell stays under the mask, because a buffer
+// cell is parked outside the window precisely so nobody sees it.
+//
+// Both cases are on screen at once below. Same symbol, one cell apart.
+
+const PLATE = 'plate';
+const FILLER = ['7', '8', '9', '10'];
+
+const COLS = 4, ROWS = 3, SIZE = 88, GAP = 6;
+const GRID_W = COLS * (SIZE + GAP) - GAP;
+const GRID_H = ROWS * (SIZE + GAP) - GAP;
+
+// A deliberately oversized symbol: 1.7x its cell in both directions, so a
+// lifted one overflows the grid edge and its neighbours, and a masked one
+// would be impossible to miss if it ever leaked.
+class PlateSymbol extends ReelSymbol {
+  onActivate() {
+    this._draw();
+  }
+  onDeactivate() {}
+  async playWin() {}
+  stopAnimation() {}
+  resize(width, height) {
+    this._w = width;
+    this._h = height;
+    this._draw();
+  }
+  _draw() {
+    if (!this._w) return;
+    this.view.removeChildren();
+    const w = this._w * 1.7;
+    const h = this._h * 1.7;
+    const x = (this._w - w) / 2;
+    const y = (this._h - h) / 2;
+    this.view.addChild(
+      new PIXI.Graphics()
+        .roundRect(x, y, w, h, 14)
+        .fill({ color: 0x7c3aed })
+        .stroke({ color: 0xfef08a, width: 4 }),
+    );
+    const label = new PIXI.Text({
+      text: 'JACKPOT',
+      style: { fontFamily: 'ui-monospace, monospace', fontSize: 15, fontWeight: '900', fill: 0xfef08a },
+    });
+    label.anchor.set(0.5);
+    label.x = this._w / 2;
+    label.y = this._h / 2;
+    this.view.addChild(label);
+  }
+}
+
+const spare = () => FILLER[Math.floor(Math.random() * FILLER.length)];
+const result = () => [
+  { visible: [spare(), spare(), spare()] },
+  // Visible cell 0 -> lifted above the mask on land.
+  { visible: [PLATE, spare(), spare()] },
+  { visible: [spare(), spare(), spare()] },
+  // Buffer cell above the window -> masked, invisible, and it must stay that
+  // way through a skip as well: hit SPIN then SKIP and nothing pops out.
+  { visible: [spare(), spare(), spare()], bufferStart: [PLATE] },
+];
+
+const reelSet = new ReelSetBuilder()
+  .reels(COLS)
+  .visibleCells(ROWS)
+  .symbolSize(SIZE, SIZE)
+  .symbolGap(GAP, GAP)
+  .bufferSymbols(1)
+  .symbols((r) => {
+    for (const sym of CARD_DECK) {
+      r.register(sym.id, CardSymbol, { color: sym.color, label: sym.label, textColor: sym.textColor });
+    }
+    r.register(PLATE, PlateSymbol, {});
+  })
+  // The plate is never drawn at random: it only ever lands where the result
+  // puts it. A pool is the tidy way to say so.
+  .randomSymbols({ exclude: [PLATE] })
+  .symbolData({ [PLATE]: { unmask: true, zIndex: 10 } })
+  .speed('normal', { ...SpeedPresets.NORMAL, minimumSpinTime: 900 })
+  .initialFrame(result())
+  .ticker(app.ticker)
+  .build();
+
+// --- Captions ----------------------------------------------------------
+// The lifted plate overflows ABOVE the grid, and the buffer cell it is
+// compared against sits above it too, so the composition needs real headroom.
+// One root with the reels pushed down, returned as `stage`.
+const PAD_TOP = 118;
+const stage = new PIXI.Container();
+reelSet.y = PAD_TOP;
+stage.addChild(reelSet);
+
+const caption = (text, color, x, y, anchorX) => {
+  const t = new PIXI.Text({
+    text,
+    style: { fontFamily: 'ui-monospace, monospace', fontSize: 11, fontWeight: '700', fill: color },
+  });
+  t.anchor.set(anchorX, 0);
+  t.x = x;
+  t.y = y;
+  stage.addChild(t);
+  return t;
+};
+
+caption('same symbol, one cell apart', 0x475569, 0, 0, 0);
+caption('reel 1, top VISIBLE cell: lifted, overflows the grid', 0x7c3aed, 0, 16, 0);
+caption('reel 3, BUFFER cell above: clipped by the mask at the grid edge', 0x94a3b8, 0, 32, 0);
+
+// Mark where the buffered plate actually is, since the point of it is what
+// you canNOT see. The dashes sit one cell above the grid, over reel 3.
+const ghost = new PIXI.Graphics();
+const gx = 3 * (SIZE + GAP);
+const ghostY = PAD_TOP - SIZE - GAP + SIZE / 2;
+for (let i = 0; i < 6; i++) {
+  ghost.rect(gx + i * (SIZE / 6) + 3, ghostY, SIZE / 12, 2);
+}
+ghost.fill({ color: 0x94a3b8 });
+const ghostLabel = caption('plate is parked here', 0x94a3b8, gx + SIZE / 2, ghostY + 6, 0.5);
+ghostLabel.style.fontSize = 9;
+stage.addChild(ghost);
+
+return {
+  reelSet,
+  stage,
+  onSpin: async () => {
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 200));
+    reelSet.setResult(result());
+    await p;
+  },
+};

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -9,7 +9,7 @@ import { VERTICAL_FORWARD } from './ReelAxis.js';
 import { StopSequencer } from './StopSequencer.js';
 import { EventEmitter } from '../events/EventEmitter.js';
 import type { ReelEvents } from '../events/ReelEvents.js';
-import type { RandomSymbolProvider } from '../frame/RandomSymbolProvider.js';
+import type { DrawSlot, RandomSymbolProvider } from '../frame/RandomSymbolProvider.js';
 import { columnTargetToStrip, type ColumnTarget } from '../frame/ColumnTarget.js';
 import type { ReelViewport } from './ReelViewport.js';
 import type { SpinningMode } from '../spin/modes/SpinningMode.js';
@@ -1134,7 +1134,8 @@ export class Reel implements Disposable {
         if (k <= wrapsToVisible) {
           queue.push(incoming[wrapsToVisible - k]);
         } else {
-          queue.push(this._randomProvider.next(true, this.reelIndex));
+          // These wraps enter at the buffer-start end, so that side's pools apply.
+          queue.push(this._randomProvider.next('bufferStart', this.reelIndex));
         }
       }
       this._nudgeQueue = queue;
@@ -1151,7 +1152,8 @@ export class Reel implements Disposable {
         if (k <= wrapsToVisible) {
           queue.push(incoming[bufferEnd + k - 1]);
         } else {
-          queue.push(this._randomProvider.next(true, this.reelIndex));
+          // Mirror of the branch above: these enter at the buffer-end side.
+          queue.push(this._randomProvider.next('bufferEnd', this.reelIndex));
         }
       }
       this._nudgeQueue = queue;
@@ -1315,11 +1317,10 @@ export class Reel implements Disposable {
   placeStrip(frame: ReadonlyArray<string | undefined>): void {
     const totalSlots = this.symbols.length;
     for (let i = 0; i < totalSlots; i++) {
-      // Buffer pools apply to the buffer slots only. a visible cell the
-      // frame left blank is a spinning-pool draw, same rule FrameBuilder
-      // uses when it random-fills a frame.
-      const targetId =
-        frame[i] ?? this._randomProvider.next(this._isBufferSlot(i), this.reelIndex);
+      // Buffer pools apply to the buffer slots only, and each side has its
+      // own: a visible cell the frame left blank is a spinning-pool draw,
+      // same rule FrameBuilder uses when it random-fills a frame.
+      const targetId = frame[i] ?? this._randomProvider.next(this._slotKind(i), this.reelIndex);
       this._replaceSymbol(i, targetId);
     }
     this.motion.snapToGrid();
@@ -1356,7 +1357,8 @@ export class Reel implements Disposable {
     // Grow: append additional symbols at the bottom buffer. New symbols are
     // parented based on `unmask` flag. same rule as `_replaceSymbol`.
     while (this.symbols.length < newTotal) {
-      const id = this._randomProvider.next(true, this.reelIndex);
+      // The appended slot is always the new tail, i.e. the buffer-end side.
+      const id = this._randomProvider.next('bufferEnd', this.reelIndex);
       const sym = this._symbolFactory.acquire(id);
       const slot = this.symbols.length;
       sym.resize(newSize.width, newSize.height);
@@ -1491,6 +1493,16 @@ export class Reel implements Disposable {
   /** Whether strip slot `index` sits outside the visible window. */
   private _isBufferSlot(index: number): boolean {
     return index < this._bufferStart || index >= this._bufferStart + this._visibleCells;
+  }
+
+  /**
+   * Which pool slot `index` draws from: the visible window is `'spinning'`,
+   * and a buffer cell names its side so that side's pools apply.
+   */
+  private _slotKind(index: number): DrawSlot {
+    if (index < this._bufferStart) return 'bufferStart';
+    if (index >= this._bufferStart + this._visibleCells) return 'bufferEnd';
+    return 'spinning';
   }
 
   /**
@@ -1656,7 +1668,7 @@ export class Reel implements Disposable {
     } else if (this._isStopping && this.stopSequencer.hasRemaining) {
       newSymbolId = this.stopSequencer.next();
     } else {
-      newSymbolId = this._randomProvider.next(false, this.reelIndex);
+      newSymbolId = this._randomProvider.next('spinning', this.reelIndex);
     }
 
     this._replaceSymbol(this.symbols.indexOf(symbol), newSymbolId);

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -802,10 +802,33 @@ export class Reel implements Disposable {
    * @internal SpinController and AdjustPhase finalization only.
    */
   snapToGrid(): void {
+    this._reMaskLiftedBufferSlots();
     this.motion.snapToGrid();
     this._syncUnmaskedViewOffsets();
     this._finalizeFrame();
     this.refreshZIndex();
+  }
+
+  /**
+   * Pull any lifted (unmasked) view that has ended up in a buffer slot back
+   * under the mask.
+   *
+   * `_replaceSymbol` never lifts a buffer slot, but a symbol lifted while it
+   * was VISIBLE can still travel into a buffer slot without being replaced:
+   * a nudge rotates the array and only the wrapped symbol goes through
+   * `_replaceSymbol`, so an unmask symbol nudged out of the window kept its
+   * seat above the mask and hung there outside the grid. Runs on every
+   * settle, where the strip's final slots are known.
+   */
+  private _reMaskLiftedBufferSlots(): void {
+    for (let i = 0; i < this.symbols.length; i++) {
+      const view = this.symbols[i].view;
+      if (view.parent !== this._viewport.unmaskedContainer) continue;
+      if (!this._isBufferSlot(i)) continue;
+      const reelLocalMain = this._toReelLocalY(view);
+      this.container.addChild(view);
+      this._placeSymbolView(view, reelLocalMain, false);
+    }
   }
 
   /**
@@ -1331,9 +1354,10 @@ export class Reel implements Disposable {
     while (this.symbols.length < newTotal) {
       const id = this._randomProvider.next(true);
       const sym = this._symbolFactory.acquire(id);
+      const slot = this.symbols.length;
       sym.resize(newSize.width, newSize.height);
-      this._placeSymbolView(sym.view, this._axis.getMain(sym.view), this._effectiveUnmask(id));
-      this._parentForSymbolId(id).addChild(sym.view);
+      this._placeSymbolView(sym.view, this._axis.getMain(sym.view), this._effectiveUnmask(id, slot));
+      this._parentForSymbolId(id, slot).addChild(sym.view);
       this.symbols.push(sym);
     }
 
@@ -1460,28 +1484,41 @@ export class Reel implements Disposable {
     return !!this._symbolsData[symbolId]?.unmask;
   }
 
+  /** Whether strip slot `index` sits outside the visible window. */
+  private _isBufferSlot(index: number): boolean {
+    return index < this._bufferStart || index >= this._bufferStart + this._visibleCells;
+  }
+
   /**
-   * Whether the symbol should render above the mask RIGHT NOW. Unmask is
-   * an at-rest presentation: while the reel is in motion (including the
-   * stop approach and bounce, when the result symbols are installed),
-   * every view (unmask ids included) stays in the masked reel container so
-   * nothing scrolls visibly outside the grid or sits parked in a buffer
-   * cell. Landed visible-cell symbols are lifted by `notifyLanded()`;
+   * Whether the symbol at strip slot `index` should render above the mask
+   * RIGHT NOW. Unmask is an at-rest presentation of a VISIBLE cell:
+   *
+   *   - while the reel is in motion (including the stop approach and
+   *     bounce, when the result symbols are installed), every view
+   *     (unmask ids included) stays in the masked reel container so
+   *     nothing scrolls visibly outside the grid, and
+   *   - a buffer slot never lifts at all. it is parked outside the window
+   *     precisely so the mask hides it, and a lifted one hangs above or
+   *     below the grid in plain sight until the next spin re-masks it.
+   *     `placeStrip` writes buffer slots at rest on every skip, which is
+   *     exactly when that used to happen.
+   *
+   * Landed visible-cell symbols are lifted by `notifyLanded()`;
    * `notifySpinStart()` pulls them back down before the strip moves.
    */
-  private _effectiveUnmask(symbolId: string): boolean {
-    return this._atRest && this._isUnmasked(symbolId);
+  private _effectiveUnmask(symbolId: string, index: number): boolean {
+    return this._atRest && !this._isBufferSlot(index) && this._isUnmasked(symbolId);
   }
 
   /**
    * Pick the right parent container for a symbol view based on its
-   * `unmask` flag and the reel's spin state. At-rest unmasked symbols sit
-   * in `viewport.unmaskedContainer` (above the reel mask); everything
-   * else lives in this reel's own container (which is itself inside
-   * `viewport.maskedContainer`).
+   * `unmask` flag, its slot, and the reel's spin state. At-rest unmasked
+   * symbols in a visible cell sit in `viewport.unmaskedContainer` (above
+   * the reel mask); everything else lives in this reel's own container
+   * (which is itself inside `viewport.maskedContainer`).
    */
-  private _parentForSymbolId(symbolId: string): Container {
-    return this._effectiveUnmask(symbolId)
+  private _parentForSymbolId(symbolId: string, index: number): Container {
+    return this._effectiveUnmask(symbolId, index)
       ? this._viewport.unmaskedContainer
       : this.container;
   }
@@ -1597,9 +1634,7 @@ export class Reel implements Disposable {
       const main = (i - config.bufferStart) * slotH;
       // Unmask applies to visible cells only. a buffer-cell symbol lifted
       // above the mask would sit visibly parked outside the grid.
-      const inWindow =
-        i >= config.bufferStart && i < config.bufferStart + config.visibleCells;
-      const unmasked = inWindow && this._isUnmasked(symbol.symbolId);
+      const unmasked = this._effectiveUnmask(symbol.symbolId, i);
       this._placeSymbolView(symbol.view, main, unmasked);
       (unmasked ? this._viewport.unmaskedContainer : this.container).addChild(symbol.view);
     }
@@ -1675,13 +1710,13 @@ export class Reel implements Disposable {
     if (isOldStub) {
       this._releaseOccupiedStub(oldSymbol);
       const newSymbol = this._symbolFactory.acquire(newSymbolId);
-      const newIsUnmasked = this._effectiveUnmask(newSymbolId);
+      const newIsUnmasked = this._effectiveUnmask(newSymbolId, index);
       newSymbol.resize(this.symbolWidth, this.symbolHeight);
       this._placeSymbolView(newSymbol.view, reelLocalY, newIsUnmasked);
       newSymbol.view.alpha = 1;
       newSymbol.view.scale.set(1, 1);
       newSymbol.view.zIndex = this._computeSymbolZIndex(newSymbolId, index);
-      this._parentForSymbolId(newSymbolId).addChild(newSymbol.view);
+      this._parentForSymbolId(newSymbolId, index).addChild(newSymbol.view);
       this.symbols[index] = newSymbol;
       if (this._spinPresentationActive) newSymbol.onReelSpinStart(true);
       if (this._anticipationActive) newSymbol.onReelAnticipationStart();
@@ -1701,10 +1736,10 @@ export class Reel implements Disposable {
       oldSymbol.view.zIndex = this._computeSymbolZIndex(newSymbolId, index);
       // Same id → same unmask status; pick the right destination by id
       // so an unmasked symbol stays in `unmaskedContainer` post-spotlight.
-      const target = this._parentForSymbolId(newSymbolId);
+      const target = this._parentForSymbolId(newSymbolId, index);
       if (oldSymbol.view.parent !== target) target.addChild(oldSymbol.view);
       // Reset Y in case spotlight or another mutator displaced it.
-      this._placeSymbolView(oldSymbol.view, reelLocalY, this._effectiveUnmask(newSymbolId));
+      this._placeSymbolView(oldSymbol.view, reelLocalY, this._effectiveUnmask(newSymbolId, index));
       // The instance was never deactivated, so it usually still carries its
       // spin state. re-notify anyway for uniformity (hooks are idempotent).
       if (this._spinPresentationActive) oldSymbol.onReelSpinStart(true);
@@ -1714,14 +1749,14 @@ export class Reel implements Disposable {
 
     this._symbolFactory.release(oldSymbol);
     const newSymbol = this._symbolFactory.acquire(newSymbolId);
-    const newIsUnmasked = this._effectiveUnmask(newSymbolId);
+    const newIsUnmasked = this._effectiveUnmask(newSymbolId, index);
     newSymbol.resize(this.symbolWidth, this.symbolHeight);
     this._placeSymbolView(newSymbol.view, reelLocalY, newIsUnmasked);
     newSymbol.view.alpha = 1;
     newSymbol.view.scale.set(1, 1);
     newSymbol.view.zIndex = this._computeSymbolZIndex(newSymbolId, index);
 
-    this._parentForSymbolId(newSymbolId).addChild(newSymbol.view);
+    this._parentForSymbolId(newSymbolId, index).addChild(newSymbol.view);
 
     this.symbols[index] = newSymbol;
     if (this._spinPresentationActive) newSymbol.onReelSpinStart(true);

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -1134,7 +1134,7 @@ export class Reel implements Disposable {
         if (k <= wrapsToVisible) {
           queue.push(incoming[wrapsToVisible - k]);
         } else {
-          queue.push(this._randomProvider.next(true));
+          queue.push(this._randomProvider.next(true, this.reelIndex));
         }
       }
       this._nudgeQueue = queue;
@@ -1151,7 +1151,7 @@ export class Reel implements Disposable {
         if (k <= wrapsToVisible) {
           queue.push(incoming[bufferEnd + k - 1]);
         } else {
-          queue.push(this._randomProvider.next(true));
+          queue.push(this._randomProvider.next(true, this.reelIndex));
         }
       }
       this._nudgeQueue = queue;
@@ -1315,7 +1315,11 @@ export class Reel implements Disposable {
   placeStrip(frame: ReadonlyArray<string | undefined>): void {
     const totalSlots = this.symbols.length;
     for (let i = 0; i < totalSlots; i++) {
-      const targetId = frame[i] ?? this._randomProvider.next(true);
+      // Buffer pools apply to the buffer slots only. a visible cell the
+      // frame left blank is a spinning-pool draw, same rule FrameBuilder
+      // uses when it random-fills a frame.
+      const targetId =
+        frame[i] ?? this._randomProvider.next(this._isBufferSlot(i), this.reelIndex);
       this._replaceSymbol(i, targetId);
     }
     this.motion.snapToGrid();
@@ -1352,7 +1356,7 @@ export class Reel implements Disposable {
     // Grow: append additional symbols at the bottom buffer. New symbols are
     // parented based on `unmask` flag. same rule as `_replaceSymbol`.
     while (this.symbols.length < newTotal) {
-      const id = this._randomProvider.next(true);
+      const id = this._randomProvider.next(true, this.reelIndex);
       const sym = this._symbolFactory.acquire(id);
       const slot = this.symbols.length;
       sym.resize(newSize.width, newSize.height);
@@ -1652,7 +1656,7 @@ export class Reel implements Disposable {
     } else if (this._isStopping && this.stopSequencer.hasRemaining) {
       newSymbolId = this.stopSequencer.next();
     } else {
-      newSymbolId = this._randomProvider.next();
+      newSymbolId = this._randomProvider.next(false, this.reelIndex);
     }
 
     this._replaceSymbol(this.symbols.indexOf(symbol), newSymbolId);

--- a/packages/pixi-reels/src/core/ReelSet.ts
+++ b/packages/pixi-reels/src/core/ReelSet.ts
@@ -26,6 +26,7 @@ import { pinKey } from '../pins/CellPin.js';
 
 import type { FrameMiddleware } from '../frame/FrameBuilder.js';
 import type { ColumnTarget } from '../frame/ColumnTarget.js';
+import type { RandomSymbolControl } from '../frame/SymbolPool.js';
 import { assertBufferCountsInRange, assertColumnTargets, cloneColumnTarget } from '../frame/ColumnTarget.js';
 import { V1_OPTION_KEYS, assertNoV1Keys } from '../config/v1Renames.js';
 import type { Cell } from '../cascade/tumbleAlgorithm.js';
@@ -1680,6 +1681,25 @@ export class ReelSet extends Container implements Disposable {
     return this._spotlight;
   }
 
+  // ─── Random symbol pools ──────────────────────────────────
+
+  /**
+   * Control over what the engine may draw when it fills a cell the game
+   * did not name: the strip streaming past during a spin, and the buffer
+   * cells parked either side of the visible window.
+   *
+   * ```ts
+   * reelSet.randomSymbols.set({ exclude: ['EMPTY'] });
+   * reelSet.randomSymbols.set({ weights: { WILD: 40 } }, { reel: 2 });
+   * reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'buffer' });
+   * ```
+   *
+   * Build-time equivalent: `builder.randomSymbols(pool, scope)`.
+   */
+  get randomSymbols(): RandomSymbolControl {
+    return this._frameBuilder.randomProvider;
+  }
+
   // ─── Reel access ──────────────────────────────────────────
 
   /** Get all reels. */
@@ -1948,7 +1968,7 @@ export class ReelSet extends Container implements Disposable {
     // the vacated cell visually swaps to the backfill while the flight
     // symbol is still in motion.
     const backfill =
-      opts?.backfill ?? this._frameBuilder.randomProvider.next(false);
+      opts?.backfill ?? this._frameBuilder.randomProvider.next(false, from.reel);
     const fromVisible = fromReel.getVisibleSymbols();
     fromVisible[from.cell] = backfill;
     fromReel.placeSymbols({ visible: fromVisible });

--- a/packages/pixi-reels/src/core/ReelSet.ts
+++ b/packages/pixi-reels/src/core/ReelSet.ts
@@ -1968,7 +1968,7 @@ export class ReelSet extends Container implements Disposable {
     // the vacated cell visually swaps to the backfill while the flight
     // symbol is still in motion.
     const backfill =
-      opts?.backfill ?? this._frameBuilder.randomProvider.next(false, from.reel);
+      opts?.backfill ?? this._frameBuilder.randomProvider.next('spinning', from.reel);
     const fromVisible = fromReel.getVisibleSymbols();
     fromVisible[from.cell] = backfill;
     fromReel.placeSymbols({ visible: fromVisible });

--- a/packages/pixi-reels/src/core/ReelSetBuilder.ts
+++ b/packages/pixi-reels/src/core/ReelSetBuilder.ts
@@ -25,6 +25,7 @@ import { ReelViewport } from './ReelViewport.js';
 import { SymbolRegistry } from '../symbols/SymbolRegistry.js';
 import { SymbolFactory } from '../symbols/SymbolFactory.js';
 import { RandomSymbolProvider } from '../frame/RandomSymbolProvider.js';
+import type { SymbolPool, SymbolPoolScope } from '../frame/SymbolPool.js';
 import { FrameBuilder } from '../frame/FrameBuilder.js';
 import { PhaseFactory } from '../spin/phases/PhaseFactory.js';
 import type { SpinningMode } from '../spin/modes/SpinningMode.js';
@@ -85,6 +86,7 @@ export class ReelSetBuilder {
   private _bufferEnd = DEFAULTS.bufferSymbols;
   private _symbolRegistry = new SymbolRegistry();
   private _weights: Record<string, number> = {};
+  private _symbolPools: { pool: SymbolPool; scope: SymbolPoolScope }[] = [];
   private _speeds = new Map<string, SpeedProfile>();
   private _initialSpeed = DEFAULTS.initialSpeed;
   private _offset: OffsetConfig = { mode: 'none' };
@@ -433,6 +435,27 @@ export class ReelSetBuilder {
   /** Set weights for random symbol generation. */
   weights(weights: Record<string, number>): this {
     this._weights = weights;
+    return this;
+  }
+
+  /**
+   * Narrow what the engine may draw when it fills a cell you did not name.
+   *
+   * `weights()` sets the base table for every reel; this layers pools on
+   * top of it, so a symbol can be common on the strip and impossible in
+   * the buffer cells, or heavy on one reel only. Call it once per scope.
+   *
+   * Buffer pools apply ON TOP of the spinning ones (see `SymbolPoolScope`),
+   * and the same pools are reachable at run time as
+   * `reelSet.randomSymbols`, which is where a game mode switch belongs.
+   *
+   * @example
+   * .randomSymbols({ exclude: ['EMPTY'] })                       // every reel
+   * .randomSymbols({ exclude: ['COIN'] }, { slots: 'buffer' })   // buffers only
+   * .randomSymbols({ weights: { WILD: 40 } }, { reel: 2 })       // reel 2 only
+   */
+  randomSymbols(pool: SymbolPool, scope: SymbolPoolScope = {}): this {
+    this._symbolPools.push({ pool, scope });
     return this;
   }
 
@@ -802,6 +825,9 @@ export class ReelSetBuilder {
       setAxis.mainProp,
     );
     const randomProvider = new RandomSymbolProvider(symbolsData, this._rng);
+    for (const { pool, scope } of this._symbolPools) {
+      randomProvider.set(pool, scope);
+    }
     const frameBuilder = new FrameBuilder(randomProvider);
 
     for (const mw of this._middlewares) {

--- a/packages/pixi-reels/src/frame/FrameBuilder.ts
+++ b/packages/pixi-reels/src/frame/FrameBuilder.ts
@@ -148,10 +148,15 @@ class RandomFillMiddleware implements FrameMiddleware {
   process(context: FrameContext, next: () => void): void {
     for (let i = 0; i < context.symbols.length; i++) {
       if (!context.symbols[i]) {
-        const isBuffer =
-          i < context.bufferStart ||
-          i >= context.bufferStart + context.visibleCells;
-        context.symbols[i] = this._provider.next(isBuffer, context.reelIndex);
+        // Each slot names the pool it belongs to: the visible window, or
+        // whichever side of the buffer it sits on.
+        const slot =
+          i < context.bufferStart
+            ? 'bufferStart'
+            : i >= context.bufferStart + context.visibleCells
+              ? 'bufferEnd'
+              : 'spinning';
+        context.symbols[i] = this._provider.next(slot, context.reelIndex);
       }
     }
     next();

--- a/packages/pixi-reels/src/frame/FrameBuilder.ts
+++ b/packages/pixi-reels/src/frame/FrameBuilder.ts
@@ -151,7 +151,7 @@ class RandomFillMiddleware implements FrameMiddleware {
         const isBuffer =
           i < context.bufferStart ||
           i >= context.bufferStart + context.visibleCells;
-        context.symbols[i] = this._provider.next(isBuffer);
+        context.symbols[i] = this._provider.next(isBuffer, context.reelIndex);
       }
     }
     next();

--- a/packages/pixi-reels/src/frame/RandomSymbolProvider.ts
+++ b/packages/pixi-reels/src/frame/RandomSymbolProvider.ts
@@ -3,7 +3,14 @@ import type {
   RandomSymbolControl,
   SymbolPool,
   SymbolPoolScope,
+  SymbolPoolSlots,
 } from './SymbolPool.js';
+
+/**
+ * Which slot the engine is filling. `'buffer'` is a LAYER, never a slot: a
+ * real cell is always on one side or the other.
+ */
+export type DrawSlot = 'spinning' | 'bufferStart' | 'bufferEnd';
 
 /** A compiled draw table: ids with weight > 0 plus their cumulative weights. */
 interface DrawTable {
@@ -18,9 +25,10 @@ const ALL_REELS = '*';
 /**
  * Weighted random symbol selector using binary search on cumulative weights.
  *
- * On top of the registered weights it carries up to four layers of
- * `SymbolPool` overrides. global and per-reel, for the spinning strip and
- * for the buffer cells. See `SymbolPoolScope` for how they resolve.
+ * On top of the registered weights it carries layers of `SymbolPool`
+ * overrides. global and per-reel, for the spinning strip, for both buffer
+ * ends at once, and for either end on its own. See `SymbolPoolScope` for
+ * how they resolve.
  */
 export class RandomSymbolProvider implements RandomSymbolControl {
   private _symbols: string[];
@@ -47,13 +55,13 @@ export class RandomSymbolProvider implements RandomSymbolControl {
   /**
    * Get a random symbol for one slot.
    *
-   * @param useBufferExclusion - True for a slot outside the visible window,
-   *   so the buffer pools apply on top of the spinning ones.
+   * @param slot - Which slot is being filled. A buffer slot names its side,
+   *   so the pools for that side apply on top of the wider ones.
    * @param reelIndex - Reel the slot belongs to. Omit for a draw that
    *   belongs to no particular reel; per-reel pools then don't apply.
    */
-  next(useBufferExclusion: boolean = false, reelIndex?: number): string {
-    const table = this._table(useBufferExclusion, reelIndex);
+  next(slot: DrawSlot = 'spinning', reelIndex?: number): string {
+    const table = this._table(slot, reelIndex);
     const rand = this._rng() * table.total;
     let lo = 0;
     let hi = table.cumulative.length - 1;
@@ -70,7 +78,7 @@ export class RandomSymbolProvider implements RandomSymbolControl {
 
   /** @inheritdoc */
   set(pool: SymbolPool | null, scope: SymbolPoolScope = {}): void {
-    const key = this._key(scope.slots === 'buffer', scope.reel);
+    const key = this._key(scope.slots ?? 'spinning', scope.reel);
     const previous = this._pools.get(key);
     if (pool === null) {
       this._pools.delete(key);
@@ -101,7 +109,7 @@ export class RandomSymbolProvider implements RandomSymbolControl {
 
   /** @inheritdoc */
   weights(scope: SymbolPoolScope = {}): Record<string, number> {
-    const resolved = this._resolve(scope.slots === 'buffer', scope.reel);
+    const resolved = this._resolve(scope.slots ?? 'spinning', scope.reel);
     const out: Record<string, number> = {};
     for (const id of this._symbols) out[id] = resolved[id];
     return out;
@@ -114,7 +122,7 @@ export class RandomSymbolProvider implements RandomSymbolControl {
    * weight overrides on the global spinning pool alone.
    */
   setExcludeSpinning(symbolIds: string[]): void {
-    this._setExclude(false, symbolIds);
+    this._setExclude('spinning', symbolIds);
   }
 
   /**
@@ -124,7 +132,7 @@ export class RandomSymbolProvider implements RandomSymbolControl {
    * weight overrides on the global buffer pool alone.
    */
   setExcludeBuffer(symbolIds: string[]): void {
-    this._setExclude(true, symbolIds);
+    this._setExclude('buffer', symbolIds);
   }
 
   /** Update weights at runtime (e.g., for different game modes). */
@@ -149,16 +157,13 @@ export class RandomSymbolProvider implements RandomSymbolControl {
     this._assertDrawable();
   }
 
-  private _setExclude(isBuffer: boolean, symbolIds: string[]): void {
-    const current = this._pools.get(this._key(isBuffer, undefined));
-    this.set(
-      { weights: current?.weights, exclude: symbolIds },
-      { slots: isBuffer ? 'buffer' : 'spinning' },
-    );
+  private _setExclude(slots: SymbolPoolSlots, symbolIds: string[]): void {
+    const current = this._pools.get(this._key(slots, undefined));
+    this.set({ weights: current?.weights, exclude: symbolIds }, { slots });
   }
 
-  private _key(isBuffer: boolean, reel: number | undefined): string {
-    return `${isBuffer ? 'buffer' : 'spinning'}:${reel ?? ALL_REELS}`;
+  private _key(slots: SymbolPoolSlots, reel: number | undefined): string {
+    return `${slots}:${reel ?? ALL_REELS}`;
   }
 
   private _readBaseWeights(symbolsData: Record<string, SymbolData>): void {
@@ -169,19 +174,37 @@ export class RandomSymbolProvider implements RandomSymbolControl {
   }
 
   /**
-   * Effective weight per symbol id for one draw, excluded ids flattened to
-   * `0`. Layers apply base → global spinning → reel spinning → global
-   * buffer → reel buffer, so a buffer pool always narrows what the
-   * spinning pools already allow.
+   * The layer keys that apply to one draw, widest first.
+   *
+   * A `'bufferStart'` cell reads the spinning layers, then the both-sides
+   * buffer layers, then its own side's - so every layer only ever narrows
+   * the one before it. Asking for `'buffer'` stops before the side layers:
+   * that is what both sides inherit, and what `weights()` reports for it.
    */
-  private _resolve(isBuffer: boolean, reelIndex: number | undefined): Record<string, number> {
+  private _layerKeys(slots: SymbolPoolSlots, reelIndex: number | undefined): string[] {
+    const perReel = (key: SymbolPoolSlots): string[] =>
+      reelIndex === undefined
+        ? [this._key(key, undefined)]
+        : [this._key(key, undefined), this._key(key, reelIndex)];
+
+    const keys = perReel('spinning');
+    if (slots === 'spinning') return keys;
+    keys.push(...perReel('buffer'));
+    if (slots === 'buffer') return keys;
+    keys.push(...perReel(slots));
+    return keys;
+  }
+
+  /**
+   * Effective weight per symbol id for one draw, excluded ids flattened to
+   * `0`. See `_layerKeys` for the order.
+   */
+  private _resolve(
+    slots: SymbolPoolSlots,
+    reelIndex: number | undefined,
+  ): Record<string, number> {
     const weights = { ...this._baseWeights };
-    const layers = [this._key(false, undefined)];
-    if (reelIndex !== undefined) layers.push(this._key(false, reelIndex));
-    if (isBuffer) {
-      layers.push(this._key(true, undefined));
-      if (reelIndex !== undefined) layers.push(this._key(true, reelIndex));
-    }
+    const layers = this._layerKeys(slots, reelIndex);
     const excluded = new Set<string>();
     for (const key of layers) {
       const pool = this._pools.get(key);
@@ -201,20 +224,20 @@ export class RandomSymbolProvider implements RandomSymbolControl {
     return weights;
   }
 
-  private _table(isBuffer: boolean, reelIndex: number | undefined): DrawTable {
-    const key = this._key(isBuffer, reelIndex);
+  private _table(slots: SymbolPoolSlots, reelIndex: number | undefined): DrawTable {
+    const key = this._key(slots, reelIndex);
     const cached = this._tables.get(key);
     if (cached) return cached;
-    const table = this._compile(isBuffer, reelIndex);
+    const table = this._compile(slots, reelIndex);
     if (table.total <= 0) {
-      throw new Error(this._emptyPoolMessage(isBuffer, reelIndex));
+      throw new Error(this._emptyPoolMessage(slots, reelIndex));
     }
     this._tables.set(key, table);
     return table;
   }
 
-  private _compile(isBuffer: boolean, reelIndex: number | undefined): DrawTable {
-    const weights = this._resolve(isBuffer, reelIndex);
+  private _compile(slots: SymbolPoolSlots, reelIndex: number | undefined): DrawTable {
+    const weights = this._resolve(slots, reelIndex);
     const table: DrawTable = { ids: [], cumulative: [], total: 0 };
     for (const id of this._symbols) {
       const weight = weights[id];
@@ -233,7 +256,7 @@ export class RandomSymbolProvider implements RandomSymbolControl {
     for (const id of ids) {
       if (this._baseWeights[id] === undefined) {
         throw new Error(
-          `SymbolPool ${this._scopeName(scope.slots === 'buffer', scope.reel)} names symbol '${id}', ` +
+          `SymbolPool ${this._scopeName(scope.slots ?? 'spinning', scope.reel)} names symbol '${id}', ` +
             `which is not registered. Registered ids: ${this._symbols.join(', ')}.`,
         );
       }
@@ -251,29 +274,35 @@ export class RandomSymbolProvider implements RandomSymbolControl {
       const reel = key.slice(key.indexOf(':') + 1);
       if (reel !== ALL_REELS) reels.add(Number(reel));
     }
-    const scopes: [boolean, number | undefined][] = [
-      [false, undefined],
-      [true, undefined],
-    ];
+    // Widest scope first, so the message names the layer that actually
+    // emptied things: a pool that clears `'buffer'` empties both sides, and
+    // "buffer cells" is a better answer than "buffer-start cells".
+    const drawn: SymbolPoolSlots[] = ['spinning', 'buffer', 'bufferStart', 'bufferEnd'];
+    const scopes: [SymbolPoolSlots, number | undefined][] = drawn.map((slot) => [slot, undefined]);
     for (const reel of reels) {
-      scopes.push([false, reel], [true, reel]);
+      for (const slot of drawn) scopes.push([slot, reel]);
     }
-    for (const [isBuffer, reel] of scopes) {
-      if (this._compile(isBuffer, reel).total <= 0) {
-        throw new Error(this._emptyPoolMessage(isBuffer, reel));
+    for (const [slot, reel] of scopes) {
+      if (this._compile(slot, reel).total <= 0) {
+        throw new Error(this._emptyPoolMessage(slot, reel));
       }
     }
   }
 
-  private _emptyPoolMessage(isBuffer: boolean, reelIndex: number | undefined): string {
+  private _emptyPoolMessage(slots: SymbolPoolSlots, reelIndex: number | undefined): string {
     return (
-      `No symbol left to draw ${this._scopeName(isBuffer, reelIndex)}: every registered symbol is ` +
+      `No symbol left to draw ${this._scopeName(slots, reelIndex)}: every registered symbol is ` +
       'excluded or weighted 0, so the strip cannot be filled. Leave at least one symbol drawable.'
     );
   }
 
-  private _scopeName(isBuffer: boolean, reelIndex: number | undefined): string {
-    const where = isBuffer ? 'buffer cells' : 'spinning cells';
+  private _scopeName(slots: SymbolPoolSlots, reelIndex: number | undefined): string {
+    const where = {
+      spinning: 'spinning cells',
+      buffer: 'buffer cells',
+      bufferStart: 'buffer-start cells',
+      bufferEnd: 'buffer-end cells',
+    }[slots];
     return reelIndex === undefined ? `for ${where} on every reel` : `for ${where} on reel ${reelIndex}`;
   }
 

--- a/packages/pixi-reels/src/frame/RandomSymbolProvider.ts
+++ b/packages/pixi-reels/src/frame/RandomSymbolProvider.ts
@@ -1,18 +1,34 @@
 import type { SymbolData } from '../config/types.js';
+import type {
+  RandomSymbolControl,
+  SymbolPool,
+  SymbolPoolScope,
+} from './SymbolPool.js';
+
+/** A compiled draw table: ids with weight > 0 plus their cumulative weights. */
+interface DrawTable {
+  ids: string[];
+  cumulative: number[];
+  total: number;
+}
+
+/** Global layers use this in place of a reel index. */
+const ALL_REELS = '*';
 
 /**
  * Weighted random symbol selector using binary search on cumulative weights.
  *
- * Supports exclusion lists for symbols that shouldn't appear during
- * spinning or in buffer areas.
+ * On top of the registered weights it carries up to four layers of
+ * `SymbolPool` overrides. global and per-reel, for the spinning strip and
+ * for the buffer cells. See `SymbolPoolScope` for how they resolve.
  */
-export class RandomSymbolProvider {
+export class RandomSymbolProvider implements RandomSymbolControl {
   private _symbols: string[];
-  private _weights: number[];
-  private _cumulativeWeights: number[] = [];
-  private _totalWeight: number = 0;
-  private _excludeSpinning = new Set<string>();
-  private _excludeBuffer = new Set<string>();
+  private _baseWeights: Record<string, number> = {};
+  /** Installed pools, keyed by `${slots}:${reel}`. */
+  private _pools = new Map<string, SymbolPool>();
+  /** Compiled tables, same key shape. Dropped wholesale on any mutation. */
+  private _tables = new Map<string, DrawTable>();
   private _rng: () => number;
 
   /**
@@ -24,113 +40,254 @@ export class RandomSymbolProvider {
   constructor(symbolsData: Record<string, SymbolData>, rng: () => number = Math.random) {
     this._rng = rng;
     this._symbols = Object.keys(symbolsData);
-    this._weights = this._symbols.map((id) => symbolsData[id].weight);
-    this._rebuildWeights();
+    this._readBaseWeights(symbolsData);
     this._assertUsable();
   }
 
-  /** Get a random symbol, optionally excluding buffer-only symbols. */
-  next(useBufferExclusion: boolean = false): string {
-    const exclude = useBufferExclusion
-      ? new Set([...this._excludeSpinning, ...this._excludeBuffer])
-      : this._excludeSpinning;
-
-    if (exclude.size === 0) {
-      return this._pickWeighted();
-    }
-
-    // Build filtered weights on the fly for exclusions
-    let total = 0;
-    const filtered: { id: string; cumWeight: number }[] = [];
-    for (let i = 0; i < this._symbols.length; i++) {
-      if (exclude.has(this._symbols[i])) continue;
-      total += this._weights[i];
-      filtered.push({ id: this._symbols[i], cumWeight: total });
-    }
-
-    if (total === 0 || filtered.length === 0) {
-      // Fallback: return first non-excluded symbol
-      for (const s of this._symbols) {
-        if (!exclude.has(s)) return s;
-      }
-      return this._symbols[0];
-    }
-
-    const rand = this._rng() * total;
-    // Binary search
+  /**
+   * Get a random symbol for one slot.
+   *
+   * @param useBufferExclusion - True for a slot outside the visible window,
+   *   so the buffer pools apply on top of the spinning ones.
+   * @param reelIndex - Reel the slot belongs to. Omit for a draw that
+   *   belongs to no particular reel; per-reel pools then don't apply.
+   */
+  next(useBufferExclusion: boolean = false, reelIndex?: number): string {
+    const table = this._table(useBufferExclusion, reelIndex);
+    const rand = this._rng() * table.total;
     let lo = 0;
-    let hi = filtered.length - 1;
+    let hi = table.cumulative.length - 1;
     while (lo < hi) {
       const mid = (lo + hi) >> 1;
-      if (filtered[mid].cumWeight <= rand) {
+      if (table.cumulative[mid] <= rand) {
         lo = mid + 1;
       } else {
         hi = mid;
       }
     }
-    return filtered[lo].id;
+    return table.ids[lo];
   }
 
-  /** Set symbols to exclude during spinning. */
+  /** @inheritdoc */
+  set(pool: SymbolPool | null, scope: SymbolPoolScope = {}): void {
+    const key = this._key(scope.slots === 'buffer', scope.reel);
+    const previous = this._pools.get(key);
+    if (pool === null) {
+      this._pools.delete(key);
+    } else {
+      this._assertKnownIds(pool, scope);
+      this._pools.set(key, {
+        weights: pool.weights ? { ...pool.weights } : undefined,
+        exclude: pool.exclude ? [...pool.exclude] : undefined,
+      });
+    }
+    this._tables.clear();
+    // Roll back rather than leave the set holding a pool it cannot draw from.
+    try {
+      this._assertDrawable();
+    } catch (err) {
+      if (previous === undefined) this._pools.delete(key);
+      else this._pools.set(key, previous);
+      this._tables.clear();
+      throw err;
+    }
+  }
+
+  /** @inheritdoc */
+  clear(): void {
+    this._pools.clear();
+    this._tables.clear();
+  }
+
+  /** @inheritdoc */
+  weights(scope: SymbolPoolScope = {}): Record<string, number> {
+    const resolved = this._resolve(scope.slots === 'buffer', scope.reel);
+    const out: Record<string, number> = {};
+    for (const id of this._symbols) out[id] = resolved[id];
+    return out;
+  }
+
+  /**
+   * Set symbols to exclude during spinning.
+   *
+   * Sugar for `set({ exclude }, { slots: 'spinning' })` that leaves any
+   * weight overrides on the global spinning pool alone.
+   */
   setExcludeSpinning(symbolIds: string[]): void {
-    this._excludeSpinning = new Set(symbolIds);
+    this._setExclude(false, symbolIds);
   }
 
-  /** Set symbols to exclude from buffer (above/below) areas. */
+  /**
+   * Set symbols to exclude from buffer (above/below) areas.
+   *
+   * Sugar for `set({ exclude }, { slots: 'buffer' })` that leaves any
+   * weight overrides on the global buffer pool alone.
+   */
   setExcludeBuffer(symbolIds: string[]): void {
-    this._excludeBuffer = new Set(symbolIds);
+    this._setExclude(true, symbolIds);
   }
 
   /** Update weights at runtime (e.g., for different game modes). */
   updateWeights(symbolsData: Record<string, SymbolData>): void {
     this._symbols = Object.keys(symbolsData);
-    this._weights = this._symbols.map((id) => symbolsData[id].weight);
-    this._rebuildWeights();
+    this._readBaseWeights(symbolsData);
     this._assertUsable();
-    // Drop exclusions that reference symbols no longer present in this mode,
+    // Drop pool entries that reference symbols no longer present in this mode,
     // otherwise a stale exclusion from the previous game mode silently lingers.
     const present = new Set(this._symbols);
-    this._excludeSpinning = new Set(
-      [...this._excludeSpinning].filter((id) => present.has(id)),
+    for (const [key, pool] of this._pools) {
+      this._pools.set(key, {
+        weights: pool.weights
+          ? Object.fromEntries(
+              Object.entries(pool.weights).filter(([id]) => present.has(id)),
+            )
+          : undefined,
+        exclude: pool.exclude?.filter((id) => present.has(id)),
+      });
+    }
+    this._tables.clear();
+    this._assertDrawable();
+  }
+
+  private _setExclude(isBuffer: boolean, symbolIds: string[]): void {
+    const current = this._pools.get(this._key(isBuffer, undefined));
+    this.set(
+      { weights: current?.weights, exclude: symbolIds },
+      { slots: isBuffer ? 'buffer' : 'spinning' },
     );
-    this._excludeBuffer = new Set(
-      [...this._excludeBuffer].filter((id) => present.has(id)),
+  }
+
+  private _key(isBuffer: boolean, reel: number | undefined): string {
+    return `${isBuffer ? 'buffer' : 'spinning'}:${reel ?? ALL_REELS}`;
+  }
+
+  private _readBaseWeights(symbolsData: Record<string, SymbolData>): void {
+    this._baseWeights = {};
+    for (const id of this._symbols) {
+      this._baseWeights[id] = symbolsData[id].weight;
+    }
+  }
+
+  /**
+   * Effective weight per symbol id for one draw, excluded ids flattened to
+   * `0`. Layers apply base → global spinning → reel spinning → global
+   * buffer → reel buffer, so a buffer pool always narrows what the
+   * spinning pools already allow.
+   */
+  private _resolve(isBuffer: boolean, reelIndex: number | undefined): Record<string, number> {
+    const weights = { ...this._baseWeights };
+    const layers = [this._key(false, undefined)];
+    if (reelIndex !== undefined) layers.push(this._key(false, reelIndex));
+    if (isBuffer) {
+      layers.push(this._key(true, undefined));
+      if (reelIndex !== undefined) layers.push(this._key(true, reelIndex));
+    }
+    const excluded = new Set<string>();
+    for (const key of layers) {
+      const pool = this._pools.get(key);
+      if (!pool) continue;
+      if (pool.weights) {
+        for (const [id, weight] of Object.entries(pool.weights)) {
+          if (id in weights) weights[id] = weight;
+        }
+      }
+      if (pool.exclude) {
+        for (const id of pool.exclude) excluded.add(id);
+      }
+    }
+    // Exclusions win over every weight in the chain: a narrower layer can't
+    // re-admit what a wider one banned, it can only ban more.
+    for (const id of excluded) weights[id] = 0;
+    return weights;
+  }
+
+  private _table(isBuffer: boolean, reelIndex: number | undefined): DrawTable {
+    const key = this._key(isBuffer, reelIndex);
+    const cached = this._tables.get(key);
+    if (cached) return cached;
+    const table = this._compile(isBuffer, reelIndex);
+    if (table.total <= 0) {
+      throw new Error(this._emptyPoolMessage(isBuffer, reelIndex));
+    }
+    this._tables.set(key, table);
+    return table;
+  }
+
+  private _compile(isBuffer: boolean, reelIndex: number | undefined): DrawTable {
+    const weights = this._resolve(isBuffer, reelIndex);
+    const table: DrawTable = { ids: [], cumulative: [], total: 0 };
+    for (const id of this._symbols) {
+      const weight = weights[id];
+      // Zero-weight ids are dropped rather than carried at a repeated
+      // cumulative value: same draw either way, smaller table.
+      if (weight <= 0) continue;
+      table.total += weight;
+      table.ids.push(id);
+      table.cumulative.push(table.total);
+    }
+    return table;
+  }
+
+  private _assertKnownIds(pool: SymbolPool, scope: SymbolPoolScope): void {
+    const ids = [...Object.keys(pool.weights ?? {}), ...(pool.exclude ?? [])];
+    for (const id of ids) {
+      if (this._baseWeights[id] === undefined) {
+        throw new Error(
+          `SymbolPool ${this._scopeName(scope.slots === 'buffer', scope.reel)} names symbol '${id}', ` +
+            `which is not registered. Registered ids: ${this._symbols.join(', ')}.`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Every scope a draw can reach must still have something to draw. Checked
+   * on mutation so a pool that empties the strip fails at the call that
+   * caused it, not mid-spin on whichever reel happens to wrap first.
+   */
+  private _assertDrawable(): void {
+    const reels = new Set<number>();
+    for (const key of this._pools.keys()) {
+      const reel = key.slice(key.indexOf(':') + 1);
+      if (reel !== ALL_REELS) reels.add(Number(reel));
+    }
+    const scopes: [boolean, number | undefined][] = [
+      [false, undefined],
+      [true, undefined],
+    ];
+    for (const reel of reels) {
+      scopes.push([false, reel], [true, reel]);
+    }
+    for (const [isBuffer, reel] of scopes) {
+      if (this._compile(isBuffer, reel).total <= 0) {
+        throw new Error(this._emptyPoolMessage(isBuffer, reel));
+      }
+    }
+  }
+
+  private _emptyPoolMessage(isBuffer: boolean, reelIndex: number | undefined): string {
+    return (
+      `No symbol left to draw ${this._scopeName(isBuffer, reelIndex)}: every registered symbol is ` +
+      'excluded or weighted 0, so the strip cannot be filled. Leave at least one symbol drawable.'
     );
+  }
+
+  private _scopeName(isBuffer: boolean, reelIndex: number | undefined): string {
+    const where = isBuffer ? 'buffer cells' : 'spinning cells';
+    return reelIndex === undefined ? `for ${where} on every reel` : `for ${where} on reel ${reelIndex}`;
   }
 
   private _assertUsable(): void {
     if (this._symbols.length === 0) {
       throw new Error('RandomSymbolProvider requires at least one symbol.');
     }
-    if (this._totalWeight <= 0) {
+    let total = 0;
+    for (const id of this._symbols) total += Math.max(0, this._baseWeights[id]);
+    if (total <= 0) {
       throw new Error(
         'RandomSymbolProvider requires at least one symbol with weight > 0; ' +
           'all registered symbols have weight 0, so the spinning strip cannot be filled.',
       );
     }
-  }
-
-  private _rebuildWeights(): void {
-    this._cumulativeWeights = [];
-    this._totalWeight = 0;
-    for (const w of this._weights) {
-      this._totalWeight += w;
-      this._cumulativeWeights.push(this._totalWeight);
-    }
-  }
-
-  private _pickWeighted(): string {
-    const rand = this._rng() * this._totalWeight;
-    let lo = 0;
-    let hi = this._cumulativeWeights.length - 1;
-    while (lo < hi) {
-      const mid = (lo + hi) >> 1;
-      if (this._cumulativeWeights[mid] <= rand) {
-        lo = mid + 1;
-      } else {
-        hi = mid;
-      }
-    }
-    return this._symbols[lo];
   }
 }

--- a/packages/pixi-reels/src/frame/SymbolPool.ts
+++ b/packages/pixi-reels/src/frame/SymbolPool.ts
@@ -1,0 +1,81 @@
+/**
+ * What the engine is allowed to draw when it needs a random symbol.
+ *
+ * Every cell the game does not name explicitly (the strip streaming past
+ * during a spin, and the buffer cells parked either side of the visible
+ * window) is filled from a weighted draw. A pool narrows that draw: it
+ * layers weight overrides on top of the registered `builder.weights(...)`
+ * table and hard-excludes ids that must never show up.
+ */
+export interface SymbolPool {
+  /**
+   * Weight overrides by symbol id, layered over the registered weights.
+   * A weight of `0` removes the symbol from this pool as surely as
+   * listing it in `exclude` does.
+   */
+  weights?: Readonly<Record<string, number>>;
+  /** Symbol ids that must never be drawn in this pool. */
+  exclude?: readonly string[];
+}
+
+/**
+ * Which draws a pool applies to.
+ *
+ * Layers resolve base -> global spinning -> per-reel spinning -> global
+ * buffer -> per-reel buffer. Weights override per symbol id, exclusions
+ * accumulate. So a `'buffer'` pool is always ON TOP of the spinning rules
+ * for that reel: what the strip may not show while it scrolls, the buffer
+ * may not show either.
+ */
+export interface SymbolPoolScope {
+  /** Restrict to one reel index. Omit to apply to every reel. */
+  reel?: number;
+  /**
+   * `'spinning'` (default) covers every random draw on the reel.
+   * `'buffer'` narrows only the cells outside the visible window.
+   */
+  slots?: 'spinning' | 'buffer';
+}
+
+/**
+ * Runtime control over the random symbol draw, reachable as
+ * `reelSet.randomSymbols`.
+ *
+ * ```ts
+ * // No EMPTY anywhere on any reel while it spins.
+ * reelSet.randomSymbols.set({ exclude: ['EMPTY'] });
+ *
+ * // Reel 2 runs hot on wilds during the feature.
+ * reelSet.randomSymbols.set({ weights: { WILD: 40 } }, { reel: 2 });
+ *
+ * // Nothing collectible may sit half-visible above or below the grid.
+ * reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'buffer' });
+ *
+ * // Drop one layer, or all of them.
+ * reelSet.randomSymbols.set(null, { reel: 2 });
+ * reelSet.randomSymbols.clear();
+ * ```
+ *
+ * Changes apply to the next draw. symbols already on the strip stay until
+ * they wrap out, so set the pools before `spin()` (or before the reels
+ * reach the cells you care about), not after.
+ */
+export interface RandomSymbolControl {
+  /**
+   * Install (or with `null`, remove) the pool for one scope. Each scope
+   * holds exactly one pool: setting it again replaces the previous one.
+   *
+   * @throws If the pool names an unregistered symbol id, or if it leaves
+   *   some reachable scope with nothing left to draw.
+   */
+  set(pool: SymbolPool | null, scope?: SymbolPoolScope): void;
+
+  /** Remove every pool. back to the weights the set was built with. */
+  clear(): void;
+
+  /**
+   * The weights the engine will actually draw from for a scope, excluded
+   * ids reported as `0`. For tests, debug overlays, and sanity checks.
+   */
+  weights(scope?: SymbolPoolScope): Record<string, number>;
+}

--- a/packages/pixi-reels/src/frame/SymbolPool.ts
+++ b/packages/pixi-reels/src/frame/SymbolPool.ts
@@ -19,22 +19,37 @@ export interface SymbolPool {
 }
 
 /**
+ * Which slots a pool applies to.
+ *
+ *   - `'spinning'` covers every random draw on the reel.
+ *   - `'buffer'` narrows the cells outside the visible window, both sides.
+ *   - `'bufferStart'` / `'bufferEnd'` narrow ONE side of the window.
+ *
+ * `bufferStart` is the side at the smaller main coordinate (above on a
+ * vertical set, left on a horizontal one) and `bufferEnd` the larger,
+ * whichever way the reel travels. Same ends `ColumnTarget.bufferStart` /
+ * `bufferEnd` address.
+ */
+export type SymbolPoolSlots = 'spinning' | 'buffer' | 'bufferStart' | 'bufferEnd';
+
+/**
  * Which draws a pool applies to.
  *
  * Layers resolve base -> global spinning -> per-reel spinning -> global
- * buffer -> per-reel buffer. Weights override per symbol id, exclusions
- * accumulate. So a `'buffer'` pool is always ON TOP of the spinning rules
- * for that reel: what the strip may not show while it scrolls, the buffer
- * may not show either.
+ * buffer -> per-reel buffer -> global side -> per-reel side, where "side" is
+ * whichever of `bufferStart` / `bufferEnd` the slot belongs to. Weights
+ * override per symbol id, exclusions accumulate.
+ *
+ * So each layer is always ON TOP of the wider ones: what the strip may not
+ * show while it scrolls, no buffer cell may show either, and what a
+ * `'buffer'` pool bans is banned on both sides regardless of what the
+ * side pools say.
  */
 export interface SymbolPoolScope {
   /** Restrict to one reel index. Omit to apply to every reel. */
   reel?: number;
-  /**
-   * `'spinning'` (default) covers every random draw on the reel.
-   * `'buffer'` narrows only the cells outside the visible window.
-   */
-  slots?: 'spinning' | 'buffer';
+  /** Which slots this pool governs. Defaults to `'spinning'`. */
+  slots?: SymbolPoolSlots;
 }
 
 /**
@@ -50,6 +65,10 @@ export interface SymbolPoolScope {
  *
  * // Nothing collectible may sit half-visible above or below the grid.
  * reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'buffer' });
+ *
+ * // Or one side of the window only: nothing peeks in from above, while
+ * // the cell below the grid is left alone.
+ * reelSet.randomSymbols.set({ exclude: ['COIN'] }, { slots: 'bufferStart' });
  *
  * // Drop one layer, or all of them.
  * reelSet.randomSymbols.set(null, { reel: 2 });
@@ -76,6 +95,10 @@ export interface RandomSymbolControl {
   /**
    * The weights the engine will actually draw from for a scope, excluded
    * ids reported as `0`. For tests, debug overlays, and sanity checks.
+   *
+   * `slots: 'buffer'` reports what BOTH sides inherit, before either side's
+   * own pool; ask for `'bufferStart'` / `'bufferEnd'` for the exact table a
+   * side draws from.
    */
   weights(scope?: SymbolPoolScope): Record<string, number>;
 }

--- a/packages/pixi-reels/src/index.ts
+++ b/packages/pixi-reels/src/index.ts
@@ -113,6 +113,11 @@ export { SpeedManager } from './speed/SpeedManager.js';
 export { FrameBuilder } from './frame/FrameBuilder.js';
 export type { FrameContext, FrameMiddleware } from './frame/FrameBuilder.js';
 export type { ColumnTarget } from './frame/ColumnTarget.js';
+export type {
+  RandomSymbolControl,
+  SymbolPool,
+  SymbolPoolScope,
+} from './frame/SymbolPool.js';
 export {
   cloneColumnTarget,
   columnTargetToStrip,

--- a/packages/pixi-reels/src/index.ts
+++ b/packages/pixi-reels/src/index.ts
@@ -117,6 +117,7 @@ export type {
   RandomSymbolControl,
   SymbolPool,
   SymbolPoolScope,
+  SymbolPoolSlots,
 } from './frame/SymbolPool.js';
 export {
   cloneColumnTarget,

--- a/packages/pixi-reels/tests/integration/symbolPools.test.ts
+++ b/packages/pixi-reels/tests/integration/symbolPools.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Symbol pools: what the engine is allowed to draw when it fills a cell the
+ * game did not name.
+ *
+ * Two questions a game has to be able to answer and could not before:
+ *   - "this symbol may spin, but it must never sit in the buffer cells
+ *     above and below the window" (`{ slots: 'buffer' }`), and
+ *   - "reel 3 draws from a different table than the rest" (`{ reel: 3 }`).
+ *
+ * Both are asserted through a real `ReelSet`, not the provider alone, so a
+ * call site that forgets to pass its reel index fails here.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Ticker } from 'pixi.js';
+import { ReelSetBuilder } from '../../src/core/ReelSetBuilder.js';
+import { createTestReelSet } from '../../src/testing/index.js';
+import { FakeTicker } from '../../src/testing/FakeTicker.js';
+import { HeadlessSymbol } from '../../src/testing/HeadlessSymbol.js';
+import type { Reel } from '../../src/core/Reel.js';
+
+const SYMBOLS = ['a', 'b', 'coin'];
+/** Everything random comes up 'coin' unless a pool forbids it. */
+const WEIGHTS = { a: 1, b: 1, coin: 5000 };
+
+function makeHarness() {
+  return createTestReelSet({
+    reels: 3,
+    visibleCells: 3,
+    symbolIds: SYMBOLS,
+    weights: WEIGHTS,
+    bufferSymbols: 2,
+  });
+}
+
+const bufferIds = (reel: Reel): string[] => {
+  const strip = reel.symbols.map((s) => s.symbolId);
+  const start = strip.slice(0, 2);
+  const end = strip.slice(strip.length - 2);
+  return [...start, ...end];
+};
+
+describe('buffer pools decide what may sit above and below the window', () => {
+  it('keeps an excluded symbol out of the buffers while leaving the strip alone', async () => {
+    const h = makeHarness();
+    try {
+      h.reelSet.randomSymbols.set({ exclude: ['coin'] }, { slots: 'buffer' });
+      // Land a grid with no explicit buffer targets, so every buffer cell is
+      // a random draw. Without the pool all of them come up 'coin'.
+      await h.spinAndLand([
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+      ]);
+
+      for (const reel of h.reelSet.reels) {
+        expect(bufferIds(reel)).not.toContain('coin');
+      }
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('still lets the game place that symbol in a buffer cell explicitly', async () => {
+    const h = makeHarness();
+    try {
+      h.reelSet.randomSymbols.set({ exclude: ['coin'] }, { slots: 'buffer' });
+      await h.spinAndLand([
+        { visible: ['a', 'a', 'a'], bufferStart: ['coin'] },
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+      ]);
+
+      // A pool governs the RANDOM draw. an explicit target is the game
+      // speaking, and it wins.
+      expect(h.reelSet.reels[0].symbols[1].symbolId).toBe('coin');
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('a buffer pool does not narrow the visible cells a skip random-fills', () => {
+    const h = makeHarness();
+    try {
+      h.reelSet.randomSymbols.set({ exclude: ['coin'] }, { slots: 'buffer' });
+      const reel = h.reelSet.reels[0];
+      // Undefined entries are random-filled by placeStrip: buffer slots
+      // follow the buffer pool, visible cells follow the spinning one.
+      reel.placeStrip([undefined, undefined, undefined, undefined, undefined, undefined, undefined]);
+
+      expect(bufferIds(reel)).not.toContain('coin');
+      expect(reel.getVisibleSymbols()).toEqual(['coin', 'coin', 'coin']);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('can be configured at build time, so even the initial strip obeys it', () => {
+    const set = new ReelSetBuilder()
+      .reels(2)
+      .visibleCells(3)
+      .symbolSize(120, 100)
+      .bufferSymbols(2)
+      .ticker(new FakeTicker() as unknown as Ticker)
+      .symbols((r) => {
+        for (const id of SYMBOLS) r.register(id, HeadlessSymbol, {});
+      })
+      .weights(WEIGHTS)
+      .randomSymbols({ exclude: ['coin'] }, { slots: 'buffer' })
+      .build();
+    try {
+      for (const reel of set.reels) {
+        expect(bufferIds(reel)).not.toContain('coin');
+        expect(reel.getVisibleSymbols()).toEqual(['coin', 'coin', 'coin']);
+      }
+    } finally {
+      set.destroy();
+    }
+  });
+});
+
+describe('per-reel pools narrow one reel without touching the others', () => {
+  it('excludes a symbol from the spinning strip of one reel only', async () => {
+    const h = makeHarness();
+    try {
+      h.reelSet.randomSymbols.set({ exclude: ['coin'] }, { reel: 1 });
+      await h.spinAndLand([
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+      ]);
+
+      // Reel 1's buffers inherit its spinning ban; its neighbours don't.
+      expect(bufferIds(h.reelSet.reels[1])).not.toContain('coin');
+      expect(bufferIds(h.reelSet.reels[0])).toContain('coin');
+      expect(bufferIds(h.reelSet.reels[2])).toContain('coin');
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('applies per-reel weights to the symbols that stream past mid-spin', () => {
+    const h = makeHarness();
+    try {
+      // Reel 0 draws 'a' only; every other reel keeps the coin-heavy table.
+      h.reelSet.randomSymbols.set({ weights: { coin: 0, b: 0 } }, { reel: 0 });
+
+      // The mid-spin refill happens on wrap, and the phase ramp that gets a
+      // reel there runs on gsap's own clock - which the FakeTicker does not
+      // drive. Drive the motion layer directly instead: the wrap callback is
+      // the code path under test, and this is the only way to see it before
+      // the stop sequencer takes over the feed.
+      for (const reel of h.reelSet.reels) {
+        reel.beginMotion();
+        const step = reel.motion.slotPitch * 0.45;
+        for (let i = 0; i < 60; i++) reel.motion.advance(step);
+      }
+
+      const spun = h.reelSet.reels[0].symbols.map((s) => s.symbolId);
+      expect(new Set(spun)).toEqual(new Set(['a']));
+      expect(h.reelSet.reels[2].symbols.map((s) => s.symbolId)).toContain('coin');
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('reports the effective table per scope so a game can assert its own config', () => {
+    const h = makeHarness();
+    try {
+      h.reelSet.randomSymbols.set({ exclude: ['coin'] }, { slots: 'buffer' });
+      h.reelSet.randomSymbols.set({ weights: { a: 99 } }, { reel: 2 });
+
+      expect(h.reelSet.randomSymbols.weights({ reel: 2 })).toEqual({
+        a: 99,
+        b: 1,
+        coin: 5000,
+      });
+      expect(h.reelSet.randomSymbols.weights({ reel: 2, slots: 'buffer' })).toEqual({
+        a: 99,
+        b: 1,
+        coin: 0,
+      });
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('clear() puts every reel back on the built-in weights', async () => {
+    const h = makeHarness();
+    try {
+      h.reelSet.randomSymbols.set({ exclude: ['coin'] });
+      h.reelSet.randomSymbols.clear();
+      await h.spinAndLand([
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+      ]);
+
+      expect(bufferIds(h.reelSet.reels[0])).toContain('coin');
+    } finally {
+      h.destroy();
+    }
+  });
+});

--- a/packages/pixi-reels/tests/integration/symbolPools.test.ts
+++ b/packages/pixi-reels/tests/integration/symbolPools.test.ts
@@ -32,12 +32,9 @@ function makeHarness() {
   });
 }
 
-const bufferIds = (reel: Reel): string[] => {
-  const strip = reel.symbols.map((s) => s.symbolId);
-  const start = strip.slice(0, 2);
-  const end = strip.slice(strip.length - 2);
-  return [...start, ...end];
-};
+const bufferIds = (reel: Reel): string[] => [...startIds(reel), ...endIds(reel)];
+const startIds = (reel: Reel): string[] => reel.symbols.slice(0, 2).map((s) => s.symbolId);
+const endIds = (reel: Reel): string[] => reel.symbols.slice(-2).map((s) => s.symbolId);
 
 describe('buffer pools decide what may sit above and below the window', () => {
   it('keeps an excluded symbol out of the buffers while leaving the strip alone', async () => {
@@ -112,6 +109,113 @@ describe('buffer pools decide what may sit above and below the window', () => {
         expect(bufferIds(reel)).not.toContain('coin');
         expect(reel.getVisibleSymbols()).toEqual(['coin', 'coin', 'coin']);
       }
+    } finally {
+      set.destroy();
+    }
+  });
+});
+
+describe('the two buffer ends can be controlled separately', () => {
+  it('keeps a symbol out of the cells above the window only', async () => {
+    const h = makeHarness();
+    try {
+      h.reelSet.randomSymbols.set({ exclude: ['coin'] }, { slots: 'bufferStart' });
+      await h.spinAndLand([
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+      ]);
+
+      for (const reel of h.reelSet.reels) {
+        expect(startIds(reel), `reel ${reel.reelIndex} start`).not.toContain('coin');
+      }
+      // The other end is untouched: on a coin-heavy table it still fills.
+      expect(h.reelSet.reels.flatMap((r) => endIds(r))).toContain('coin');
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('keeps a symbol out of the cells below the window only', async () => {
+    const h = makeHarness();
+    try {
+      h.reelSet.randomSymbols.set({ exclude: ['coin'] }, { slots: 'bufferEnd' });
+      await h.spinAndLand([
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+      ]);
+
+      for (const reel of h.reelSet.reels) {
+        expect(endIds(reel), `reel ${reel.reelIndex} end`).not.toContain('coin');
+      }
+      expect(h.reelSet.reels.flatMap((r) => startIds(r))).toContain('coin');
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('scopes one end of one reel', async () => {
+    const h = makeHarness();
+    try {
+      h.reelSet.randomSymbols.set({ exclude: ['coin'] }, { reel: 2, slots: 'bufferEnd' });
+      await h.spinAndLand([
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+        { visible: ['a', 'a', 'a'] },
+      ]);
+
+      expect(endIds(h.reelSet.reels[2])).not.toContain('coin');
+      expect(startIds(h.reelSet.reels[2])).toContain('coin');
+      expect(endIds(h.reelSet.reels[0])).toContain('coin');
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('applies the entering end when a nudge wraps symbols in', async () => {
+    const h = makeHarness();
+    try {
+      // On a vertical forward set, a 'forward' nudge feeds new cells in at
+      // the buffer-start end (`travelSign * polarity > 0`), so the padding
+      // the queue draws for the off-window slots is a bufferStart draw.
+      h.reelSet.randomSymbols.set({ exclude: ['coin'] }, { slots: 'bufferStart' });
+      await h.reelSet.nudge(0, { distance: 2, direction: 'forward', incoming: ['a', 'a'] });
+      expect(startIds(h.reelSet.reels[0])).not.toContain('coin');
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('applies the other end when the nudge feeds from there', async () => {
+    const h = makeHarness();
+    try {
+      h.reelSet.randomSymbols.set({ exclude: ['coin'] }, { slots: 'bufferEnd' });
+      await h.reelSet.nudge(0, { distance: 2, direction: 'reverse', incoming: ['a', 'a'] });
+      expect(endIds(h.reelSet.reels[0])).not.toContain('coin');
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('build-time form takes a side too', () => {
+    const set = new ReelSetBuilder()
+      .reels(2)
+      .visibleCells(3)
+      .symbolSize(120, 100)
+      .bufferSymbols(2)
+      .ticker(new FakeTicker() as unknown as Ticker)
+      .symbols((r) => {
+        for (const id of SYMBOLS) r.register(id, HeadlessSymbol, {});
+      })
+      .weights(WEIGHTS)
+      .randomSymbols({ exclude: ['coin'] }, { slots: 'bufferStart' })
+      .build();
+    try {
+      for (const reel of set.reels) {
+        expect(startIds(reel)).not.toContain('coin');
+      }
+      expect(set.reels.flatMap((r) => endIds(r))).toContain('coin');
     } finally {
       set.destroy();
     }

--- a/packages/pixi-reels/tests/integration/unmask.test.ts
+++ b/packages/pixi-reels/tests/integration/unmask.test.ts
@@ -389,3 +389,105 @@ describe('unmask through the cascade refill path', () => {
     }
   });
 });
+
+/**
+ * Regression: an `unmask` symbol that lands in a BUFFER slot must stay under
+ * the mask.
+ *
+ * `unmask` lifts a view out of the reel's masked container so it can render
+ * above the mask. That is a presentation for a symbol the player is looking
+ * at, i.e. a visible cell. The lift was decided from the symbol id alone, so
+ * any at-rest write to a buffer slot lifted it too - and a buffer slot is
+ * parked outside the window precisely because the mask should hide it. The
+ * result was a symbol hanging above or below the grid until the next spin
+ * pulled it back down.
+ *
+ * `StopPhase.onSkip` is the path that made it visible in a real game: the
+ * skip lands the full strip (buffers included) through `placeStrip`, and if
+ * the bounce has already started the reel is back at rest, so every buffered
+ * unmask symbol lifted.
+ */
+describe('unmask never lifts a buffer cell', () => {
+  const makeBufferHarness = () =>
+    createTestReelSet({
+      reels: 1,
+      visibleCells: 3,
+      symbolIds: SYMBOLS,
+      bufferSymbols: 2,
+      symbolData: { wild: { unmask: true } },
+    });
+
+  it('keeps a buffer-start / buffer-end wild masked when the strip is placed at rest', () => {
+    const h = makeBufferHarness();
+    try {
+      const reel = h.reelSet.reels[0];
+      reel.placeSymbols({
+        visible: ['a', 'a', 'a'],
+        bufferStart: ['wild'],
+        bufferEnd: ['wild'],
+      });
+
+      expect(reel.symbols[1].symbolId).toBe('wild');
+      expect(reel.symbols[1].view.parent).toBe(reel.container);
+      const last = reel.symbols.length - 1;
+      expect(reel.symbols[last - 1].symbolId).toBe('wild');
+      expect(reel.symbols[last - 1].view.parent).toBe(reel.container);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('still lifts the visible cells of that same at-rest placement', () => {
+    const h = makeBufferHarness();
+    try {
+      const reel = h.reelSet.reels[0];
+      reel.placeSymbols({ visible: ['a', 'wild', 'a'], bufferStart: ['wild'] });
+
+      expect(reel.getSymbolAt(1).view.parent).toBe(h.reelSet.viewport.unmaskedContainer);
+      expect(reel.symbols[1].view.parent).toBe(reel.container);
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('lands a skip during the bounce with the buffered wilds still masked', async () => {
+    const h = makeBufferHarness();
+    try {
+      // Land once so the reel is at rest with a lifted wild, exactly the
+      // state `onSkip` finds when the bounce has already begun.
+      await h.spinAndLand([{ visible: ['a', 'wild', 'a'] }]);
+      const reel = h.reelSet.reels[0];
+      expect(reel.getSymbolAt(1).view.parent).toBe(h.reelSet.viewport.unmaskedContainer);
+
+      // The skip path lands the FULL strip, buffers included.
+      reel.placeStrip(['wild', 'a', 'a', 'a', 'a', 'wild', 'wild']);
+
+      // Slots 0-1 and 5-6 are buffer; 2-4 are the window.
+      for (const i of [0, 1, 5, 6]) {
+        expect(reel.symbols[i].view.parent, `buffer slot ${i}`).toBe(reel.container);
+      }
+    } finally {
+      h.destroy();
+    }
+  });
+
+  it('re-masks a lifted wild that a nudge carried out of the window', async () => {
+    const h = makeBufferHarness();
+    try {
+      await h.spinAndLand([{ visible: ['wild', 'a', 'a'] }]);
+      const reel = h.reelSet.reels[0];
+      const wild = reel.getSymbolAt(0);
+      expect(wild.view.parent).toBe(h.reelSet.viewport.unmaskedContainer);
+
+      // Nudge backward by one: the lifted wild rotates from visible cell 0
+      // into the buffer above. Nothing replaces it, so only the settle can
+      // put it back under the mask.
+      await h.reelSet.nudge(0, { distance: 1, direction: 'reverse', incoming: ['b'] });
+
+      expect(reel.symbols[1].symbolId).toBe('wild');
+      expect(reel.symbols[1].view.parent).toBe(reel.container);
+    } finally {
+      h.destroy();
+    }
+  });
+});

--- a/packages/pixi-reels/tests/unit/RandomSymbolProvider.test.ts
+++ b/packages/pixi-reels/tests/unit/RandomSymbolProvider.test.ts
@@ -58,7 +58,7 @@ describe('RandomSymbolProvider', () => {
     provider.setExcludeBuffer(['b']);
 
     for (let i = 0; i < 50; i++) {
-      expect(provider.next(true)).toBe('a');
+      expect(provider.next('bufferStart')).toBe('a');
     }
   });
 
@@ -103,7 +103,7 @@ describe('RandomSymbolProvider', () => {
     });
     for (let i = 0; i < 500; i++) {
       expect(provider.next()).not.toBe('empty');
-      expect(provider.next(true)).not.toBe('empty');
+      expect(provider.next('bufferStart')).not.toBe('empty');
     }
   });
 
@@ -143,41 +143,41 @@ describe('RandomSymbolProvider symbol pools', () => {
 
   const draw = (
     provider: RandomSymbolProvider,
-    isBuffer: boolean,
+    slot: 'spinning' | 'bufferStart' | 'bufferEnd',
     reel?: number,
   ): Set<string> => {
     const seen = new Set<string>();
-    for (let i = 0; i < 300; i++) seen.add(provider.next(isBuffer, reel));
+    for (let i = 0; i < 300; i++) seen.add(provider.next(slot, reel));
     return seen;
   };
 
   it('a global pool excludes on every reel and in every slot', () => {
     const provider = make();
     provider.set({ exclude: ['coin'] });
-    expect(draw(provider, false, 0).has('coin')).toBe(false);
-    expect(draw(provider, false, 3).has('coin')).toBe(false);
-    expect(draw(provider, true, 3).has('coin')).toBe(false);
+    expect(draw(provider, 'spinning', 0).has('coin')).toBe(false);
+    expect(draw(provider, 'spinning', 3).has('coin')).toBe(false);
+    expect(draw(provider, 'bufferStart', 3).has('coin')).toBe(false);
   });
 
   it('a per-reel pool leaves the other reels alone', () => {
     const provider = make();
     provider.set({ exclude: ['coin'] }, { reel: 1 });
-    expect(draw(provider, false, 1).has('coin')).toBe(false);
-    expect(draw(provider, false, 0).has('coin')).toBe(true);
-    expect(draw(provider, false, undefined).has('coin')).toBe(true);
+    expect(draw(provider, 'spinning', 1).has('coin')).toBe(false);
+    expect(draw(provider, 'spinning', 0).has('coin')).toBe(true);
+    expect(draw(provider, 'spinning', undefined).has('coin')).toBe(true);
   });
 
   it('a buffer pool narrows the buffer cells but not the spinning strip', () => {
     const provider = make();
     provider.set({ exclude: ['coin'] }, { slots: 'buffer' });
-    expect(draw(provider, true, 0).has('coin')).toBe(false);
-    expect(draw(provider, false, 0).has('coin')).toBe(true);
+    expect(draw(provider, 'bufferStart', 0).has('coin')).toBe(false);
+    expect(draw(provider, 'spinning', 0).has('coin')).toBe(true);
   });
 
   it('weight 0 in a pool is as final as an exclusion', () => {
     const provider = make();
     provider.set({ weights: { coin: 0 } }, { reel: 2 });
-    expect(draw(provider, false, 2).has('coin')).toBe(false);
+    expect(draw(provider, 'spinning', 2).has('coin')).toBe(false);
     expect(provider.weights({ reel: 2 }).coin).toBe(0);
   });
 
@@ -188,8 +188,8 @@ describe('RandomSymbolProvider symbol pools', () => {
     let hotCoins = 0;
     let coldCoins = 0;
     for (let i = 0; i < 2000; i++) {
-      if (provider.next(false, 0) === 'coin') hotCoins++;
-      if (provider.next(false, 1) === 'coin') coldCoins++;
+      if (provider.next('spinning', 0) === 'coin') hotCoins++;
+      if (provider.next('spinning', 1) === 'coin') coldCoins++;
     }
     expect(hotCoins).toBeGreaterThan(1800);
     expect(coldCoins).toBeLessThan(900);
@@ -200,15 +200,15 @@ describe('RandomSymbolProvider symbol pools', () => {
     provider.set({ exclude: ['a'] });
     provider.set({ exclude: ['b'] }, { slots: 'buffer' });
     // Spinning: 'a' banned. Buffer: 'a' AND 'b' banned.
-    expect(draw(provider, false, 0)).toEqual(new Set(['b', 'coin']));
-    expect(draw(provider, true, 0)).toEqual(new Set(['coin']));
+    expect(draw(provider, 'spinning', 0)).toEqual(new Set(['b', 'coin']));
+    expect(draw(provider, 'bufferStart', 0)).toEqual(new Set(['coin']));
   });
 
   it('a narrower pool cannot re-admit what a wider one excluded', () => {
     const provider = make();
     provider.set({ exclude: ['coin'] });
     provider.set({ weights: { coin: 500 } }, { reel: 0 });
-    expect(draw(provider, false, 0).has('coin')).toBe(false);
+    expect(draw(provider, 'spinning', 0).has('coin')).toBe(false);
   });
 
   it('set(null) drops one layer and clear() drops them all', () => {
@@ -217,11 +217,11 @@ describe('RandomSymbolProvider symbol pools', () => {
     provider.set({ exclude: ['a'] }, { slots: 'buffer' });
 
     provider.set(null, { reel: 0 });
-    expect(draw(provider, false, 0).has('coin')).toBe(true);
-    expect(draw(provider, true, 0).has('a')).toBe(false);
+    expect(draw(provider, 'spinning', 0).has('coin')).toBe(true);
+    expect(draw(provider, 'bufferStart', 0).has('a')).toBe(false);
 
     provider.clear();
-    expect(draw(provider, true, 0).has('a')).toBe(true);
+    expect(draw(provider, 'bufferStart', 0).has('a')).toBe(true);
   });
 
   it('reports the effective weights it will draw from', () => {
@@ -246,7 +246,7 @@ describe('RandomSymbolProvider symbol pools', () => {
       /No symbol left to draw for spinning cells on reel 1/,
     );
     // The rejected pool must not have been installed.
-    expect(draw(provider, false, 1)).toEqual(new Set(['a', 'b']));
+    expect(draw(provider, 'spinning', 1)).toEqual(new Set(['a', 'b']));
   });
 
   it('throws when the buffer pool empties the buffer, naming the buffer scope', () => {
@@ -261,6 +261,71 @@ describe('RandomSymbolProvider symbol pools', () => {
     provider.set({ exclude: ['coin'] }, { reel: 0 });
     provider.updateWeights({ a: { weight: 10 }, b: { weight: 10 } });
     expect(provider.weights({ reel: 0 })).toEqual({ a: 10, b: 10 });
+  });
+
+  it('a bufferStart pool leaves the bufferEnd cells alone', () => {
+    const provider = make();
+    provider.set({ exclude: ['coin'] }, { slots: 'bufferStart' });
+    expect(draw(provider, 'bufferStart', 0).has('coin')).toBe(false);
+    expect(draw(provider, 'bufferEnd', 0).has('coin')).toBe(true);
+    expect(draw(provider, 'spinning', 0).has('coin')).toBe(true);
+  });
+
+  it('a bufferEnd pool leaves the bufferStart cells alone', () => {
+    const provider = make();
+    provider.set({ weights: { coin: 0 } }, { slots: 'bufferEnd' });
+    expect(draw(provider, 'bufferEnd', 0).has('coin')).toBe(false);
+    expect(draw(provider, 'bufferStart', 0).has('coin')).toBe(true);
+  });
+
+  it('scopes a side to one reel', () => {
+    const provider = make();
+    provider.set({ exclude: ['coin'] }, { reel: 1, slots: 'bufferStart' });
+    expect(draw(provider, 'bufferStart', 1).has('coin')).toBe(false);
+    expect(draw(provider, 'bufferEnd', 1).has('coin')).toBe(true);
+    expect(draw(provider, 'bufferStart', 0).has('coin')).toBe(true);
+  });
+
+  it('a both-sides buffer pool still covers each side', () => {
+    const provider = make();
+    provider.set({ exclude: ['coin'] }, { slots: 'buffer' });
+    expect(draw(provider, 'bufferStart', 0).has('coin')).toBe(false);
+    expect(draw(provider, 'bufferEnd', 0).has('coin')).toBe(false);
+  });
+
+  it('a side pool narrows what the both-sides pool already allows', () => {
+    const provider = make();
+    provider.set({ exclude: ['a'] }, { slots: 'buffer' });
+    provider.set({ exclude: ['b'] }, { slots: 'bufferEnd' });
+    expect(draw(provider, 'bufferStart', 0)).toEqual(new Set(['b', 'coin']));
+    expect(draw(provider, 'bufferEnd', 0)).toEqual(new Set(['coin']));
+  });
+
+  it('a side pool cannot re-admit what the both-sides pool excluded', () => {
+    const provider = make();
+    provider.set({ exclude: ['coin'] }, { slots: 'buffer' });
+    provider.set({ weights: { coin: 500 } }, { slots: 'bufferStart' });
+    expect(draw(provider, 'bufferStart', 0).has('coin')).toBe(false);
+  });
+
+  it('reports the table for a side, and what both sides inherit', () => {
+    const provider = make();
+    provider.set({ exclude: ['a'] }, { slots: 'buffer' });
+    provider.set({ weights: { b: 77 } }, { slots: 'bufferEnd' });
+
+    expect(provider.weights({ slots: 'buffer' })).toEqual({ a: 0, b: 10, coin: 10 });
+    expect(provider.weights({ slots: 'bufferStart' })).toEqual({ a: 0, b: 10, coin: 10 });
+    expect(provider.weights({ slots: 'bufferEnd' })).toEqual({ a: 0, b: 77, coin: 10 });
+  });
+
+  it('names the side that ran out of symbols', () => {
+    const provider = make();
+    expect(() => provider.set({ exclude: ['a', 'b', 'coin'] }, { slots: 'bufferEnd' })).toThrow(
+      /No symbol left to draw for buffer-end cells on every reel/,
+    );
+    expect(() =>
+      provider.set({ exclude: ['a', 'b', 'coin'] }, { reel: 2, slots: 'bufferStart' }),
+    ).toThrow(/No symbol left to draw for buffer-start cells on reel 2/);
   });
 
   it('legacy setExcludeBuffer keeps the global buffer weights it was given', () => {

--- a/packages/pixi-reels/tests/unit/RandomSymbolProvider.test.ts
+++ b/packages/pixi-reels/tests/unit/RandomSymbolProvider.test.ts
@@ -95,6 +95,18 @@ describe('RandomSymbolProvider', () => {
     expect(seqA).toEqual(seqB);
   });
 
+  it('never draws a symbol whose weight is 0', () => {
+    const provider = new RandomSymbolProvider({
+      a: { weight: 10 },
+      empty: { weight: 0 },
+      b: { weight: 10 },
+    });
+    for (let i = 0; i < 500; i++) {
+      expect(provider.next()).not.toBe('empty');
+      expect(provider.next(true)).not.toBe('empty');
+    }
+  });
+
   it('throws on empty symbol data', () => {
     expect(() => new RandomSymbolProvider({})).toThrow(/at least one symbol/);
   });
@@ -118,5 +130,143 @@ describe('RandomSymbolProvider', () => {
     provider.updateWeights({ a: { weight: 10 }, b: { weight: 10 } });
     provider.setExcludeSpinning(['a']);
     for (let i = 0; i < 20; i++) expect(provider.next()).toBe('b');
+  });
+});
+
+describe('RandomSymbolProvider symbol pools', () => {
+  const make = () =>
+    new RandomSymbolProvider({
+      a: { weight: 10 },
+      b: { weight: 10 },
+      coin: { weight: 10 },
+    });
+
+  const draw = (
+    provider: RandomSymbolProvider,
+    isBuffer: boolean,
+    reel?: number,
+  ): Set<string> => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 300; i++) seen.add(provider.next(isBuffer, reel));
+    return seen;
+  };
+
+  it('a global pool excludes on every reel and in every slot', () => {
+    const provider = make();
+    provider.set({ exclude: ['coin'] });
+    expect(draw(provider, false, 0).has('coin')).toBe(false);
+    expect(draw(provider, false, 3).has('coin')).toBe(false);
+    expect(draw(provider, true, 3).has('coin')).toBe(false);
+  });
+
+  it('a per-reel pool leaves the other reels alone', () => {
+    const provider = make();
+    provider.set({ exclude: ['coin'] }, { reel: 1 });
+    expect(draw(provider, false, 1).has('coin')).toBe(false);
+    expect(draw(provider, false, 0).has('coin')).toBe(true);
+    expect(draw(provider, false, undefined).has('coin')).toBe(true);
+  });
+
+  it('a buffer pool narrows the buffer cells but not the spinning strip', () => {
+    const provider = make();
+    provider.set({ exclude: ['coin'] }, { slots: 'buffer' });
+    expect(draw(provider, true, 0).has('coin')).toBe(false);
+    expect(draw(provider, false, 0).has('coin')).toBe(true);
+  });
+
+  it('weight 0 in a pool is as final as an exclusion', () => {
+    const provider = make();
+    provider.set({ weights: { coin: 0 } }, { reel: 2 });
+    expect(draw(provider, false, 2).has('coin')).toBe(false);
+    expect(provider.weights({ reel: 2 }).coin).toBe(0);
+  });
+
+  it('per-reel weights bias that reel only', () => {
+    const provider = make();
+    provider.set({ weights: { coin: 980 } }, { reel: 0 });
+
+    let hotCoins = 0;
+    let coldCoins = 0;
+    for (let i = 0; i < 2000; i++) {
+      if (provider.next(false, 0) === 'coin') hotCoins++;
+      if (provider.next(false, 1) === 'coin') coldCoins++;
+    }
+    expect(hotCoins).toBeGreaterThan(1800);
+    expect(coldCoins).toBeLessThan(900);
+  });
+
+  it('buffer pools stack on top of the spinning pools, they do not replace them', () => {
+    const provider = make();
+    provider.set({ exclude: ['a'] });
+    provider.set({ exclude: ['b'] }, { slots: 'buffer' });
+    // Spinning: 'a' banned. Buffer: 'a' AND 'b' banned.
+    expect(draw(provider, false, 0)).toEqual(new Set(['b', 'coin']));
+    expect(draw(provider, true, 0)).toEqual(new Set(['coin']));
+  });
+
+  it('a narrower pool cannot re-admit what a wider one excluded', () => {
+    const provider = make();
+    provider.set({ exclude: ['coin'] });
+    provider.set({ weights: { coin: 500 } }, { reel: 0 });
+    expect(draw(provider, false, 0).has('coin')).toBe(false);
+  });
+
+  it('set(null) drops one layer and clear() drops them all', () => {
+    const provider = make();
+    provider.set({ exclude: ['coin'] }, { reel: 0 });
+    provider.set({ exclude: ['a'] }, { slots: 'buffer' });
+
+    provider.set(null, { reel: 0 });
+    expect(draw(provider, false, 0).has('coin')).toBe(true);
+    expect(draw(provider, true, 0).has('a')).toBe(false);
+
+    provider.clear();
+    expect(draw(provider, true, 0).has('a')).toBe(true);
+  });
+
+  it('reports the effective weights it will draw from', () => {
+    const provider = make();
+    provider.set({ weights: { a: 1 } });
+    provider.set({ exclude: ['b'] }, { slots: 'buffer' });
+
+    expect(provider.weights()).toEqual({ a: 1, b: 10, coin: 10 });
+    expect(provider.weights({ slots: 'buffer' })).toEqual({ a: 1, b: 0, coin: 10 });
+  });
+
+  it('throws on an unregistered symbol id instead of silently doing nothing', () => {
+    const provider = make();
+    expect(() => provider.set({ exclude: ['coinn'] })).toThrow(/not registered/);
+    expect(() => provider.set({ weights: { nope: 5 } }, { reel: 1 })).toThrow(/not registered/);
+  });
+
+  it('throws when a pool leaves a scope with nothing to draw, and keeps the old pool', () => {
+    const provider = make();
+    provider.set({ exclude: ['coin'] });
+    expect(() => provider.set({ exclude: ['a', 'b', 'coin'] }, { reel: 1 })).toThrow(
+      /No symbol left to draw for spinning cells on reel 1/,
+    );
+    // The rejected pool must not have been installed.
+    expect(draw(provider, false, 1)).toEqual(new Set(['a', 'b']));
+  });
+
+  it('throws when the buffer pool empties the buffer, naming the buffer scope', () => {
+    const provider = make();
+    expect(() => provider.set({ exclude: ['a', 'b', 'coin'] }, { slots: 'buffer' })).toThrow(
+      /No symbol left to draw for buffer cells on every reel/,
+    );
+  });
+
+  it('drops pool entries for symbols a game-mode swap removed', () => {
+    const provider = make();
+    provider.set({ exclude: ['coin'] }, { reel: 0 });
+    provider.updateWeights({ a: { weight: 10 }, b: { weight: 10 } });
+    expect(provider.weights({ reel: 0 })).toEqual({ a: 10, b: 10 });
+  });
+
+  it('legacy setExcludeBuffer keeps the global buffer weights it was given', () => {
+    const provider = make();
+    provider.set({ weights: { a: 50 } }, { slots: 'buffer' });
+    provider.setExcludeBuffer(['coin']);
+    expect(provider.weights({ slots: 'buffer' })).toEqual({ a: 50, b: 10, coin: 0 });
   });
 });


### PR DESCRIPTION
## Summary

Adds **symbol pools**: control over what the engine may draw for the cells a game does not name — the strip streaming past mid-spin and the buffer cells parked either side of the window — scoped per reel and per end of the strip. Fixes an `unmask` bug the buffer work surfaced: an unmasked symbol landing in a buffer cell rendered *above* the mask, hanging outside the grid until the next spin.

## Changes

**Symbol pools** (`src/frame/SymbolPool.ts`, `src/frame/RandomSymbolProvider.ts`)

- `builder.randomSymbols(pool, scope)` and the runtime `reelSet.randomSymbols` (`{ set, clear, weights }`). A pool is `{ weights?, exclude? }`; a scope is `{ reel?, slots? }` where `slots` is `'spinning' | 'buffer' | 'bufferStart' | 'bufferEnd'`.
- Until now `weights()` was one table for the whole set and the only lever past it. `setExcludeSpinning` / `setExcludeBuffer` existed on `RandomSymbolProvider` but were unreachable from a built set (the provider is deliberately unexported and `Reel` keeps its reference private), so "keep this symbol out of the buffers" meant writing a `FrameMiddleware`, and "reel 3 draws differently" had no answer at all.
- Layers resolve base -> global spinning -> reel spinning -> global buffer -> reel buffer -> global side -> reel side. Weights override per id, exclusions accumulate, and a narrower layer can never re-admit what a wider one banned. Weight `0` bans as surely as `exclude`.
- Pools govern the RANDOM draw only; an explicit `setResult` / `initialFrame` target always wins.
- Two silent no-ops now fail loud: an unregistered symbol id in a pool throws with the registered ids listed, and a pool that leaves a reachable scope with nothing to draw throws at that call naming the scope (widest scope first) rather than mid-spin on whichever reel wraps first. The rejected pool is not installed.
- `RandomSymbolProvider.next` takes the slot by name instead of an `isBuffer` flag; every call site names the end it is filling, including the nudge queue (whichever end the wrap feeds from) and `reshape` (new tail cells are buffer-end). `Reel.placeStrip` now draws each empty slot from the pool that slot belongs to — it used to apply the buffer rules to visible cells too.
- `setExcludeSpinning` / `setExcludeBuffer` keep working as sugar over the global layers.

**Fix: `unmask` never lifts a buffer cell** (`src/core/Reel.ts`)

- The lift was decided from the symbol id alone, so any at-rest write to a buffer slot lifted it out of the masked container. `StopPhase.onSkip` lands the full strip through `placeStrip`, so a skip taken once the bounce had started (i.e. after `notifyLanded()` put the reel back at rest) lifted every unmask symbol the target frame had in `bufferStart` / `bufferEnd`, and they hung above and below the grid until the next spin. `reshape` growing a strip at rest did the same to its new tail cells.
- The lift now reads the slot. A second case needed the settle: a view lifted while VISIBLE can travel into a buffer slot without being replaced (a nudge rotates the array and only the wrapped symbol goes through `_replaceSymbol`), so `snapToGrid` re-masks any lifted view that ended up outside the window.

**Docs** — `randomSymbols` rows in the builder and ReelSet API tables, rewritten "Cells you skip" section in the buffer-indexing guide (it previously told readers to write a `FrameMiddleware` because "there is no separate buffer weighting"), a pools section in the symbols guide, and three live demos on `/recipes/symbols/`:

- `buffer-pool-exclude` — cycles no pool -> `{ reel: 1, slots: 'buffer' }` -> `{ slots: 'bufferStart' }` -> `{ slots: 'buffer' }` one step per spin, on a coin-heavy table, with a live readout of what each hidden cell actually holds.
- `per-reel-symbol-pool` — one `weights()` table with three pools over it: low cards only on reel 0, a wild reel on 2, no wild on 4.
- `unmask-stays-in-the-grid` — an oversized plate lifted in a visible cell beside the same id in a buffer cell, which the mask clips at the grid edge, through a skip as well.

## Test plan

- [x] `pnpm test` — 861 passing (27 new: pool layering, per-reel and per-side scoping, validation, plus four unmask regressions)
- [x] `pnpm typecheck` (library + fixtures), `pnpm check:lint` (incl. `check-api-surface`, `check-recipe-syntax`), `pnpm check:doc-links`
- [x] Both halves of the unmask fix proved by mutation: reverting the slot-aware lift reds three of the new tests, reverting the settle re-mask reds the fourth, and the twelve pre-existing unmask tests stay green through both
- [x] The three demos driven headlessly through Playwright against the real docs site, reading engine state after each click — no console errors:

```
BUFFER DEMO / mode off        : [["coin","coin"],["coin","coin"],["coin","coin"]]
BUFFER DEMO / mode reel 1 only: [["coin","coin"],["7","A"],["coin","coin"]]
BUFFER DEMO / mode above only : [["10","coin"],["Q","coin"],["K","coin"]]
BUFFER DEMO / mode every reel : [["K","9"],["Q","7"],["A","Q"]]
PER-REEL DEMO mid-spin        : reel0 all 7/8 - reel2 all wild - reel4 no wild
UNMASK DEMO at rest / + SKIP  : reel1 lifted=true, reel3 buffer lifted=false (both)
```

Not covered: `pnpm test:e2e` was not run (it builds and serves the static site); the demos were exercised against the dev server instead.

## Changeset

- [x] This PR ships user-visible changes in a publishable package and a `.changeset/*.md` file is included.

`symbol-pools.md` (minor) and `unmask-never-lifts-buffer-cells.md` (patch).

## Related issues

None filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
