### PR TITLE
fix(e2e): budget the scroll test by page height instead of a fixed 60s

### DIFF
--- a/tests/e2e/recipes-mount.spec.ts
+++ b/tests/e2e/recipes-mount.spec.ts
@@ -165,6 +165,11 @@ for (const path of SCROLL_PAGES) {
     // survivors then threw from inside their own render loop, one frame
     // later -- "Cannot read properties of null (reading 'geometry')".
     const height = await page.evaluate(() => document.body.scrollHeight);
+    // Each step waits 700ms and then pays for whatever the demos that just
+    // scrolled in cost to mount. On CI's software GL a Spine-heavy page (Hold
+    // & Win stacks ~40 demos) spent the whole fixed 60s inside this loop, so
+    // budget by page height instead: a longer page is not a red build.
+    test.setTimeout(Math.ceil(height / 700) * 2500 + 30_000);
     for (let y = 0; y < height; y += 700) {
       await page.evaluate((to) => window.scrollTo(0, to), y);
       await page.waitForTimeout(700);


### PR DESCRIPTION
## Summary

`recipes survive scrolling: /recipes/hold-and-win/` in `tests/e2e/recipes-mount.spec.ts` has timed out on every `main` CI run since #218 (e341a10, e0e9763). That page now stacks ~40 demos; the scroll walk spends 700ms per 700px step plus the cost of mounting each batch of demos on CI's software GL, and that no longer fits the default 60s test timeout.

This sizes the test's timeout from the measured page height (`steps * 2.5s + 30s`) so a longer recipe page does not turn the build red. Test-only change, no library code touched.

## Test plan

- [x] Built the site and ran `pnpm exec playwright test recipes-mount -g hold-and-win` locally against the branch that adds one more Hold & Win demo (#221)
- [x] CI e2e green on this PR (7m59s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
