### PR TITLE
feat(mask): outer-corner rounding per reel and per Hold & Win cell

### DIFF
--- a/.changeset/mask-outer-corners.md
+++ b/.changeset/mask-outer-corners.md
@@ -1,0 +1,5 @@
+---
+"pixi-reels": minor
+---
+
+Add: `RoundedRectMaskStrategy` gains `scope: 'outer'` (one rect per reel, only the corners that sit on the set's bounding box rounded, safe at a zero cross gap) and a `corners` option (`{ topLeft, topRight, bottomLeft, bottomRight }`, screen-space) that limits which corners round in any scope. `HoldAndWinBuilder.cellMask` and the `BoardGrid` `mask` option now hand the factory `(cell, { cols, rows, corners })`, where `corners` are the board corners that cell sits on, so `(_, { corners }) => new RoundedRectMaskStrategy({ radius, corners })` clips a gapless board as one rounded window with a separate rect mask per cell. Zero-argument factories keep working.

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -1,6 +1,6 @@
 # pixi-reels
 
-pixi-reels 2.4.0 is a reel engine for PixiJS v8.
+pixi-reels 2.5.0 is a reel engine for PixiJS v8.
 It ships reel-only primitives. Win math, paytable math, RNG, and audio live in consumer code.
 This file inlines every guide, API page, recipe (with source) and answered FAQ entry for offline LLM context.
 
@@ -504,6 +504,10 @@ Progressive slow-down across the tease sequence. Values interpolate linearly acr
 URL: https://pixi-reels.schmooky.dev/api/interfaces/index.BoardCell/
 A cell coordinate in the grid.
 
+### BoardCellMaskInfo
+URL: https://pixi-reels.schmooky.dev/api/interfaces/index.BoardCellMaskInfo/
+What a cell-mask factory is told about the cell it builds for.
+
 ### BoardGridOptions
 URL: https://pixi-reels.schmooky.dev/api/interfaces/index.BoardGridOptions/
 
@@ -624,6 +628,10 @@ Mask configuration for the reel viewport.
 ### MaskContext
 URL: https://pixi-reels.schmooky.dev/api/interfaces/index.MaskContext/
 Everything a mask strategy is given. Passed as one object so the axis cannot be forgotten, and so later additions do not break the signature.
+
+### MaskCorners
+URL: https://pixi-reels.schmooky.dev/api/interfaces/index.MaskCorners/
+Which corners of a box a [RoundedRectMaskStrategy](/api/classes/index.RoundedRectMaskStrategy/) may round. SCREEN corners in every orientation: `topLeft` is the top-left of the drawn rect on a horizon
 
 ### MaskStrategy
 URL: https://pixi-reels.schmooky.dev/api/interfaces/index.MaskStrategy/
@@ -972,7 +980,7 @@ URL: https://pixi-reels.schmooky.dev/api/types/index.ReelCurveInput/
 
 ### RoundedMaskScope
 URL: https://pixi-reels.schmooky.dev/api/types/index.RoundedMaskScope/
-```ts type RoundedMaskScope = "set" | "reel"; ```
+```ts type RoundedMaskScope = "set" | "reel" | "outer"; ```
 
 ### RunCascadeResult
 URL: https://pixi-reels.schmooky.dev/api/types/index.RunCascadeResult/
@@ -11388,6 +11396,145 @@ return {
 };
 ```
 
+### hold-and-win-outer-corners
+URL: https://pixi-reels.schmooky.dev/recipes/hold-and-win-outer-corners/
+```ts
+// @ts-nocheck
+// Injected: HoldAndWinBuilder, RoundedRectMaskStrategy, CloverSymbol, loadHwClover, CLOVER_SPEED, CLOVER_CELL, PIXI, gsap, app
+//
+// One rounded window, one mask per cell. Every Hold & Win cell is its own
+// 1x1 reel set with its own mask, and `cellMask` takes a FUNCTION: it is
+// called once per cell with the cell's column and row plus the board size,
+// and returns that cell's strategy. Here each cell clips to a plain rect -
+// except the four corner cells, each rounded on its single outer corner:
+// top-left for (0, 0), top-right for (4, 0), and so on. With no gap between
+// the cells the fifteen masks read as one rounded frame, cut on the same
+// radius as the panel drawn behind the board.
+
+const COLS = 5, ROWS = 3;
+const CELL = { width: CLOVER_CELL.width / 2, height: CLOVER_CELL.height / 2 }; // 101 x 85
+const RADIUS = 20;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const fmt = (v) => v.toFixed(2);
+const pick = (a) => a[Math.floor(Math.random() * a.length)];
+
+const art = await loadHwClover();
+
+const STRIP_VALUES = [1, 1, 1.5, 2, 2.5, 3, 5, 7, 10];
+class Clover extends CloverSymbol {
+  onActivate(id) {
+    super.onActivate(id);
+    if (id === 'gold') this.setLabel(fmt(pick(STRIP_VALUES)));
+  }
+}
+// The clover glow is drawn past the cell: lift landed coins above their cell's
+// mask (unmask), so only the strip in motion and the empty tiles are clipped.
+const UNMASK = Object.fromEntries(['gold', 'collect', 'multi', 'mystery', 'super', 'capsule'].map((id) => [id, { unmask: true }]));
+
+const board = new HoldAndWinBuilder()
+  .grid(COLS, ROWS)
+  // No gap: the cells butt together and the corner masks meet the panel edge.
+  .cellSize(CELL, { gap: 0 })
+  .symbols((r) => {
+    for (const id of ['gold', 'collect', 'multi', 'mystery', 'super', 'capsule', 'empty']) r.register(id, Clover, { art });
+  })
+  .weights({ gold: 2, collect: 0.6, multi: 0.6, mystery: 0.6, super: 0.4, capsule: 0.5, empty: 5 })
+  .symbolData(UNMASK)
+  .speedProfile(CLOVER_SPEED)
+  // One strategy per cell, decided from the cell's own column (`reel`) and
+  // row (`cell`) and the board size: a plain rect everywhere, one rounded
+  // corner on each of the four corner cells. `info.corners` carries this
+  // exact object precomputed, so `(_, { corners }) => new
+  // RoundedRectMaskStrategy({ radius, corners })` is the short form.
+  .cellMask(({ reel, cell }, { cols, rows }) => new RoundedRectMaskStrategy({
+    radius: RADIUS,
+    corners: {
+      topLeft: reel === 0 && cell === 0,
+      topRight: reel === cols - 1 && cell === 0,
+      bottomLeft: reel === 0 && cell === rows - 1,
+      bottomRight: reel === cols - 1 && cell === rows - 1,
+    },
+  }))
+  .respins(3)
+  .ticker(app.ticker)
+  .build();
+
+const boardW = COLS * CELL.width;
+const boardH = ROWS * CELL.height;
+board.container.position.set(Math.round((app.screen.width - boardW) / 2), Math.round((app.screen.height - boardH) / 2 - 8));
+
+// The frame: one rounded panel on the board's exact bounds, same radius as
+// the corner masks, plus a soft glow just outside it.
+const frame = new PIXI.Graphics();
+const { x: bx, y: by } = board.container;
+frame.roundRect(bx - 6, by - 6, boardW + 12, boardH + 12, RADIUS + 6).stroke({ color: 0x5fa0ff, width: 6, alpha: 0.25 });
+frame.roundRect(bx, by, boardW, boardH, RADIUS).fill({ color: 0x0b1a4a }).stroke({ color: 0x5fa0ff, width: 2, alpha: 0.95 });
+app.stage.addChild(frame);
+app.stage.addChild(board.container);
+
+// Trace every cell's own mask on top, faintly: fifteen rects, four of them
+// with one rounded corner. This is the shape the engine clips each cell to.
+const seams = new PIXI.Graphics();
+for (let reel = 0; reel < COLS; reel++) {
+  for (let cell = 0; cell < ROWS; cell++) {
+    const b = board.cellBounds({ reel, cell });
+    const r = (on) => (on ? RADIUS : 0);
+    seams.roundShape([
+      { x: b.x, y: b.y, radius: r(reel === 0 && cell === 0) },
+      { x: b.x + b.width, y: b.y, radius: r(reel === COLS - 1 && cell === 0) },
+      { x: b.x + b.width, y: b.y + b.height, radius: r(reel === COLS - 1 && cell === ROWS - 1) },
+      { x: b.x, y: b.y + b.height, radius: r(reel === 0 && cell === ROWS - 1) },
+    ], RADIUS).stroke({ color: 0x9cc8ff, width: 1, alpha: 0.35 });
+  }
+}
+seams.position.copyFrom(board.container.position);
+app.stage.addChild(seams);
+
+const hud = new PIXI.Text({
+  text: `gap 0 · radius ${RADIUS} · cellMask(({ reel, cell }, { cols, rows }) => strategy for that cell) · press spin`,
+  style: { fontFamily: 'system-ui, sans-serif', fontSize: 13, fontWeight: '600', fill: 0x9c8f78 },
+});
+hud.anchor.set(0.5, 0);
+hud.position.set(app.screen.width / 2, board.container.y + boardH + 24);
+app.stage.addChild(hud);
+
+board.events.on('cell:landed', ({ cell, coin }) => {
+  if (coin) board.symbolAt(cell).setLabel(fmt(coin.data.value));
+});
+
+const SEED = [
+  { cell: { reel: 0, cell: 0 }, id: 'gold', data: { value: 2 } },
+  { cell: { reel: 4, cell: 2 }, id: 'gold', data: { value: 5 } },
+];
+const ROUNDS = [[{ reel: 2, cell: 1 }, { reel: 4, cell: 0 }], [{ reel: 0, cell: 2 }], [], [], []];
+
+let busy = false;
+return {
+  cleanup: () => {
+    try { hud.destroy(); } catch {}
+    try { seams.destroy(); } catch {}
+    try { frame.destroy(); } catch {}
+    board.destroy();
+  },
+  onSpin: async () => {
+    if (busy) return;
+    busy = true;
+    board.reset();
+    board.enter(SEED);
+    for (const c of SEED) { const sym = board.symbolAt(c.cell); sym.setLabel(fmt(c.data.value)); sym.playIdle(); }
+    await sleep(350);
+    for (const cells of ROUNDS) {
+      const result = await board.respin(cells.map((cell) => ({ cell, id: 'gold', data: { value: pick(STRIP_VALUES) } })));
+      await sleep(400);
+      if (result.done) break;
+    }
+    const total = board.lockedCoins.reduce((a, c) => a + c.data.value, 0);
+    hud.text = `feature over · TOTAL ${fmt(total)} · press spin to replay`;
+    busy = false;
+  },
+};
+```
+
 ### hold-and-win-payer-coin
 URL: https://pixi-reels.schmooky.dev/recipes/hold-and-win-payer-coin/
 ```ts
@@ -13768,6 +13915,89 @@ return {
   cleanup: () => {
     drift.kill();
     try { banner.destroy({ children: true }); } catch {}
+    try { hud.destroy(); } catch {}
+  },
+  onSpin: async () => {
+    const grid = Array.from({ length: REELS }, () => ({ visible: [rv(), rv(), rv()] }));
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 380));
+    reelSet.setResult(grid);
+    await p;
+  },
+};
+```
+
+### mask-outer-corners
+URL: https://pixi-reels.schmooky.dev/recipes/mask-outer-corners/
+```ts
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, RoundedRectMaskStrategy,
+//                   CardSymbol, CARD_DECK, PIXI, app
+//
+// ONE RECT PER REEL, ONLY THE WINDOW'S CORNERS ROUNDED.
+//
+// `scope: 'outer'` keeps the default's one-rect-per-reel clipping (a short
+// reel never shows its buffer cells) and rounds a reel corner only where it
+// sits on a corner of the union box: the first reel's left pair, the last
+// reel's right pair, and nothing on the reels in between. Every inner edge
+// stays square, so unlike `scope: 'reel'` this is fine at cross gap 0 - the
+// reels butt together and the set reads as one rounded window.
+//
+// `corners` narrows it further to named SCREEN corners, in any scope. Set
+// CORNERS below to `{ topLeft: true }` and only that one corner rounds.
+
+const IDS = ['9', '10', 'J', 'Q', 'K'];
+const REELS = 5, ROWS = 3, SIZE = 80;
+const RADIUS = 22;
+// Which of the window's corners may round. `undefined` means all four.
+const CORNERS = undefined;
+const CARDS = CARD_DECK.filter((c) => IDS.includes(c.id));
+function rv() { return IDS[Math.floor(Math.random() * IDS.length)]; }
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS).visibleCells(ROWS).symbolSize(SIZE, SIZE)
+  // Zero gap on both axes: the reels touch, and 'outer' is built for that.
+  .symbolGap(0, 0)
+  .symbols((r) => {
+    for (const c of CARDS) {
+      r.register(c.id, CardSymbol, { color: c.color, label: c.label, textColor: c.textColor });
+    }
+  })
+  .maskStrategy(new RoundedRectMaskStrategy({ radius: RADIUS, scope: 'outer', corners: CORNERS }))
+  .speed('normal', { ...SpeedPresets.NORMAL, stopDelay: 150 })
+  .ticker(app.ticker)
+  .build();
+
+const W = REELS * SIZE, H = ROWS * SIZE;
+
+// The frame the mask is cut to match: one rounded window around the grid...
+const outline = new PIXI.Graphics();
+const rr = (on) => (on ? RADIUS : 0);
+const c = CORNERS ?? { topLeft: true, topRight: true, bottomLeft: true, bottomRight: true };
+outline.roundShape([
+  { x: 0, y: 0, radius: rr(c.topLeft) },
+  { x: W, y: 0, radius: rr(c.topRight) },
+  { x: W, y: H, radius: rr(c.bottomRight) },
+  { x: 0, y: H, radius: rr(c.bottomLeft) },
+], RADIUS).stroke({ width: 2, color: 0x6ad0ff, alpha: 0.85 });
+// ...and the seams between the reels' own rects, which stay straight.
+for (let i = 1; i < REELS; i++) {
+  outline.moveTo(i * SIZE, 0).lineTo(i * SIZE, H);
+}
+outline.stroke({ width: 1, color: 0x6ad0ff, alpha: 0.3 });
+reelSet.addChild(outline);
+
+const hud = new PIXI.Text({
+  text: `scope: 'outer', radius ${RADIUS}, gap 0  -  one rect per reel, seams square, window corners round`,
+  style: { fontFamily: "'Fira Code', ui-monospace, monospace", fontSize: 11, fill: 0x9c8f78 },
+});
+hud.position.set(0, H + 10);
+reelSet.addChild(hud);
+
+return {
+  reelSet,
+  cleanup: () => {
+    try { outline.destroy(); } catch {}
     try { hud.destroy(); } catch {}
   },
   onSpin: async () => {

--- a/apps/site/src/content/recipes/hold-and-win.mdx
+++ b/apps/site/src/content/recipes/hold-and-win.mdx
@@ -290,6 +290,14 @@ Real gaps between the cells (columnGap and rowGap) and no chrome, so the board i
 
 <RecipeDemo code="hold-and-win-clover-grid-bg" height={420} />
 
+<a id="hold-and-win-outer-corners"></a>
+
+## One rounded window, one mask per cell
+
+Every cell is its own reel set with its own mask, and cellMask takes a function called once per cell with its column and row plus the board size, returning that cell's strategy. Here every cell clips to a plain rect except the four corner cells, each rounded on its single outer corner through `RoundedRectMaskStrategy({ radius, corners })`; with no gap the fifteen masks read as one rounded frame, cut on the panel's own radius. The info argument also carries corners, that same per-cell object precomputed.
+
+<RecipeDemo code="hold-and-win-outer-corners" height={360} />
+
 <a id="hold-and-win-clover-speeds"></a>
 
 ## One speed switch for every cell

--- a/apps/site/src/content/recipes/masks.mdx
+++ b/apps/site/src/content/recipes/masks.mdx
@@ -20,6 +20,7 @@ The viewport clips the reels through a `MaskStrategy` so buffer cells never leak
 | Rounded frame, reels flush | `RoundedRectMaskStrategy` (`scope: 'set'`) |
 | Reels as separate cards, with a cross gap | `RoundedRectMaskStrategy` (`scope: 'reel'`) |
 | Rounded frame, one rect per reel, any gap | `RoundedRectMaskStrategy` (`scope: 'outer'`) |
+| Hold & Win board, a mask per cell | `cellMask((cell, { corners }) => ...)` |
 | Pyramid / MultiWays, rounded, reels flush | `SilhouetteMaskStrategy` |
 | Hexes, holes, cut-outs | `PathMaskStrategy` |
 
@@ -50,6 +51,14 @@ The viewport clips the reels through a `MaskStrategy` so buffer cells never leak
 **Gotcha:** on a jagged set the box corners may touch no reel, and then nothing rounds. Use `SilhouetteMaskStrategy` there.
 
 <RecipeDemo code="mask-outer-corners" />
+
+<a id="mask-hold-and-win-cells"></a>
+
+## A mask per Hold & Win cell, from its row and column
+
+Every Hold & Win cell is its own 1x1 reel set with its own mask, and `cellMask` takes a function called once per cell with `{ reel, cell }` (column, row) and `{ cols, rows, corners }`. Return any strategy per cell: here a plain rect everywhere and one rounded corner on each of the four corner cells, so a gapless board clips as one rounded window built from fifteen masks. `corners` is that per-cell corner set precomputed, for the short form `(_, { corners }) => new RoundedRectMaskStrategy({ radius, corners })`.
+
+<RecipeDemo code="hold-and-win-outer-corners" height={360} />
 
 <a id="mask-silhouette"></a>
 

--- a/apps/site/src/content/recipes/masks.mdx
+++ b/apps/site/src/content/recipes/masks.mdx
@@ -19,6 +19,7 @@ The viewport clips the reels through a `MaskStrategy` so buffer cells never leak
 | Square frame art | `RectMaskStrategy` (default) |
 | Rounded frame, reels flush | `RoundedRectMaskStrategy` (`scope: 'set'`) |
 | Reels as separate cards, with a cross gap | `RoundedRectMaskStrategy` (`scope: 'reel'`) |
+| Rounded frame, one rect per reel, any gap | `RoundedRectMaskStrategy` (`scope: 'outer'`) |
 | Pyramid / MultiWays, rounded, reels flush | `SilhouetteMaskStrategy` |
 | Hexes, holes, cut-outs | `PathMaskStrategy` |
 
@@ -39,6 +40,16 @@ The viewport clips the reels through a `MaskStrategy` so buffer cells never leak
 **Gotcha:** needs a non-zero CROSS gap. At gap `0` neighbours share an edge and rounding both sides of it notches every seam. The strategy warns once.
 
 <RecipeDemo code="mask-rounded-reels" />
+
+<a id="mask-outer-corners"></a>
+
+## One rect per reel, the window's corners only
+
+`scope: 'outer'` keeps one rect per reel, so buffer cells past a short reel stay hidden as with the default, and rounds a corner only where it sits on a corner of the union box: the first reel's outer pair, the last reel's outer pair, nothing in between. Inner edges stay square, so it is fine at cross gap `0`, where `scope: 'reel'` notches. `corners: { topLeft: true, ... }` narrows any scope to named screen corners.
+
+**Gotcha:** on a jagged set the box corners may touch no reel, and then nothing rounds. Use `SilhouetteMaskStrategy` there.
+
+<RecipeDemo code="mask-outer-corners" />
 
 <a id="mask-silhouette"></a>
 

--- a/apps/site/src/recipes/hold-and-win-outer-corners.recipe.ts
+++ b/apps/site/src/recipes/hold-and-win-outer-corners.recipe.ts
@@ -1,0 +1,134 @@
+// @ts-nocheck
+// Injected: HoldAndWinBuilder, RoundedRectMaskStrategy, CloverSymbol, loadHwClover, CLOVER_SPEED, CLOVER_CELL, PIXI, gsap, app
+//
+// One rounded window, one mask per cell. Every Hold & Win cell is its own
+// 1x1 reel set with its own mask, and `cellMask` takes a FUNCTION: it is
+// called once per cell with the cell's column and row plus the board size,
+// and returns that cell's strategy. Here each cell clips to a plain rect -
+// except the four corner cells, each rounded on its single outer corner:
+// top-left for (0, 0), top-right for (4, 0), and so on. With no gap between
+// the cells the fifteen masks read as one rounded frame, cut on the same
+// radius as the panel drawn behind the board.
+
+const COLS = 5, ROWS = 3;
+const CELL = { width: CLOVER_CELL.width / 2, height: CLOVER_CELL.height / 2 }; // 101 x 85
+const RADIUS = 20;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const fmt = (v) => v.toFixed(2);
+const pick = (a) => a[Math.floor(Math.random() * a.length)];
+
+const art = await loadHwClover();
+
+const STRIP_VALUES = [1, 1, 1.5, 2, 2.5, 3, 5, 7, 10];
+class Clover extends CloverSymbol {
+  onActivate(id) {
+    super.onActivate(id);
+    if (id === 'gold') this.setLabel(fmt(pick(STRIP_VALUES)));
+  }
+}
+// The clover glow is drawn past the cell: lift landed coins above their cell's
+// mask (unmask), so only the strip in motion and the empty tiles are clipped.
+const UNMASK = Object.fromEntries(['gold', 'collect', 'multi', 'mystery', 'super', 'capsule'].map((id) => [id, { unmask: true }]));
+
+const board = new HoldAndWinBuilder()
+  .grid(COLS, ROWS)
+  // No gap: the cells butt together and the corner masks meet the panel edge.
+  .cellSize(CELL, { gap: 0 })
+  .symbols((r) => {
+    for (const id of ['gold', 'collect', 'multi', 'mystery', 'super', 'capsule', 'empty']) r.register(id, Clover, { art });
+  })
+  .weights({ gold: 2, collect: 0.6, multi: 0.6, mystery: 0.6, super: 0.4, capsule: 0.5, empty: 5 })
+  .symbolData(UNMASK)
+  .speedProfile(CLOVER_SPEED)
+  // One strategy per cell, decided from the cell's own column (`reel`) and
+  // row (`cell`) and the board size: a plain rect everywhere, one rounded
+  // corner on each of the four corner cells. `info.corners` carries this
+  // exact object precomputed, so `(_, { corners }) => new
+  // RoundedRectMaskStrategy({ radius, corners })` is the short form.
+  .cellMask(({ reel, cell }, { cols, rows }) => new RoundedRectMaskStrategy({
+    radius: RADIUS,
+    corners: {
+      topLeft: reel === 0 && cell === 0,
+      topRight: reel === cols - 1 && cell === 0,
+      bottomLeft: reel === 0 && cell === rows - 1,
+      bottomRight: reel === cols - 1 && cell === rows - 1,
+    },
+  }))
+  .respins(3)
+  .ticker(app.ticker)
+  .build();
+
+const boardW = COLS * CELL.width;
+const boardH = ROWS * CELL.height;
+board.container.position.set(Math.round((app.screen.width - boardW) / 2), Math.round((app.screen.height - boardH) / 2 - 8));
+
+// The frame: one rounded panel on the board's exact bounds, same radius as
+// the corner masks, plus a soft glow just outside it.
+const frame = new PIXI.Graphics();
+const { x: bx, y: by } = board.container;
+frame.roundRect(bx - 6, by - 6, boardW + 12, boardH + 12, RADIUS + 6).stroke({ color: 0x5fa0ff, width: 6, alpha: 0.25 });
+frame.roundRect(bx, by, boardW, boardH, RADIUS).fill({ color: 0x0b1a4a }).stroke({ color: 0x5fa0ff, width: 2, alpha: 0.95 });
+app.stage.addChild(frame);
+app.stage.addChild(board.container);
+
+// Trace every cell's own mask on top, faintly: fifteen rects, four of them
+// with one rounded corner. This is the shape the engine clips each cell to.
+const seams = new PIXI.Graphics();
+for (let reel = 0; reel < COLS; reel++) {
+  for (let cell = 0; cell < ROWS; cell++) {
+    const b = board.cellBounds({ reel, cell });
+    const r = (on) => (on ? RADIUS : 0);
+    seams.roundShape([
+      { x: b.x, y: b.y, radius: r(reel === 0 && cell === 0) },
+      { x: b.x + b.width, y: b.y, radius: r(reel === COLS - 1 && cell === 0) },
+      { x: b.x + b.width, y: b.y + b.height, radius: r(reel === COLS - 1 && cell === ROWS - 1) },
+      { x: b.x, y: b.y + b.height, radius: r(reel === 0 && cell === ROWS - 1) },
+    ], RADIUS).stroke({ color: 0x9cc8ff, width: 1, alpha: 0.35 });
+  }
+}
+seams.position.copyFrom(board.container.position);
+app.stage.addChild(seams);
+
+const hud = new PIXI.Text({
+  text: `gap 0 · radius ${RADIUS} · cellMask(({ reel, cell }, { cols, rows }) => strategy for that cell) · press spin`,
+  style: { fontFamily: 'system-ui, sans-serif', fontSize: 13, fontWeight: '600', fill: 0x9c8f78 },
+});
+hud.anchor.set(0.5, 0);
+hud.position.set(app.screen.width / 2, board.container.y + boardH + 24);
+app.stage.addChild(hud);
+
+board.events.on('cell:landed', ({ cell, coin }) => {
+  if (coin) board.symbolAt(cell).setLabel(fmt(coin.data.value));
+});
+
+const SEED = [
+  { cell: { reel: 0, cell: 0 }, id: 'gold', data: { value: 2 } },
+  { cell: { reel: 4, cell: 2 }, id: 'gold', data: { value: 5 } },
+];
+const ROUNDS = [[{ reel: 2, cell: 1 }, { reel: 4, cell: 0 }], [{ reel: 0, cell: 2 }], [], [], []];
+
+let busy = false;
+return {
+  cleanup: () => {
+    try { hud.destroy(); } catch {}
+    try { seams.destroy(); } catch {}
+    try { frame.destroy(); } catch {}
+    board.destroy();
+  },
+  onSpin: async () => {
+    if (busy) return;
+    busy = true;
+    board.reset();
+    board.enter(SEED);
+    for (const c of SEED) { const sym = board.symbolAt(c.cell); sym.setLabel(fmt(c.data.value)); sym.playIdle(); }
+    await sleep(350);
+    for (const cells of ROUNDS) {
+      const result = await board.respin(cells.map((cell) => ({ cell, id: 'gold', data: { value: pick(STRIP_VALUES) } })));
+      await sleep(400);
+      if (result.done) break;
+    }
+    const total = board.lockedCoins.reduce((a, c) => a + c.data.value, 0);
+    hud.text = `feature over · TOTAL ${fmt(total)} · press spin to replay`;
+    busy = false;
+  },
+};

--- a/apps/site/src/recipes/mask-outer-corners.recipe.ts
+++ b/apps/site/src/recipes/mask-outer-corners.recipe.ts
@@ -1,0 +1,78 @@
+// @ts-nocheck
+// Injected globals: ReelSetBuilder, SpeedPresets, RoundedRectMaskStrategy,
+//                   CardSymbol, CARD_DECK, PIXI, app
+//
+// ONE RECT PER REEL, ONLY THE WINDOW'S CORNERS ROUNDED.
+//
+// `scope: 'outer'` keeps the default's one-rect-per-reel clipping (a short
+// reel never shows its buffer cells) and rounds a reel corner only where it
+// sits on a corner of the union box: the first reel's left pair, the last
+// reel's right pair, and nothing on the reels in between. Every inner edge
+// stays square, so unlike `scope: 'reel'` this is fine at cross gap 0 - the
+// reels butt together and the set reads as one rounded window.
+//
+// `corners` narrows it further to named SCREEN corners, in any scope. Set
+// CORNERS below to `{ topLeft: true }` and only that one corner rounds.
+
+const IDS = ['9', '10', 'J', 'Q', 'K'];
+const REELS = 5, ROWS = 3, SIZE = 80;
+const RADIUS = 22;
+// Which of the window's corners may round. `undefined` means all four.
+const CORNERS = undefined;
+const CARDS = CARD_DECK.filter((c) => IDS.includes(c.id));
+function rv() { return IDS[Math.floor(Math.random() * IDS.length)]; }
+
+const reelSet = new ReelSetBuilder()
+  .reels(REELS).visibleCells(ROWS).symbolSize(SIZE, SIZE)
+  // Zero gap on both axes: the reels touch, and 'outer' is built for that.
+  .symbolGap(0, 0)
+  .symbols((r) => {
+    for (const c of CARDS) {
+      r.register(c.id, CardSymbol, { color: c.color, label: c.label, textColor: c.textColor });
+    }
+  })
+  .maskStrategy(new RoundedRectMaskStrategy({ radius: RADIUS, scope: 'outer', corners: CORNERS }))
+  .speed('normal', { ...SpeedPresets.NORMAL, stopDelay: 150 })
+  .ticker(app.ticker)
+  .build();
+
+const W = REELS * SIZE, H = ROWS * SIZE;
+
+// The frame the mask is cut to match: one rounded window around the grid...
+const outline = new PIXI.Graphics();
+const rr = (on) => (on ? RADIUS : 0);
+const c = CORNERS ?? { topLeft: true, topRight: true, bottomLeft: true, bottomRight: true };
+outline.roundShape([
+  { x: 0, y: 0, radius: rr(c.topLeft) },
+  { x: W, y: 0, radius: rr(c.topRight) },
+  { x: W, y: H, radius: rr(c.bottomRight) },
+  { x: 0, y: H, radius: rr(c.bottomLeft) },
+], RADIUS).stroke({ width: 2, color: 0x6ad0ff, alpha: 0.85 });
+// ...and the seams between the reels' own rects, which stay straight.
+for (let i = 1; i < REELS; i++) {
+  outline.moveTo(i * SIZE, 0).lineTo(i * SIZE, H);
+}
+outline.stroke({ width: 1, color: 0x6ad0ff, alpha: 0.3 });
+reelSet.addChild(outline);
+
+const hud = new PIXI.Text({
+  text: `scope: 'outer', radius ${RADIUS}, gap 0  -  one rect per reel, seams square, window corners round`,
+  style: { fontFamily: "'Fira Code', ui-monospace, monospace", fontSize: 11, fill: 0x9c8f78 },
+});
+hud.position.set(0, H + 10);
+reelSet.addChild(hud);
+
+return {
+  reelSet,
+  cleanup: () => {
+    try { outline.destroy(); } catch {}
+    try { hud.destroy(); } catch {}
+  },
+  onSpin: async () => {
+    const grid = Array.from({ length: REELS }, () => ({ visible: [rv(), rv(), rv()] }));
+    const p = reelSet.spin();
+    await new Promise((r) => setTimeout(r, 380));
+    reelSet.setResult(grid);
+    await p;
+  },
+};

--- a/packages/pixi-reels/src/board/BoardGrid.ts
+++ b/packages/pixi-reels/src/board/BoardGrid.ts
@@ -5,6 +5,7 @@ import type { Direction, Orientation } from '../core/ReelAxis.js';
 import type { ReelSet } from '../core/ReelSet.js';
 import { SharedRectMaskStrategy } from '../core/ReelViewport.js';
 import type { MaskStrategy } from '../core/ReelViewport.js';
+import type { MaskCorners } from '../core/maskStrategies.js';
 import type { ReelSymbol } from '../symbols/ReelSymbol.js';
 import type { SymbolRegistry } from '../symbols/SymbolRegistry.js';
 import { EmptySymbol } from '../symbols/EmptySymbol.js';
@@ -22,6 +23,19 @@ export interface BoardCell {
 export interface BoardSpinTarget {
   cell: BoardCell;
   id: string;
+}
+
+/** What a cell-mask factory is told about the cell it builds for. */
+export interface BoardCellMaskInfo {
+  cols: number;
+  rows: number;
+  /**
+   * The BOARD corners this cell sits on: `{ topLeft: true }` and the rest
+   * `false` for cell `(0, 0)`, all `false` for an inner cell. Hand it to
+   * `RoundedRectMaskStrategy` as `corners` and the board reads as one rounded
+   * window built from one rect per cell.
+   */
+  corners: MaskCorners;
 }
 
 /** A speed profile, or a per-cell function of one (e.g. a stagger wave). */
@@ -61,9 +75,12 @@ export interface BoardGridOptions {
    * Mask for each cell, built once per cell (every cell is its own reel set
    * and owns its mask). Default: a shared rect over the cell. Hand it
    * `() => new RoundedRectMaskStrategy({ radius })` for cells whose art and
-   * frame have rounded corners.
+   * frame have rounded corners. The factory is told which cell it builds for
+   * and which board corners that cell sits on, so
+   * `(_, { corners }) => new RoundedRectMaskStrategy({ radius, corners })`
+   * rounds only the board's outer corners and keeps every other cell square.
    */
-  mask?: () => MaskStrategy;
+  mask?: (cell: BoardCell, info: BoardCellMaskInfo) => MaskStrategy;
   /**
    * Which way each cell's own strip travels while it spins. Every cell is a
    * 1x1 reel set, so this changes the direction a symbol scrolls in from, not
@@ -80,6 +97,20 @@ export interface BoardGridOptions {
    * profile, which is the active one until you `setProfile` otherwise.
    */
   profiles?: Record<string, BoardProfile>;
+}
+
+/** Which of the board's four screen corners `cell` sits on. */
+function boardCorners(cell: BoardCell, cols: number, rows: number): MaskCorners {
+  const left = cell.reel === 0;
+  const right = cell.reel === cols - 1;
+  const top = cell.cell === 0;
+  const bottom = cell.cell === rows - 1;
+  return {
+    topLeft: left && top,
+    topRight: right && top,
+    bottomLeft: left && bottom,
+    bottomRight: right && bottom,
+  };
 }
 
 const key = (c: BoardCell): string => `${c.reel},${c.cell}`;
@@ -186,7 +217,11 @@ export class BoardGrid implements Disposable {
           .symbolGap(0, 0)
           // Spine symbols overrun the default per-reel rect mask; a shared rect
           // keeps buffer-cell art from painting over neighbouring cells.
-          .maskStrategy(opts.mask ? opts.mask() : new SharedRectMaskStrategy())
+          .maskStrategy(
+            opts.mask
+              ? opts.mask(cell, { cols: opts.cols, rows: opts.rows, corners: boardCorners(cell, opts.cols, opts.rows) })
+              : new SharedRectMaskStrategy(),
+          )
           .symbols((registry) => {
             opts.symbols(registry);
             if (!registry.has(this.emptyId)) registry.register(this.emptyId, EmptySymbol, {});

--- a/packages/pixi-reels/src/board/HoldAndWinBoard.ts
+++ b/packages/pixi-reels/src/board/HoldAndWinBoard.ts
@@ -6,7 +6,7 @@ import type { SymbolRegistry } from '../symbols/SymbolRegistry.js';
 import type { SpeedProfile, SymbolData } from '../config/types.js';
 import type { Disposable } from '../utils/Disposable.js';
 import { BoardGrid } from './BoardGrid.js';
-import type { BoardProfile } from './BoardGrid.js';
+import type { BoardCellMaskInfo, BoardProfile } from './BoardGrid.js';
 import type { Direction, Orientation } from '../core/ReelAxis.js';
 import type { MaskStrategy } from '../core/ReelViewport.js';
 import { HoldAndWinState } from './HoldAndWinState.js';
@@ -49,7 +49,7 @@ export interface HoldAndWinBoardConfig<TData> {
     | null;
   chrome: ((g: Graphics, width: number, height: number) => void) | null;
   /** Per-cell mask factory. See `HoldAndWinBuilder.cellMask`. */
-  mask: (() => MaskStrategy) | null;
+  mask: ((cell: HwCell, info: BoardCellMaskInfo) => MaskStrategy) | null;
   /** Travel axis for each cell's own strip. See `HoldAndWinBuilder.axis`. */
   orientation?: Orientation;
   direction?: Direction;

--- a/packages/pixi-reels/src/board/HoldAndWinBuilder.ts
+++ b/packages/pixi-reels/src/board/HoldAndWinBuilder.ts
@@ -5,6 +5,7 @@ import type { SymbolRegistry } from '../symbols/SymbolRegistry.js';
 import { HoldAndWinBoard } from './HoldAndWinBoard.js';
 import type { Direction, Orientation } from '../core/ReelAxis.js';
 import type { MaskStrategy } from '../core/ReelViewport.js';
+import type { BoardCellMaskInfo } from './BoardGrid.js';
 import type { HwCell, HwCellSizeOptions, HwLockAnimation } from './HwTypes.js';
 
 /**
@@ -40,7 +41,7 @@ export class HoldAndWinBuilder<TData = unknown> {
     | ((state: { locked: number; capacity: number; respinsLeft: number }) => boolean)
     | null = null;
   private _chrome: ((g: Graphics, width: number, height: number) => void) | null = null;
-  private _mask: (() => MaskStrategy) | null = null;
+  private _mask: ((cell: HwCell, info: BoardCellMaskInfo) => MaskStrategy) | null = null;
   private _orientation: Orientation = 'vertical';
   private _direction: Direction = 'forward';
   private _ticker: Ticker | null = null;
@@ -206,8 +207,16 @@ export class HoldAndWinBuilder<TData = unknown> {
    * Mask for each cell, built once per cell. Default: a shared rect over the
    * cell. `() => new RoundedRectMaskStrategy({ radius: 8 })` rounds every
    * cell's corners to match a rounded frame drawn behind the board.
+   *
+   * The factory receives the cell and the board corners it sits on, so a
+   * board framed as ONE rounded window keeps every cell a plain rect except
+   * the four corner cells, each rounded on its outer corner only:
+   *
+   * ```ts
+   * .cellMask((_, { corners }) => new RoundedRectMaskStrategy({ radius: 18, corners }))
+   * ```
    */
-  cellMask(factory: () => MaskStrategy): this {
+  cellMask(factory: (cell: HwCell, info: BoardCellMaskInfo) => MaskStrategy): this {
     this._mask = factory;
     return this;
   }

--- a/packages/pixi-reels/src/core/maskStrategies.ts
+++ b/packages/pixi-reels/src/core/maskStrategies.ts
@@ -84,13 +84,126 @@ export type RoundedMaskScope =
    * bites a lens-shaped notch out of the seam. The strategy warns once when
    * it sees touching rects.
    */
-  | 'reel';
+  | 'reel'
+  /**
+   * One rect per reel, like `'reel'`, but a reel corner is rounded only when
+   * it sits on a corner of the union bounding box: the first reel's outer
+   * pair, the last reel's outer pair, nothing in between. Inner edges stay
+   * square, so the seams never notch and a zero cross gap is fine - the set
+   * reads as one rounded window while every reel keeps its own rect.
+   *
+   * On a jagged set the box corners may touch no reel at all, in which case
+   * nothing rounds; use {@link SilhouetteMaskStrategy} there.
+   */
+  | 'outer';
+
+/**
+ * Which corners of a box a {@link RoundedRectMaskStrategy} may round.
+ * SCREEN corners in every orientation: `topLeft` is the top-left of the drawn
+ * rect on a horizontal set too. Only the keys set to `true` round; `{}`
+ * rounds nothing. Absent (`undefined`) means all four.
+ */
+export interface MaskCorners {
+  topLeft?: boolean;
+  topRight?: boolean;
+  bottomLeft?: boolean;
+  bottomRight?: boolean;
+}
 
 export interface RoundedRectMaskOptions {
   /** Corner radius in pixels. Pixi clamps it per corner to half the shorter adjacent edge. */
   radius: number;
   /** Which boxes get rounded. Default `'set'`. */
   scope?: RoundedMaskScope;
+  /**
+   * Which corners may round at all. Default: all four. With `scope: 'set'`
+   * these are the corners of the union box; with `'reel'` the same corners of
+   * every reel; with `'outer'` the box corners that are also listed here. The
+   * way a 1x1 Hold & Win cell rounds only the board corner it sits on - see
+   * `HoldAndWinBuilder.cellMask`.
+   */
+  corners?: MaskCorners;
+}
+
+const ALL_CORNERS: Required<MaskCorners> = {
+  topLeft: true,
+  topRight: true,
+  bottomLeft: true,
+  bottomRight: true,
+};
+
+/** `undefined` means all four; an object means exactly its `true` keys. */
+function resolveCorners(corners: MaskCorners | undefined): Required<MaskCorners> {
+  if (corners === undefined) return ALL_CORNERS;
+  if (typeof corners !== 'object' || corners === null) {
+    throw new Error(
+      `RoundedRectMaskStrategy: corners must be an object like { topLeft: true }, got ${String(corners)}.`,
+    );
+  }
+  return {
+    topLeft: corners.topLeft === true,
+    topRight: corners.topRight === true,
+    bottomLeft: corners.bottomLeft === true,
+    bottomRight: corners.bottomRight === true,
+  };
+}
+
+/** Edge-coincidence tolerance for `scope: 'outer'`, in pixels. */
+const CORNER_EPS = 0.5;
+
+/**
+ * Of `allowed`, the corners of `r` (already shifted by the origin) that lie
+ * on a corner of the union box `b`.
+ */
+function cornersOnBox(
+  r: ReelMaskRect,
+  b: ReelMaskRect,
+  allowed: Required<MaskCorners>,
+): Required<MaskCorners> {
+  const left = Math.abs(r.x - b.x) < CORNER_EPS;
+  const top = Math.abs(r.y - b.y) < CORNER_EPS;
+  const right = Math.abs(r.x + r.width - (b.x + b.width)) < CORNER_EPS;
+  const bottom = Math.abs(r.y + r.height - (b.y + b.height)) < CORNER_EPS;
+  return {
+    topLeft: allowed.topLeft && left && top,
+    topRight: allowed.topRight && right && top,
+    bottomLeft: allowed.bottomLeft && left && bottom,
+    bottomRight: allowed.bottomRight && right && bottom,
+  };
+}
+
+/**
+ * Fill a box with only `corners` rounded: a `roundRect` when all four round,
+ * a plain `rect` when none, else a `roundShape` with a radius per vertex (a
+ * `0` vertex radius is a sharp corner in Pixi).
+ */
+function fillBox(
+  g: Graphics,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+  corners: Required<MaskCorners>,
+): void {
+  const { topLeft, topRight, bottomLeft, bottomRight } = corners;
+  if (topLeft && topRight && bottomLeft && bottomRight) {
+    g.roundRect(x, y, width, height, radius).fill(MASK_FILL);
+    return;
+  }
+  if (!topLeft && !topRight && !bottomLeft && !bottomRight) {
+    g.rect(x, y, width, height).fill(MASK_FILL);
+    return;
+  }
+  g.roundShape(
+    [
+      { x, y, radius: topLeft ? radius : 0 },
+      { x: x + width, y, radius: topRight ? radius : 0 },
+      { x: x + width, y: y + height, radius: bottomRight ? radius : 0 },
+      { x, y: y + height, radius: bottomLeft ? radius : 0 },
+    ],
+    radius,
+  ).fill(MASK_FILL);
 }
 
 /**
@@ -111,12 +224,21 @@ export interface RoundedRectMaskOptions {
  * // Each reel its own rounded card. Needs a cross gap.
  * builder.symbolGap({ x: 12, y: 0 })
  *        .maskStrategy(new RoundedRectMaskStrategy({ radius: 14, scope: 'reel' }))
+ *
+ * @example
+ * // One rect per reel, only the window's four corners rounded. Any gap.
+ * builder.maskStrategy(new RoundedRectMaskStrategy({ radius: 18, scope: 'outer' }))
+ *
+ * @example
+ * // A 1x1 Hold & Win cell that rounds only the board corner it sits on.
+ * hw.cellMask((_cell, { corners }) => new RoundedRectMaskStrategy({ radius: 18, corners }))
  */
 export class RoundedRectMaskStrategy implements DrawableMaskStrategy {
   readonly version = MASK_STRATEGY_VERSION;
 
   private readonly _radius: number;
   private readonly _scope: RoundedMaskScope;
+  private readonly _corners: Required<MaskCorners>;
 
   constructor(options: RoundedRectMaskOptions) {
     if (!Number.isFinite(options?.radius) || options.radius < 0) {
@@ -126,6 +248,7 @@ export class RoundedRectMaskStrategy implements DrawableMaskStrategy {
     }
     this._radius = options.radius;
     this._scope = options.scope ?? 'set';
+    this._corners = resolveCorners(options.corners);
   }
 
   build(ctx: MaskContext): Graphics {
@@ -145,25 +268,34 @@ export class RoundedRectMaskStrategy implements DrawableMaskStrategy {
 
     if (this._scope === 'set' || ctx.rects.length === 0) {
       const b = boundsOf(ctx);
-      g.roundRect(
+      fillBox(
+        g,
         b.x - out.x,
         b.y - out.y,
         b.width + out.x * 2,
         b.height + out.y * 2,
         this._radius,
-      ).fill(MASK_FILL);
+        this._corners,
+      );
       return;
     }
 
-    this._warnIfTouching(ctx);
+    // 'outer' leaves every inner edge square, so touching reels are its
+    // normal case rather than a notched seam.
+    if (this._scope === 'reel') this._warnIfTouching(ctx);
+    const box = this._scope === 'outer' ? boundsOf(ctx) : null;
     for (const r of ctx.rects) {
-      g.roundRect(
-        o.x + r.x - out.x,
-        o.y + r.y - out.y,
+      const shifted = { x: o.x + r.x, y: o.y + r.y, width: r.width, height: r.height };
+      const corners = box ? cornersOnBox(shifted, box, this._corners) : this._corners;
+      fillBox(
+        g,
+        shifted.x - out.x,
+        shifted.y - out.y,
         r.width + out.x * 2,
         r.height + out.y * 2,
         this._radius,
-      ).fill(MASK_FILL);
+        corners,
+      );
     }
   }
 

--- a/packages/pixi-reels/src/index.ts
+++ b/packages/pixi-reels/src/index.ts
@@ -47,6 +47,7 @@ export type {
 export type { ReelMaskRect, MaskStrategy, MaskContext } from './core/ReelViewport.js';
 export type {
   DrawableMaskStrategy,
+  MaskCorners,
   MaskPathFn,
   RoundedMaskScope,
   RoundedRectMaskOptions,
@@ -200,7 +201,13 @@ export type { SpotlightOptions, WinLine, CycleOptions } from './spotlight/Symbol
 //   opinionated lock / respin / collect layer, built entirely on BoardGrid's
 //   public surface, so you can copy it and change the rules.
 export { BoardGrid } from './board/BoardGrid.js';
-export type { BoardCell, BoardSpinTarget, BoardProfile, BoardGridOptions } from './board/BoardGrid.js';
+export type {
+  BoardCell,
+  BoardCellMaskInfo,
+  BoardSpinTarget,
+  BoardProfile,
+  BoardGridOptions,
+} from './board/BoardGrid.js';
 export { HoldAndWinBuilder } from './board/HoldAndWinBuilder.js';
 export { HoldAndWinBoard } from './board/HoldAndWinBoard.js';
 // The board's own constructor parameter. `HoldAndWinBuilder.build()` returns a

--- a/packages/pixi-reels/tests/unit/BoardGrid.test.ts
+++ b/packages/pixi-reels/tests/unit/BoardGrid.test.ts
@@ -3,6 +3,7 @@ import type { Ticker } from 'pixi.js';
 import { Graphics } from 'pixi.js';
 import type { RenderLayer } from 'pixi.js';
 import { BoardGrid } from '../../src/board/BoardGrid.js';
+import type { BoardCell, BoardCellMaskInfo } from '../../src/board/BoardGrid.js';
 import { SharedRectMaskStrategy } from '../../src/core/ReelViewport.js';
 import { ReelSet } from '../../src/core/ReelSet.js';
 import { FakeTicker } from '../../src/testing/FakeTicker.js';
@@ -173,6 +174,25 @@ describe('BoardGrid cell mask', () => {
       },
     });
     expect(built).toBe(6);
+    grid.destroy();
+  });
+
+  it('tells the factory which cell it builds for and which board corners that cell sits on', () => {
+    const seen = new Map<string, BoardCellMaskInfo>();
+    const grid = make({
+      mask: (cell: BoardCell, info: BoardCellMaskInfo) => {
+        seen.set(`${cell.reel},${cell.cell}`, info);
+        return new SharedRectMaskStrategy();
+      },
+    });
+    const none = { topLeft: false, topRight: false, bottomLeft: false, bottomRight: false };
+    expect(seen.size).toBe(6);
+    expect(seen.get('0,0')).toEqual({ cols: 3, rows: 2, corners: { ...none, topLeft: true } });
+    expect(seen.get('2,0')?.corners).toEqual({ ...none, topRight: true });
+    expect(seen.get('0,1')?.corners).toEqual({ ...none, bottomLeft: true });
+    expect(seen.get('2,1')?.corners).toEqual({ ...none, bottomRight: true });
+    expect(seen.get('1,0')?.corners).toEqual(none);
+    expect(seen.get('1,1')?.corners).toEqual(none);
     grid.destroy();
   });
 });

--- a/packages/pixi-reels/tests/unit/maskStrategies.test.ts
+++ b/packages/pixi-reels/tests/unit/maskStrategies.test.ts
@@ -24,6 +24,7 @@ import {
   composeMasks,
   inset,
   isDrawableMaskStrategy,
+  type MaskCorners,
 } from '../../src/core/maskStrategies.js';
 import { reelAxis, VERTICAL_FORWARD } from '../../src/core/ReelAxis.js';
 
@@ -175,6 +176,196 @@ describe('RoundedRectMaskStrategy', () => {
 
   it('rejects a negative radius at construction rather than at draw time', () => {
     expect(() => new RoundedRectMaskStrategy({ radius: -4 })).toThrow(/non-negative/);
+  });
+});
+
+describe("RoundedRectMaskStrategy scope 'outer' and corners", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  /** One 100x100 cell - the shape of a Hold & Win board cell. */
+  const cellCtx = (): MaskContext => ({
+    rects: [{ x: 0, y: 0, width: 100, height: 100 }],
+    width: 100,
+    height: 100,
+    axis: VERTICAL_FORWARD,
+    bleed: 0,
+  });
+
+  it("scope 'outer' keeps one rect per reel and rounds only the corners on the union box", () => {
+    const drawn = shapes(
+      new RoundedRectMaskStrategy({ radius: 16, scope: 'outer' }).build(uniformCtx()),
+    );
+    expect(drawn).toEqual([
+      {
+        kind: 'roundShape',
+        points: [
+          { x: 0, y: 0, radius: 16 },
+          { x: 100, y: 0, radius: 0 },
+          { x: 100, y: 300, radius: 0 },
+          { x: 0, y: 300, radius: 16 },
+        ],
+      },
+      { kind: 'rect', x: 100, y: 0, width: 100, height: 300 },
+      {
+        kind: 'roundShape',
+        points: [
+          { x: 200, y: 0, radius: 0 },
+          { x: 300, y: 0, radius: 16 },
+          { x: 300, y: 300, radius: 16 },
+          { x: 200, y: 300, radius: 0 },
+        ],
+      },
+    ]);
+  });
+
+  it("scope 'outer' stays quiet on touching reels - square inner edges never notch", () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    new RoundedRectMaskStrategy({ radius: 16, scope: 'outer' }).build(uniformCtx());
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("scope 'outer' rounds nothing on a pyramid whose box corners touch no reel", () => {
+    const drawn = shapes(
+      new RoundedRectMaskStrategy({ radius: 16, scope: 'outer' }).build(pyramidCtx()),
+    );
+    expect(drawn).toHaveLength(3);
+    expect(drawn.every((d) => d.kind === 'rect')).toBe(true);
+  });
+
+  it("scope 'outer' inflates on the CROSS axis only, like the other scopes", () => {
+    const drawn = shapes(
+      new RoundedRectMaskStrategy({ radius: 16, scope: 'outer' }).build(uniformCtx({ bleed: 20 })),
+    );
+    expect(drawn[0]).toEqual({
+      kind: 'roundShape',
+      points: [
+        { x: -20, y: 0, radius: 16 },
+        { x: 120, y: 0, radius: 0 },
+        { x: 120, y: 300, radius: 0 },
+        { x: -20, y: 300, radius: 16 },
+      ],
+    });
+  });
+
+  it('corners rounds only the named screen corner of a single cell', () => {
+    const drawn = shapes(
+      new RoundedRectMaskStrategy({ radius: 12, corners: { topLeft: true } }).build(cellCtx()),
+    );
+    expect(drawn).toEqual([
+      {
+        kind: 'roundShape',
+        points: [
+          { x: 0, y: 0, radius: 12 },
+          { x: 100, y: 0, radius: 0 },
+          { x: 100, y: 100, radius: 0 },
+          { x: 0, y: 100, radius: 0 },
+        ],
+      },
+    ]);
+  });
+
+  it('an empty corners object rounds nothing: a plain rect, no roundShape', () => {
+    const drawn = shapes(new RoundedRectMaskStrategy({ radius: 12, corners: {} }).build(cellCtx()));
+    expect(drawn).toEqual([{ kind: 'rect', x: 0, y: 0, width: 100, height: 100 }]);
+  });
+
+  it('all four corners listed is the plain roundRect, so existing output is unchanged', () => {
+    const drawn = shapes(
+      new RoundedRectMaskStrategy({
+        radius: 12,
+        corners: { topLeft: true, topRight: true, bottomLeft: true, bottomRight: true },
+      }).build(cellCtx()),
+    );
+    expect(drawn).toEqual([{ kind: 'roundRect', x: 0, y: 0, width: 100, height: 100, radius: 12 }]);
+  });
+
+  it("corners applies to every reel under scope 'reel'", () => {
+    const ctx = uniformCtx({
+      rects: [
+        { x: 0, y: 0, width: 90, height: 300 },
+        { x: 100, y: 0, width: 90, height: 300 },
+      ],
+    });
+    const drawn = shapes(
+      new RoundedRectMaskStrategy({ radius: 10, scope: 'reel', corners: { bottomRight: true } }).build(ctx),
+    );
+    expect(drawn).toHaveLength(2);
+    for (const d of drawn) {
+      expect(d.kind).toBe('roundShape');
+      if (d.kind === 'roundShape') {
+        expect(d.points.map((pt) => pt.radius)).toEqual([0, 0, 10, 0]);
+      }
+    }
+  });
+
+  it("corners intersects with the box corners under scope 'outer'", () => {
+    const drawn = shapes(
+      new RoundedRectMaskStrategy({
+        radius: 16,
+        scope: 'outer',
+        corners: { topLeft: true, bottomRight: true },
+      }).build(uniformCtx()),
+    );
+    expect(drawn[0]).toEqual({
+      kind: 'roundShape',
+      points: [
+        { x: 0, y: 0, radius: 16 },
+        { x: 100, y: 0, radius: 0 },
+        { x: 100, y: 300, radius: 0 },
+        { x: 0, y: 300, radius: 0 },
+      ],
+    });
+    expect(drawn[1]).toEqual({ kind: 'rect', x: 100, y: 0, width: 100, height: 300 });
+    expect(drawn[2]).toEqual({
+      kind: 'roundShape',
+      points: [
+        { x: 200, y: 0, radius: 0 },
+        { x: 300, y: 0, radius: 0 },
+        { x: 300, y: 300, radius: 16 },
+        { x: 200, y: 300, radius: 0 },
+      ],
+    });
+  });
+
+  it('corners are screen corners on a horizontal set too', () => {
+    const ctx: MaskContext = {
+      rects: [
+        { x: 0, y: 0, width: 300, height: 100 },
+        { x: 0, y: 100, width: 300, height: 100 },
+        { x: 0, y: 200, width: 300, height: 100 },
+      ],
+      width: 300,
+      height: 300,
+      axis: reelAxis('horizontal', 'forward'),
+      bleed: 0,
+    };
+    const drawn = shapes(new RoundedRectMaskStrategy({ radius: 16, scope: 'outer' }).build(ctx));
+    // The first reel is the TOP row: its top-left and top-right round.
+    expect(drawn[0]).toEqual({
+      kind: 'roundShape',
+      points: [
+        { x: 0, y: 0, radius: 16 },
+        { x: 300, y: 0, radius: 16 },
+        { x: 300, y: 100, radius: 0 },
+        { x: 0, y: 100, radius: 0 },
+      ],
+    });
+    expect(drawn[1]).toEqual({ kind: 'rect', x: 0, y: 100, width: 300, height: 100 });
+    expect(drawn[2]).toEqual({
+      kind: 'roundShape',
+      points: [
+        { x: 0, y: 200, radius: 0 },
+        { x: 300, y: 200, radius: 0 },
+        { x: 300, y: 300, radius: 16 },
+        { x: 0, y: 300, radius: 16 },
+      ],
+    });
+  });
+
+  it('rejects a corners value that is not an object', () => {
+    expect(
+      () => new RoundedRectMaskStrategy({ radius: 4, corners: 'all' as unknown as MaskCorners }),
+    ).toThrow(/corners/);
   });
 });
 


### PR DESCRIPTION
## Summary

- `RoundedRectMaskStrategy` gains `scope: 'outer'`: one rect per reel, only the corners that sit on the set's bounding box are rounded. Inner edges stay square, so it works at cross gap `0` where `scope: 'reel'` notches the seams.
- New `corners: { topLeft, topRight, bottomLeft, bottomRight }` option (screen-space) limits which corners round in any scope. Draws `roundRect` when all four, a plain `rect` when none, `roundShape` with per-vertex radii otherwise.
- `HoldAndWinBuilder.cellMask` and the `BoardGrid` `mask` option now take a function called once per cell with `(cell, { cols, rows, corners })`, so every 1x1 cell reel set gets its own strategy decided from its column (`reel`) and row (`cell`). `corners` is the set of board corners that cell sits on, precomputed. Zero-argument factories keep working. New exported type `BoardCellMaskInfo`.
- Recipes: `mask-outer-corners` (5x3 card set, gap 0) and `hold-and-win-outer-corners` (5x3 gapless clover board clipped as one rounded window by fifteen masks). Both on the Masks page; the Hold & Win one also on the Hold & Win page. `llms.txt` regenerated.
- Changeset: `.changeset/mask-outer-corners.md` (minor).

## Test plan

- [x] `pnpm --filter pixi-reels typecheck`
- [x] `pnpm --filter pixi-reels test` (1146 passing; 11 new mask cases, 1 new BoardGrid case)
- [x] `pnpm check:lint` (recipe syntax, api surface, no fancy unicode, v1 keys, codemod parity, migration coverage)
- [x] Both recipes rendered headlessly with Playwright against the dev site and driven through a spin: reel set shows square seams with only the window's four corners rounded; Hold & Win board shows corner tiles cut on the panel radius, inner cells plain rects, coins lock normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)