### PR TITLE
fix(reels): reset animation pose on same-id refill

### DIFF
--- a/.changeset/same-id-refill-stops-animation.md
+++ b/.changeset/same-id-refill-stops-animation.md
@@ -1,0 +1,5 @@
+---
+"pixi-reels": patch
+---
+
+Reset the symbol's animation pose on a same-id refill. Reusing the instance without `deactivate()`/`activate()` left it parked on the final frame of its last one-shot win, so a refilled cell could hold a symbol and draw nothing.

--- a/packages/pixi-reels/src/core/Reel.ts
+++ b/packages/pixi-reels/src/core/Reel.ts
@@ -1911,6 +1911,18 @@ export class Reel implements Disposable {
     // container in case the pool moved it elsewhere since the last
     // activation (e.g. spotlight promotion above the mask).
     if (oldSymbol.symbolId === newSymbolId) {
+      // The instance is reused WITHOUT deactivate/activate, so nothing else
+      // resets its animation pose. A symbol that just played a one-shot win
+      // is still parked on that animation's final frame, and the reset below
+      // only touches `view` — anything the symbol class drives internally
+      // (a Spine skeleton, a nested container's alpha) stays where the win
+      // left it, so the refilled cell renders blank.
+      //
+      // `stopAnimation()` is the documented "spotlight is over, return to
+      // idle" hook, and `deactivate()`/`destroy()` already call it on paths
+      // that do go through the pool. This makes the same-id path agree with
+      // them.
+      oldSymbol.stopAnimation();
       oldSymbol.view.alpha = 1;
       oldSymbol.view.scale.set(1, 1);
       oldSymbol.view.rotation = 0;

--- a/packages/pixi-reels/tests/unit/sameIdRefillStopsAnimation.test.ts
+++ b/packages/pixi-reels/tests/unit/sameIdRefillStopsAnimation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { createTestReelSet } from '../../src/testing/index.js';
+import type { HeadlessSymbol } from '../../src/testing/HeadlessSymbol.js';
+
+/**
+ * A refill that lands the SAME symbol id a cell already holds takes the fast
+ * path in `Reel._replaceSymbol`: the instance is reused without
+ * `deactivate()` / `activate()`, so nothing resets its animation pose.
+ *
+ * That path resets `view.alpha`, `view.scale`, `view.rotation`, `view.filters`
+ * and `view.zIndex` -- everything the reel itself owns. It cannot reset what
+ * the symbol class drives internally, and after `playWin()` that is exactly
+ * where the leftover state lives: a Spine skeleton parked on the final frame
+ * of a one-shot win, or a nested container the class faded out itself.
+ *
+ * The visible result is a cell that holds a symbol but draws nothing. It only
+ * reproduces on a same-id refill, which is why it reads as "some symbols
+ * randomly vanish after a collapse".
+ *
+ * `stopAnimation()` is the documented "spotlight is over, return to idle"
+ * hook. `deactivate()` and `destroy()` already call it, so this makes the
+ * same-id path agree with every other path that hands a symbol back.
+ */
+describe('same-id refill returns the symbol to rest', () => {
+  it('calls stopAnimation when a cell is refilled with the same id', async () => {
+    const { reelSet, spinAndLand, destroy } = createTestReelSet({
+      reels: 1,
+      visibleCells: 3,
+      symbolIds: ['a'],
+    });
+
+    try {
+      const reel = reelSet.reels[0]!;
+      const before = reel.getSymbolAt(0) as HeadlessSymbol;
+
+      let stops = 0;
+      const original = before.stopAnimation.bind(before);
+      before.stopAnimation = () => {
+        stops += 1;
+        original();
+      };
+
+      await spinAndLand([{ visible: ['a', 'a', 'a'] }]);
+
+      // Fast path: the very same instance, never deactivated.
+      expect(reel.getSymbolAt(0)).toBe(before);
+      expect(stops).toBeGreaterThan(0);
+    } finally {
+      destroy();
+    }
+  });
+});


### PR DESCRIPTION
A refill that lands the **same symbol id a cell already holds** takes the fast path in `Reel._replaceSymbol`: the instance is reused without `deactivate()` / `activate()`, so nothing resets its animation pose.

That path resets `view.alpha`, `view.scale`, `view.rotation`, `view.filters` and `view.zIndex` — everything the reel itself owns. It cannot reset what the symbol class drives internally, and after `playWin()` that is exactly where the leftover state lives:

- a Spine skeleton parked on the final frame of a one-shot win (no `Idle` anim, or `winReturnToIdle: false`);
- a nested container the symbol class faded out itself.

The visible result is a cell that holds a symbol but draws nothing. It only reproduces on a same-id refill, so it reads as *"some symbols randomly vanish after a collapse"* — hard to pin down without knowing the fast path exists.

## The fix

`stopAnimation()` is the documented *"spotlight is over, return to idle"* hook, and `deactivate()` / `destroy()` already call it on paths that do go through the pool. This makes the same-id path agree with them.

## Testing

- New test `tests/unit/sameIdRefillStopsAnimation.test.ts` — asserts the instance is reused **and** returned to rest. Verified it fails without the fix and passes with it.
- Full suite: 107 files / 915 tests pass.
- Also verified in a shipping 7x7 cluster-pay game (sprite-based symbols): before the fix, cells refilled with the same id after a collapse rendered blank; after it, they do not.

Changeset included (patch).